### PR TITLE
fix: eslint [ROAD-74]

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,12 +57,29 @@
     "no-use-before-define": "off",
     "no-continue": "off",
     "@typescript-eslint/restrict-template-expressions": "off",
-    "@typescript-eslint/no-unsafe-assignment": "warn"
+    "@typescript-eslint/no-unsafe-assignment": "warn",
+    "import/no-extraneous-dependencies": "off",
+    "no-useless-constructor": "off",
+    "@typescript-eslint/no-useless-constructor": ["error"],
+    "no-void": [
+      "error",
+      {
+        "allowAsStatement": true
+      }
+    ],
+    "import/prefer-default-export": "off",
+    "class-methods-use-this": "off"
   },
   "settings": {
+    "import/parsers": {
+      "@typescript-eslint/parser": [".ts", ".tsx"]
+    },
     "import/resolver": {
       "node": {
         "extensions": [".js", ".jsx", ".ts", ".tsx", ".json", ".vue"]
+      },
+      "typescript": {
+        "alwaysTryTypes": true
       }
     }
   }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,10 +2,8 @@
   "plugins": ["@typescript-eslint", "prettier", "import"],
   "extends": [
     "eslint:recommended",
-    "airbnb-base",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
-    "plugin:prettier/recommended",
     "prettier",
     "prettier/@typescript-eslint"
   ],
@@ -29,14 +27,12 @@
     "require-jsdoc": "off",
     "space-before-function-paren": "off",
     "comma-dangle": "off",
-    "object-curly-spacing": "warn",
     "padded-blocks": "off",
     "camelcase": "warn",
     "object-property-newline": "off",
     "prefer-const": "warn",
     "import/no-absolute-path": "off",
     "no-prototype-builtins": "off",
-    "indent": "warn",
     "quote-props": ["warn", "as-needed"],
     "lines-between-class-members": "off",
     "import/extensions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -720,12 +720,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "confusing-browser-globals": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
-      "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
-      "dev": true
-    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -945,17 +939,6 @@
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         }
-      }
-    },
-    "eslint-config-airbnb-base": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
-      "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
-      "dev": true,
-      "requires": {
-        "confusing-browser-globals": "^1.0.10",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.2"
       }
     },
     "eslint-config-prettier": {
@@ -2126,18 +2109,6 @@
         "define-properties": "^1.1.3",
         "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
-      }
-    },
-    "object.entries": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
-      "integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
-        "has": "^1.0.3"
       }
     },
     "object.values": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "snyk-vulnerability-scanner",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -992,6 +992,19 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
+      }
+    },
+    "eslint-import-resolver-typescript": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.4.0.tgz",
+      "integrity": "sha512-useJKURidCcldRLCNKWemr1fFQL1SzB3G4a0li6lFGvlc5xGe1hY343bvG07cbpCzPuM/lK19FIJB3XGFSkplA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
       }
     },
     "eslint-module-utils": {

--- a/package.json
+++ b/package.json
@@ -260,7 +260,6 @@
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",
     "eslint": "^7.8.1",
-    "eslint-config-airbnb-base": "^14.2.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-import": "^2.22.0",

--- a/package.json
+++ b/package.json
@@ -247,8 +247,8 @@
     "watch": "tsc -watch -p ./",
     "pretest": "tsc -p ./",
     "test": "node ./out/test/runTest.js",
-    "lint": "npx eslint src/**/*.ts",
-    "lint:fix": "npx eslint --fix src/**/*.ts"
+    "lint": "npx eslint 'src/**/*.ts'",
+    "lint:fix": "npx eslint --fix 'src/**/*.ts'"
   },
   "devDependencies": {
     "@types/analytics-node": "^3.1.4",
@@ -262,6 +262,7 @@
     "eslint": "^7.8.1",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-config-prettier": "^6.11.0",
+    "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-prettier": "^3.1.4",
     "glob": "^7.1.6",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,11 +7,11 @@ export function activate(context: vscode.ExtensionContext): void {
   console.log('Activating SnykExtension');
   extension.activate(context);
 }
-export function deactivate() {
+export function deactivate(): void {
   console.log('Deactivating SnykExtension');
   extension.deactivate();
 }
 
-export function getExtension() {
+export function getExtension(): SnykExtension {
   return extension;
 }

--- a/src/interfaces/SnykInterfaces.ts
+++ b/src/interfaces/SnykInterfaces.ts
@@ -78,8 +78,7 @@ export interface SuggestionProviderInterface {
 
 export type userStateItemType = string | number | boolean | undefined;
 
-export type configType = string | Function;
-
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type errorType = Error | any;
 
 export type filesForSaveListType = string[];
@@ -104,10 +103,6 @@ export interface StateIitemsInterface {
   [key: string]: string;
 }
 
-export interface StateSelectorsInterface {
-  [key: string]: Function;
-}
-
 export interface SingleIssuePositionInterface {
   cols: number[];
   rows: number[];
@@ -130,7 +125,7 @@ export interface AnalyzerInterface {
     position: vscode.Range,
   ): completeFileSuggestionType | undefined;
   checkFullSuggestion(suggestion: completeFileSuggestionType): boolean;
-  createReviewResults(): Promise<void>;
+  createReviewResults(): void;
   updateReviewResultsPositions(extension: ExtensionInterface, updatedFile: openedTextEditorType): Promise<void>;
   setIssuesMarkersDecoration(editor: TextEditor | undefined): void;
 }

--- a/src/snyk/analytics/segment.ts
+++ b/src/snyk/analytics/segment.ts
@@ -1,19 +1,20 @@
+import Analytics from 'analytics-node';
 import { v4 as uuidv4 } from 'uuid';
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
+const { segmentWriteKey } = require('../../../snyk.config.json');
 
 export class Segment {
   private analyticsCollectionEnabled: boolean;
   private readonly anonymousId: string;
-  private analytics: any;
+  private analytics: Analytics;
   private userId: string;
 
   constructor() {
     try {
-      const { segmentWriteKey } = require('../../../snyk.config.json');
       if (!segmentWriteKey) {
         this.analyticsCollectionEnabled = false;
         console.log('Segment analytics collection is disabled because write key is empty!');
       } else {
-        const Analytics = require('analytics-node');
         this.analytics = new Analytics(segmentWriteKey, {
           flushAt: 5,
           flushInterval: 10000,
@@ -30,7 +31,6 @@ export class Segment {
 
   shutdown(): void {
     this.analytics?.flush();
-    this.analytics?.shutdown();
   }
 
   setAnalyticsCollectionEnabled(enabled: boolean): void {
@@ -62,20 +62,20 @@ export class Segment {
     });
   }
 
-  logEvent(event: string, properties?: Object): void {
+  logEvent(event: string, properties: unknown): void {
     if (!this.analyticsCollectionEnabled) return;
 
     if (this.userId) {
       this.analytics?.track({
-        event: event,
-        properties: properties,
+        event,
+        properties,
         userId: this.userId,
       });
     } else {
       this.analytics?.track({
         anonymousId: this.anonymousId,
-        event: event,
-        properties: properties,
+        event,
+        properties,
       });
     }
   }

--- a/src/snyk/constants/analysis.ts
+++ b/src/snyk/constants/analysis.ts
@@ -4,17 +4,16 @@ export const SNYK_SEVERITIES: { [key: string]: number } = {
   error: 3,
 };
 
-export const IGNORE_ISSUE_BASE_COMMENT_TEXT: string = 'deepcode ignore';
+export const IGNORE_ISSUE_BASE_COMMENT_TEXT = 'deepcode ignore';
 
-export const FILE_IGNORE_ISSUE_BASE_COMMENT_TEXT: string = `file ${IGNORE_ISSUE_BASE_COMMENT_TEXT}`;
+export const FILE_IGNORE_ISSUE_BASE_COMMENT_TEXT = `file ${IGNORE_ISSUE_BASE_COMMENT_TEXT}`;
 
-export const IGNORE_ISSUE_REASON_TIP: string = '<please specify a reason of ignoring this>';
+export const IGNORE_ISSUE_REASON_TIP = '<please specify a reason of ignoring this>';
 
-export const SHOW_ISSUE_ACTION_NAME: string = 'Show this suggestion (Snyk)';
-export const IGNORE_ISSUE_ACTION_NAME: string = 'Ignore this particular suggestion (Snyk)';
-export const FILE_IGNORE_ACTION_NAME: string = 'Ignore this suggestion in current file (Snyk)';
-export const IGNORE_TIP_FOR_USER: string =
-  "To ignore this issue for Snyk choose 'Ignore this issue' in QuickFix dropdown";
+export const SHOW_ISSUE_ACTION_NAME = 'Show this suggestion (Snyk)';
+export const IGNORE_ISSUE_ACTION_NAME = 'Ignore this particular suggestion (Snyk)';
+export const FILE_IGNORE_ACTION_NAME = 'Ignore this suggestion in current file (Snyk)';
+export const IGNORE_TIP_FOR_USER = "To ignore this issue for Snyk choose 'Ignore this issue' in QuickFix dropdown";
 
 export const ISSUES_MARKERS_DECORATION_TYPE: { [key: string]: string } = {
   border: '1px',

--- a/src/snyk/lib/modules/BaseSnykModule.ts
+++ b/src/snyk/lib/modules/BaseSnykModule.ts
@@ -72,9 +72,9 @@ export default abstract class BaseSnykModule implements BaseSnykModuleInterface 
         if (oldValue !== undefined) {
           if (!value && oldValue) event = TELEMETRY_EVENTS.viewLoginView;
           if (value && !oldValue) event = TELEMETRY_EVENTS.viewConsentView;
-        } else {
+        } else if (!value) {
           // If key was un-initialized (i.e. at start), we still report it if new value is false
-          if (!value) event = TELEMETRY_EVENTS.viewLoginView;
+          event = TELEMETRY_EVENTS.viewLoginView;
         }
         break;
       }
@@ -99,11 +99,13 @@ export default abstract class BaseSnykModule implements BaseSnykModuleInterface 
         shouldWaitForView = false;
         break;
       }
+      default:
+        return;
     }
     // We want to fire the event only when the user actually sees the View
     if (event) {
-      if (shouldWaitForView) this.initializedView.waiter.then(() => this.processEvent(event, options));
-      else this.processEvent(event, options);
+      if (shouldWaitForView) void this.initializedView.waiter.then(() => this.processEvent(event, options));
+      else void this.processEvent(event, options);
     }
   }
 

--- a/src/snyk/lib/modules/BundlesModule.ts
+++ b/src/snyk/lib/modules/BundlesModule.ts
@@ -1,14 +1,11 @@
-import * as vscode from 'vscode';
+import { analyzeFolders, constants, extendAnalysis } from '@snyk/code-client';
 import * as _ from 'lodash';
-
+import * as vscode from 'vscode';
 import { BundlesModuleInterface } from '../../../interfaces/SnykInterfaces';
-
-import LoginModule from '../../lib/modules/LoginModule';
+import { configuration } from '../../configuration';
 import { SNYK_ANALYSIS_STATUS, SNYK_CONTEXT } from '../../constants/views';
 import { errorsLogs } from '../../messages/errorsServerLogMessages';
-
-import { analyzeFolders, extendAnalysis, constants } from '@snyk/code-client';
-import { configuration } from '../../configuration';
+import LoginModule from './LoginModule';
 
 abstract class BundlesModule extends LoginModule implements BundlesModuleInterface {
   runningAnalysis = false;
@@ -19,36 +16,36 @@ abstract class BundlesModule extends LoginModule implements BundlesModuleInterfa
 
   files: string[] = [];
 
-  updateStatus(status: string, progress: string) {
+  updateStatus(status: string, progress: string): void {
     this.analysisStatus = status;
     this.analysisProgress = progress;
     this.refreshViews();
   }
 
-  onScanFilesProgress(value: number) {
+  onScanFilesProgress(value: number): void {
     this.updateStatus(SNYK_ANALYSIS_STATUS.COLLECTING, `${value}`);
   }
 
-  onCreateBundleProgress(processed: number, total: number) {
+  onCreateBundleProgress(processed: number, total: number): void {
     this.updateStatus(SNYK_ANALYSIS_STATUS.BUNDLING, `${processed}/${total}`);
   }
 
-  onUploadBundleProgress(processed: number, total: number) {
+  onUploadBundleProgress(processed: number, total: number): void {
     this.updateStatus(SNYK_ANALYSIS_STATUS.UPLOADING, `${processed}/${total}`);
   }
 
-  onAnalyseProgress(data: { status: string; progress: number }) {
+  onAnalyseProgress(data: { status: string; progress: number }): void {
     this.updateStatus(_.capitalize(_.toLower(data.status)), `${Math.round(100 * data.progress)}%`);
   }
 
-  onAPIRequestLog(message: string) {
+  static onAPIRequestLog(message: string): void {
     console.log(message);
   }
 
-  onError(error: Error) {
+  onError(error: Error): void {
     this.runningAnalysis = false;
     // no need to wait for processError since onError is called asynchronously as well
-    this.processError(error, {
+    void this.processError(error, {
       message: errorsLogs.failedServiceAI,
     });
   }
@@ -79,7 +76,7 @@ abstract class BundlesModule extends LoginModule implements BundlesModuleInterfa
         } else {
           result = await analyzeFolders({
             baseURL: configuration.baseURL,
-            sessionToken: configuration.token,
+            sessionToken: configuration.token ?? '', // todo: handle the case appropriately
             paths,
             source: configuration.source,
           });

--- a/src/snyk/lib/modules/LoginModule.ts
+++ b/src/snyk/lib/modules/LoginModule.ts
@@ -1,12 +1,9 @@
 import { checkSession, startSession } from '@snyk/code-client';
-import * as vscode from 'vscode';
 import { LoginModuleInterface } from '../../../interfaces/SnykInterfaces';
 import { configuration } from '../../configuration';
-import { TELEMETRY_EVENTS } from '../../constants/telemetry';
 import { SNYK_CONTEXT } from '../../constants/views';
 import { errorsLogs } from '../../messages/errorsServerLogMessages';
-import { snykMessages } from '../../messages/snykMessages';
-import { openSnykViewContainer, viewInBrowser } from '../../utils/vscodeCommandsUtils';
+import { viewInBrowser } from '../../utils/vscodeCommandsUtils';
 import { ISnykCode, SnykCode } from './code';
 import ReportModule from './ReportModule';
 
@@ -83,7 +80,7 @@ abstract class LoginModule extends ReportModule implements LoginModuleInterface 
       }
     }
     await this.setContext(SNYK_CONTEXT.LOGGEDIN, !!token);
-    if (!token) await this.loadingBadge.setLoadingBadge(true, this);
+    if (!token) this.loadingBadge.setLoadingBadge(true, this);
     return token;
   }
 
@@ -104,12 +101,12 @@ abstract class LoginModule extends ReportModule implements LoginModuleInterface 
     const enabled = await this.snykCode.isEnabled();
 
     await this.setContext(SNYK_CONTEXT.CODE_ENABLED, enabled);
-    await this.setContext(SNYK_CONTEXT.APPROVED, configuration.uploadApproved); //todo: removed once 'uploadApproved' is deprecated
+    await this.setContext(SNYK_CONTEXT.APPROVED, configuration.uploadApproved); // todo: removed once 'uploadApproved' is deprecated
     if (!enabled) {
-      //TODO: consent event here
+      // TODO: consent event here
       this.createAnalytics();
 
-      await this.loadingBadge.setLoadingBadge(true, this);
+      this.loadingBadge.setLoadingBadge(true, this);
     }
 
     return enabled;
@@ -118,7 +115,7 @@ abstract class LoginModule extends ReportModule implements LoginModuleInterface 
   async enableCode(): Promise<void> {
     const wasEnabled = await this.snykCode.enable();
     if (wasEnabled) {
-      await this.loadingBadge.setLoadingBadge(false, this);
+      this.loadingBadge.setLoadingBadge(false, this);
       await this.checkCodeEnabled();
     }
   }

--- a/src/snyk/lib/modules/SnykLib.ts
+++ b/src/snyk/lib/modules/SnykLib.ts
@@ -31,10 +31,10 @@ export default class SnykLib extends BundlesModule implements SnykLibInterface {
   }
 
   private unpause(): void {
-    if (this._mode === SNYK_MODE_CODES.PAUSED) this.setMode(SNYK_MODE_CODES.AUTO);
+    if (this._mode === SNYK_MODE_CODES.PAUSED) void this.setMode(SNYK_MODE_CODES.AUTO);
   }
 
-  private async startExtension_(manual: Boolean = false): Promise<void> {
+  private async startExtension_(manual = false): Promise<void> {
     console.log('STARTING EXTENSION');
     // If the execution is suspended, we only allow user-triggered analyses.
     if (!manual) {
@@ -43,7 +43,7 @@ export default class SnykLib extends BundlesModule implements SnykLibInterface {
 
     await this.setContext(SNYK_CONTEXT.ERROR, false);
     this.resetTransientErrors();
-    await this.loadingBadge.setLoadingBadge(false, this);
+    this.loadingBadge.setLoadingBadge(false, this);
 
     if (!configuration.token) {
       try {
@@ -92,12 +92,14 @@ export default class SnykLib extends BundlesModule implements SnykLibInterface {
     await this.setContext(SNYK_CONTEXT.MODE, mode);
     switch (mode) {
       case SNYK_MODE_CODES.PAUSED:
-        this._unpauseTimeout = setTimeout(this.unpause.bind(this), EXECUTION_PAUSE_INTERVAL);
+        this._unpauseTimeout = setTimeout(() => this.unpause(), EXECUTION_PAUSE_INTERVAL);
         break;
       case SNYK_MODE_CODES.AUTO:
       case SNYK_MODE_CODES.MANUAL:
       case SNYK_MODE_CODES.THROTTLED:
         if (this._unpauseTimeout) clearTimeout(this._unpauseTimeout);
+        break;
+      default:
         break;
     }
   }

--- a/src/snyk/lib/modules/code.ts
+++ b/src/snyk/lib/modules/code.ts
@@ -1,5 +1,5 @@
-import { getSastSettings } from '../../services/cliConfigService';
 import { IConfiguration } from '../../configuration';
+import { getSastSettings } from '../../services/cliConfigService';
 import { viewInBrowser } from '../../utils/vscodeCommandsUtils';
 
 export interface ISnykCode {
@@ -15,13 +15,13 @@ export class SnykCode {
 
   public async isEnabled(): Promise<boolean> {
     // Code was disabled explicitly
-    if (this.config.codeEnabled == false) {
+    if (this.config.codeEnabled === false) {
       return false;
     }
 
     const settings = await getSastSettings();
-    if (this.config.codeEnabled != settings.sastEnabled) {
-      this.config.setCodeEnabled(settings.sastEnabled);
+    if (this.config.codeEnabled !== settings.sastEnabled) {
+      await this.config.setCodeEnabled(settings.sastEnabled);
     }
 
     return settings.sastEnabled;

--- a/src/snyk/lib/snykProviders/hoverProvider/SnykHoverProvider.ts
+++ b/src/snyk/lib/snykProviders/hoverProvider/SnykHoverProvider.ts
@@ -13,9 +13,10 @@ export class DisposableHoverProvider implements vscode.Disposable {
     this.hoverProvider = vscode.languages.registerHoverProvider(
       { scheme: 'file', language: '*' },
       {
+        // eslint-disable-next-line consistent-return
         provideHover(document, position) {
           if (!snykReview || !snykReview.has(document.uri)) {
-            return;
+            return undefined;
           }
           const currentFileReviewIssues = snykReview.get(document.uri);
           if (findIssueWithRange(position, currentFileReviewIssues)) {

--- a/src/snyk/lib/watchers/EditorsWatcher.ts
+++ b/src/snyk/lib/watchers/EditorsWatcher.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { ExtensionInterface, SnykWatcherInterface, openedTextEditorType } from '../../../interfaces/SnykInterfaces';
+import { ExtensionInterface, openedTextEditorType, SnykWatcherInterface } from '../../../interfaces/SnykInterfaces';
 
 class SnykEditorsWatcher implements SnykWatcherInterface {
   private currentTextEditors: {
@@ -55,7 +55,7 @@ class SnykEditorsWatcher implements SnykWatcherInterface {
           contentChanges: [...event.contentChanges],
           document: event.document,
         };
-        extension.analyzer.updateReviewResultsPositions(extension, this.currentTextEditors[currentEditorFileName]);
+        void extension.analyzer.updateReviewResultsPositions(extension, this.currentTextEditors[currentEditorFileName]);
       }
     });
   }
@@ -64,13 +64,13 @@ class SnykEditorsWatcher implements SnykWatcherInterface {
     for await (const editor of vscode.window.visibleTextEditors) {
       this.createEditorInfo(editor);
     }
-    await this.watchEditorsNavChange(extension);
-    await this.watchClosingEditor();
-    await this.watchEditorCodeChanges(extension);
+    this.watchEditorsNavChange(extension);
+    this.watchClosingEditor();
+    this.watchEditorCodeChanges(extension);
   }
 
   public activate(extension: ExtensionInterface): void {
-    this.prepareWatchers(extension);
+    void this.prepareWatchers(extension);
   }
 }
 

--- a/src/snyk/lib/watchers/FilesWatcher.ts
+++ b/src/snyk/lib/watchers/FilesWatcher.ts
@@ -1,11 +1,12 @@
-import * as vscode from 'vscode';
 import { getGlobPatterns, ISupportedFiles } from '@snyk/code-client';
+import * as vscode from 'vscode';
 import { ExtensionInterface } from '../../../interfaces/SnykInterfaces';
 
 export default function createFileWatcher(
   extension: ExtensionInterface,
   supportedFiles: ISupportedFiles,
 ): vscode.FileSystemWatcher {
+  // eslint-disable-next-line no-useless-escape
   const globPattern: vscode.GlobPattern = `**/\{${getGlobPatterns(supportedFiles).join(',')}\}`;
   const watcher = vscode.workspace.createFileSystemWatcher(globPattern);
 

--- a/src/snyk/lib/watchers/SnykSettingsWatcher.ts
+++ b/src/snyk/lib/watchers/SnykSettingsWatcher.ts
@@ -8,35 +8,36 @@ class SnykSettingsWatcher implements SnykWatcherInterface {
       return extension.checkAdvancedMode();
     }
     const extensionConfig = vscode.workspace.getConfiguration('snyk');
-    // @ts-ignore */}
-    const url: string = extensionConfig.get('url');
+    const url: string | undefined = extensionConfig.get('url');
 
-    const cleaned = url.replace(/\/$/, '');
+    const cleaned = url?.replace(/\/$/, '');
     if (cleaned !== url) {
-      extensionConfig.update('url', cleaned, true);
-    } else {
-      await extension.startExtension();
+      void extensionConfig.update('url', cleaned, true);
     }
+
+    return extension.startExtension();
   }
 
   public activate(extension: ExtensionInterface): void {
-    vscode.workspace.onDidChangeConfiguration(async (event: vscode.ConfigurationChangeEvent): Promise<void> => {
-      const change = ['snyk.url', 'snyk.token', 'snyk.codeEnabled', 'snyk.advancedMode'].find(config =>
-        event.affectsConfiguration(config),
-      );
-      if (change) {
-        try {
-          await this.onChangeConfiguration(extension, change);
-        } catch (error) {
-          await extension.processError(error, {
-            message: errorsLogs.configWatcher,
-            data: {
-              configurationKey: change,
-            },
-          });
+    vscode.workspace.onDidChangeConfiguration(
+      async (event: vscode.ConfigurationChangeEvent): Promise<void> => {
+        const change = ['snyk.url', 'snyk.token', 'snyk.codeEnabled', 'snyk.advancedMode'].find(config =>
+          event.affectsConfiguration(config),
+        );
+        if (change) {
+          try {
+            await this.onChangeConfiguration(extension, change);
+          } catch (error) {
+            await extension.processError(error, {
+              message: errorsLogs.configWatcher,
+              data: {
+                configurationKey: change,
+              },
+            });
+          }
         }
-      }
-    });
+      },
+    );
   }
 }
 

--- a/src/snyk/services/notificationService.ts
+++ b/src/snyk/services/notificationService.ts
@@ -1,7 +1,7 @@
+import * as vscode from 'vscode';
 import { configuration } from '../configuration';
 import { TELEMETRY_EVENTS } from '../constants/telemetry';
 import { snykMessages } from '../messages/snykMessages';
-import * as vscode from 'vscode';
 import { openSnykViewContainer } from '../utils/vscodeCommandsUtils';
 import { errorType } from '../../interfaces/SnykInterfaces';
 import { errorsLogs } from '../messages/errorsServerLogMessages';
@@ -23,7 +23,7 @@ export class NotificationService {
       return;
     }
 
-    eventProcessor(TELEMETRY_EVENTS.viewWelcomeNotification);
+    void eventProcessor(TELEMETRY_EVENTS.viewWelcomeNotification);
     const pressedButton = await vscode.window.showInformationMessage(
       snykMessages.welcome.msg,
       snykMessages.welcome.button,

--- a/src/snyk/utils/analysisUtils.ts
+++ b/src/snyk/utils/analysisUtils.ts
@@ -1,14 +1,16 @@
+/* eslint-disable @typescript-eslint/no-array-constructor */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { IAnalysisResult, IFilePath, IFileSuggestion, IMarker, ISuggestion } from '@snyk/code-client';
 import * as vscode from 'vscode';
-import { openedTextEditorType, completeFileSuggestionType } from '../../interfaces/SnykInterfaces';
-
+import { completeFileSuggestionType, openedTextEditorType } from '../../interfaces/SnykInterfaces';
 import {
-  SNYK_SEVERITIES,
-  IGNORE_ISSUE_BASE_COMMENT_TEXT,
   FILE_IGNORE_ISSUE_BASE_COMMENT_TEXT,
+  IGNORE_ISSUE_BASE_COMMENT_TEXT,
   IGNORE_ISSUE_REASON_TIP,
+  SNYK_SEVERITIES,
 } from '../constants/analysis';
-
-import { IFileSuggestion, ISuggestion, IFilePath, IMarker, IAnalysisResult } from '@snyk/code-client';
 
 export const createSnykSeveritiesMap = () => {
   const { information, error, warning } = SNYK_SEVERITIES;
@@ -95,6 +97,7 @@ export const updateFileReviewResultsPositions = (
   const changesRange = updatedFile.contentChanges[0].range;
   const changesText = updatedFile.contentChanges[0].text;
   const goToNewLine = '\n';
+  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
   const offsetedline = changesRange.start.line + 1;
   const charOffset = 1;
 
@@ -102,6 +105,10 @@ export const updateFileReviewResultsPositions = (
     ...analysisResults.files[updatedFile.fullPath],
   };
   for (const issue in fileIssuesList) {
+    if (!Object.prototype.hasOwnProperty.call(fileIssuesList, issue)) {
+      continue;
+    }
+
     for (const [index, position] of fileIssuesList[issue].entries()) {
       const currentLineIsOnEdgeOfIssueRange = offsetedline === position.rows[0] || offsetedline === position.rows[1];
 
@@ -120,6 +127,7 @@ export const updateFileReviewResultsPositions = (
         if (changesText.length && changesText !== goToNewLine && currentLineIsOnEdgeOfIssueRange) {
           if (changesRange.start.character < position.cols[0] && !changesText.includes(goToNewLine)) {
             for (const col in position.cols) {
+              if (!Object.prototype.hasOwnProperty.call(position.cols, col)) continue;
               position.cols[col] += changesText.length;
             }
           }
@@ -135,6 +143,7 @@ export const updateFileReviewResultsPositions = (
           }
           if (changesRange.start.character < position.cols[0] && !changesText.includes(goToNewLine)) {
             for (const char in position.cols) {
+              if (!Object.prototype.hasOwnProperty.call(position.cols, char)) continue;
               position.cols[char] =
                 position.cols[char] > 0 ? position.cols[char] - updatedFile.contentChanges[0].rangeLength : 0;
             }
@@ -232,6 +241,7 @@ export const findCompleteSuggestion = (
   suggestionIndex = parseInt(suggestionIndex, 10);
   const suggestion = analysisResults.suggestions[suggestionIndex];
   if (!suggestion) return;
+  // eslint-disable-next-line consistent-return
   return {
     uri: uri.toString(),
     ...suggestion,
@@ -256,8 +266,8 @@ export const checkCompleteSuggestion = (
     const found = file[index].find(fs => {
       let equal = true;
       for (let dir of ['cols', 'rows']) {
-        for (let index of [0, 1]) {
-          equal = equal && fs[dir][index] === suggestion[dir][index];
+        for (const ind of [0, 1]) {
+          equal = equal && fs[dir][ind] === suggestion[dir][ind];
         }
       }
       return equal;
@@ -282,15 +292,16 @@ export const ignoreIssueCommentText = (issueId: string, isFileIgnore?: boolean):
 };
 
 export const severityAsText = (severity: number): string => {
-  if (severity === 1) {
-    return 'Low';
-  } else if (severity === 2) {
-    return 'Medium';
-  } else if (severity === 3) {
-    return 'High';
-  } else if (severity === 4) {
-    return 'Critical';
-  } else {
-    return '';
+  switch (severity) {
+    case 1:
+      return 'Low';
+    case 2:
+      return 'Medium';
+    case 3:
+      return 'High';
+    case 4:
+      return 'Critical';
+    default:
+      return '';
   }
 };

--- a/src/snyk/utils/ignoreFileUtils.ts
+++ b/src/snyk/utils/ignoreFileUtils.ts
@@ -1,7 +1,7 @@
-import * as vscode from 'vscode';
+import { constants } from '@snyk/code-client';
 import { Buffer } from 'buffer';
 import * as fs from 'fs';
-import { constants } from '@snyk/code-client';
+import * as vscode from 'vscode';
 
 export const createDCIgnore = async (path: string, custom: boolean) => {
   const content: Buffer = Buffer.from(custom ? constants.DCIGNORE_DRAFTS.custom : constants.DCIGNORE_DRAFTS.default);
@@ -10,5 +10,5 @@ export const createDCIgnore = async (path: string, custom: boolean) => {
   // We don't want to override the dcignore file with an empty one.
   if (!custom || !fs.existsSync(filePath)) await vscode.workspace.fs.writeFile(openPath, content);
   const doc = await vscode.workspace.openTextDocument(openPath);
-  vscode.window.showTextDocument(doc);
+  void vscode.window.showTextDocument(doc);
 };

--- a/src/snyk/view/Node.ts
+++ b/src/snyk/view/Node.ts
@@ -1,6 +1,6 @@
-import { Uri, Range, Command, TreeItem, TreeItemCollapsibleState, ThemeIcon } from 'vscode';
-import { SNYK_OPEN_BROWSER_COMMAND, SNYK_OPEN_LOCAL_COMMAND } from '../constants/commands';
 import * as path from 'path';
+import { Command, Range, ThemeIcon, TreeItem, TreeItemCollapsibleState, Uri } from 'vscode';
+import { SNYK_OPEN_BROWSER_COMMAND, SNYK_OPEN_LOCAL_COMMAND } from '../constants/commands';
 
 export interface INodeIcon {
   ['light']: string;
@@ -60,8 +60,8 @@ export class Node extends TreeItem implements INode {
     if (!desc && options.issue) {
       desc = options.issue.uri.path.split('/').pop() || '';
       if (options.issue.range) {
-        desc += '[' + (options.issue.range.start.line + 1) + ', ';
-        desc += options.issue.range.start.character + 1 + ']';
+        desc += `[${options.issue.range.start.line + 1}, `;
+        desc += `${options.issue.range.start.character + 1}]`;
       }
     }
     this.description = desc;

--- a/src/snyk/view/NodeProvider.ts
+++ b/src/snyk/view/NodeProvider.ts
@@ -1,5 +1,5 @@
+import { ProviderResult, TreeDataProvider } from 'vscode';
 import { ExtensionInterface } from '../../interfaces/SnykInterfaces';
-import { TreeDataProvider, ProviderResult } from 'vscode';
 import { Node } from './Node';
 
 export abstract class NodeProvider implements TreeDataProvider<Node> {

--- a/src/snyk/view/SupportProvider.ts
+++ b/src/snyk/view/SupportProvider.ts
@@ -1,7 +1,7 @@
-import { TreeItemCollapsibleState, ThemeIcon } from 'vscode';
-import { NodeProvider } from './NodeProvider';
-import { Node } from './Node';
+import { ThemeIcon, TreeItemCollapsibleState } from 'vscode';
 import { SNYK_DCIGNORE_COMMAND } from '../constants/commands';
+import { Node } from './Node';
+import { NodeProvider } from './NodeProvider';
 
 export class SupportProvider extends NodeProvider {
   getRootChildren(): Node[] {

--- a/src/snyk/view/loadingBadge.ts
+++ b/src/snyk/view/loadingBadge.ts
@@ -5,7 +5,7 @@ import { errorsLogs } from '../messages/errorsServerLogMessages';
 import { PendingTask, PendingTaskInterface } from '../utils/pendingTask';
 
 export interface ILoadingBadge {
-  setLoadingBadge(value: boolean, reportModule: BaseSnykModuleInterface): Promise<void>;
+  setLoadingBadge(value: boolean, reportModule: BaseSnykModuleInterface): void;
 }
 
 export class LoadingBadge implements ILoadingBadge {
@@ -23,10 +23,11 @@ export class LoadingBadge implements ILoadingBadge {
   }
 
   // Leave viewId undefined to remove the badge from all views
-  async setLoadingBadge(value: boolean, reportModule: BaseSnykModuleInterface): Promise<void> {
+  setLoadingBadge(value: boolean, reportModule: BaseSnykModuleInterface): void {
     this.shouldShowProgressBadge = value;
     if (value) {
       // Using closure on this to allow partial binding in arbitrary positions
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
       const self = this;
       this.initializedView.waiter
         .then(() =>
@@ -35,16 +36,14 @@ export class LoadingBadge implements ILoadingBadge {
           ),
         )
         .then(
-          () => {},
+          () => undefined,
           error =>
             reportModule.processError(error, {
               message: errorsLogs.loadingBadge,
             }),
         );
-    } else {
-      if (this.progressBadge && !this.progressBadge.isCompleted) {
-        this.progressBadge.complete();
-      }
+    } else if (this.progressBadge && !this.progressBadge.isCompleted) {
+      this.progressBadge.complete();
     }
   }
 }

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,5 +1,4 @@
 import * as path from 'path';
-
 import { runTests } from 'vscode-test';
 
 async function main() {
@@ -22,4 +21,4 @@ async function main() {
   }
 }
 
-main();
+void main();

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -2,16 +2,14 @@
 // Note: This example test is leveraging the Mocha test framework.
 // Please refer to their documentation on https://mochajs.org/ for help.
 //
-import * as assert from "assert";
-import * as vscode from "vscode";
-import * as nodePath from 'path';
+import * as assert from 'assert';
 //
-import * as extension from "../../extension";
-import { ExtensionInterface } from "../../interfaces/SnykInterfaces";
-import { configuration } from "../../snyk/configuration";
+import * as extension from '../../extension';
+import { ExtensionInterface } from '../../interfaces/SnykInterfaces';
+import { configuration } from '../../snyk/configuration';
 
 const testToken = '23';
-const mockedTestFilesDirPath = __dirname.replace("out/test", "src/test");
+const mockedTestFilesDirPath = __dirname.replace('out/test', 'src/test');
 // const mockedFolderPath = vscode.Uri.parse('scheme:' + nodePath.join(mockedTestFilesDirPath, '/../mocked_data'), true)
 //   .fsPath;
 
@@ -34,7 +32,7 @@ const preTestConfigureExtension = () => {
 
 // const testIgnoreComment = '  // deepcode ignore UseStrictEquality: <please specify a reason of ignoring this>\n';
 
-suite("Snyk Extension Tests", () => {
+suite('Snyk Extension Tests', () => {
   let testExtension: ExtensionInterface;
   test('Pre-test configuring', () => {
     testExtension = preTestConfigureExtension();
@@ -45,5 +43,4 @@ suite("Snyk Extension Tests", () => {
     //   path.join(mockedTestFilesDirPath, "../mocked_data")
     // );
   });
-
 });

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,10 +1,10 @@
-import * as path from 'path';
-import * as Mocha from 'mocha';
 import glob from 'glob';
+import * as Mocha from 'mocha';
+import * as path from 'path';
 
 export function run(): Promise<void> {
-
   // Create the mocha test
+  // eslint-disable-next-line new-cap
   const mocha = new Mocha.default({
     ui: 'tdd',
   });
@@ -29,9 +29,12 @@ export function run(): Promise<void> {
             c();
           }
         });
+        // eslint-disable-next-line no-shadow
       } catch (err) {
         e(err);
       }
+
+      return undefined;
     });
   });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,7 @@
     "rootDir": "src",
     "outDir": "out",
     "target": "es2019",
-    "lib": [
-      "esnext"
-    ],
+    "lib": ["esnext"],
     "module": "commonjs",
     "sourceMap": true,
     "allowJs": false,
@@ -18,14 +16,9 @@
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedParameters": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "resolveJsonModule": true
   },
-  "include": [
-    "src"
-  ],
-  "exclude": [
-    "out",
-    "node_modules",
-    ".vscode-test"
-  ]
+  "include": ["src"],
+  "exclude": ["out", "node_modules", ".vscode-test"]
 }


### PR DESCRIPTION
Fixes ESLint errors in the code.
Warnings are left due to time constraint and shall be fixed on-demand during future refactorings. 
Some of the errors due to dynamic typing are left as-is with line/file lint ignores in place for time constraint reason as well. 