### PR TITLE
feat: utilise itly.flush to ensure event delivery [ROAD-120]

### DIFF
--- a/src/snyk/analytics/itly.ts
+++ b/src/snyk/analytics/itly.ts
@@ -59,6 +59,8 @@ export class Iteratively {
     return this;
   }
 
+  public flush = (): Promise<void> => itly.flush();
+
   public identify(userId: string): void {
     if (!this.canReportEvents()) {
       return;
@@ -131,9 +133,9 @@ export class Iteratively {
     );
   }
 
-  public logPluginIsInstalled(): void {
+  public logPluginIsInstalled(): Promise<void> {
     if (!this.canReportEvents()) {
-      return;
+      return Promise.resolve();
     }
 
     itly.pluginIsInstalled(
@@ -149,6 +151,8 @@ export class Iteratively {
         },
       },
     );
+
+    return itly.flush();
   }
 
   public logPluginIsUninstalled(userId?: string): void {

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -59,7 +59,7 @@ class SnykExtension extends SnykLib implements ExtensionInterface {
     return this.debouncedCommands[name](...args);
   }
 
-  public activate(context: vscode.ExtensionContext): void {
+  public async activate(context: vscode.ExtensionContext): Promise<void> {
     this.context = context;
     this.emitter.on(this.emitter.events.supportedFilesLoaded, this.onSupportedFilesLoaded.bind(this));
     this.emitter.on(this.emitter.events.scanFilesProgress, this.onScanFilesProgress.bind(this));
@@ -189,7 +189,7 @@ class SnykExtension extends SnykLib implements ExtensionInterface {
     // Use memento until lifecycle hooks are implemented
     // https://github.com/microsoft/vscode/issues/98732
     if (!context.globalState.get(MEMENTO_FIRST_INSTALL_DATE_KEY)) {
-      this.analytics.logPluginIsInstalled();
+      await this.analytics.logPluginIsInstalled();
       void context.globalState.update(MEMENTO_FIRST_INSTALL_DATE_KEY, Date.now());
     }
 
@@ -197,8 +197,9 @@ class SnykExtension extends SnykLib implements ExtensionInterface {
     this.startExtension();
   }
 
-  public deactivate(): void {
+  public async deactivate(): Promise<void> {
     this.emitter.removeAllListeners();
+    await this.analytics.flush();
   }
 
   onSupportedFilesLoaded(data: ISupportedFiles | null) {

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -127,8 +127,9 @@ async function reportUninstall(): Promise<void> {
 
   const userId = await getUserId(token);
 
-  // Report event
+  // Report and flush the uninstall event
   analytics.logPluginIsUninstalled(userId);
+  await analytics.flush();
 }
 
 void reportUninstall();


### PR DESCRIPTION
- Use itly.flush() to ensure event queue is delivered when extension is deactivated or uninstalled.
- Flush after 'Plugin is Installed' event to prevent out of order delivery.