### PR TITLE
fix: prevent duplicate "Analysis is triggerred" event

### DIFF
--- a/src/interfaces/SnykInterfaces.ts
+++ b/src/interfaces/SnykInterfaces.ts
@@ -35,7 +35,6 @@ export interface ReportModuleInterface {
 export interface LoginModuleInterface {
   initiateLogin(): Promise<void>;
   checkSession(): Promise<string>;
-  enableCode(): Promise<void>;
   checkCodeEnabled(): Promise<boolean>;
   checkAdvancedMode(): Promise<void>;
 }
@@ -49,6 +48,7 @@ export interface BundlesModuleInterface {
 
 export interface SnykLibInterface {
   setMode(mode: string): void;
+  enableCode(): Promise<void>;
 }
 
 export interface ExtensionInterface

--- a/src/snyk/lib/modules/BaseSnykModule.ts
+++ b/src/snyk/lib/modules/BaseSnykModule.ts
@@ -21,6 +21,7 @@ import SnykAnalyzer from '../analyzer/SnykAnalyzer';
 import SnykStatusBarItem from '../statusBarItem/SnykStatusBarItem';
 import SnykEditorsWatcher from '../watchers/EditorsWatcher';
 import SnykSettingsWatcher from '../watchers/SnykSettingsWatcher';
+import { ISnykCode, SnykCode } from './code';
 
 export default abstract class BaseSnykModule implements BaseSnykModuleInterface {
   analyzer: AnalyzerInterface;
@@ -41,6 +42,8 @@ export default abstract class BaseSnykModule implements BaseSnykModuleInterface 
   remoteBundle: IFileBundle;
   changedFiles: Set<string> = new Set();
 
+  protected snykCode: ISnykCode;
+
   constructor() {
     this.analyzer = new SnykAnalyzer();
     this.statusBarItem = new SnykStatusBarItem();
@@ -51,6 +54,7 @@ export default abstract class BaseSnykModule implements BaseSnykModuleInterface 
     this.analysisStatus = '';
     this.analysisProgress = '';
     this.viewContext = {};
+    this.snykCode = new SnykCode(configuration);
     this.initializedView = new PendingTask();
   }
 

--- a/src/snyk/lib/modules/BundlesModule.ts
+++ b/src/snyk/lib/modules/BundlesModule.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import { BundlesModuleInterface } from '../../../interfaces/SnykInterfaces';
 import { configuration } from '../../configuration';
 import { SNYK_ANALYSIS_STATUS, SNYK_CONTEXT } from '../../constants/views';
+import { Logger } from '../../logger';
 import { errorsLogs } from '../../messages/errorsServerLogMessages';
 import LoginModule from './LoginModule';
 
@@ -57,13 +58,14 @@ abstract class BundlesModule extends LoginModule implements BundlesModuleInterfa
     try {
       const paths = (vscode.workspace.workspaceFolders || []).map(f => f.uri.fsPath);
 
-      this.analytics.logAnalysisIsTriggered({
-        analysisType: ['Snyk Code Security', 'Snyk Code Quality'],
-        ide: 'Visual Studio Code',
-        triggeredByUser: manual,
-      });
-
       if (paths.length) {
+        Logger.info('Code analysis started.');
+        this.analytics.logAnalysisIsTriggered({
+          analysisType: ['Snyk Code Security', 'Snyk Code Quality'],
+          ide: 'Visual Studio Code',
+          triggeredByUser: manual,
+        });
+
         await this.setContext(SNYK_CONTEXT.WORKSPACE_FOUND, true);
         this.runningAnalysis = true;
         this.lastAnalysisStartingTimestamp = Date.now();
@@ -88,6 +90,7 @@ abstract class BundlesModule extends LoginModule implements BundlesModuleInterfa
           this.analyzer.analysisResults = result.analysisResults;
           this.analyzer.createReviewResults();
 
+          Logger.info('Code analysis finished.');
           this.analytics.logAnalysisIsReady({
             ide: 'Visual Studio Code',
             analysisType: 'Snyk Code Security',
@@ -119,6 +122,8 @@ abstract class BundlesModule extends LoginModule implements BundlesModuleInterfa
         analysisType: 'Snyk Code Quality',
         result: 'Error',
       });
+
+      Logger.info('Code analysis failed.');
     } finally {
       this.runningAnalysis = false;
       this.lastAnalysisTimestamp = Date.now();

--- a/src/snyk/lib/modules/LoginModule.ts
+++ b/src/snyk/lib/modules/LoginModule.ts
@@ -13,13 +13,6 @@ abstract class LoginModule extends ReportModule implements LoginModuleInterface 
   private pendingLogin = false;
   private pendingToken = '';
 
-  private snykCode: ISnykCode;
-
-  constructor() {
-    super();
-    this.snykCode = new SnykCode(configuration);
-  }
-
   async initiateLogin(): Promise<void> {
     await this.setContext(SNYK_CONTEXT.LOGGEDIN, false);
 
@@ -109,14 +102,6 @@ abstract class LoginModule extends ReportModule implements LoginModuleInterface 
     }
 
     return enabled;
-  }
-
-  async enableCode(): Promise<void> {
-    const wasEnabled = await this.snykCode.enable();
-    if (wasEnabled) {
-      this.loadingBadge.setLoadingBadge(false, this);
-      await this.checkCodeEnabled();
-    }
   }
 
   async checkAdvancedMode(): Promise<void> {

--- a/src/snyk/lib/modules/SnykLib.ts
+++ b/src/snyk/lib/modules/SnykLib.ts
@@ -94,6 +94,17 @@ export default class SnykLib extends BundlesModule implements SnykLibInterface {
     }
   }
 
+  async enableCode(): Promise<void> {
+    const wasEnabled = await this.snykCode.enable();
+    if (wasEnabled) {
+      this.loadingBadge.setLoadingBadge(false, this);
+      await this.checkCodeEnabled();
+
+      Logger.info('Snyk Code was enabled.');
+      await this.startAnalysis(false);
+    }
+  }
+
   onDidChangeAnalysisViewVisibility(visible: boolean): void {
     if (visible && !configuration.token) {
       // Track if a user is not authenticated and expanded the analysis view

--- a/src/snyk/lib/watchers/SnykSettingsWatcher.ts
+++ b/src/snyk/lib/watchers/SnykSettingsWatcher.ts
@@ -6,7 +6,11 @@ class SnykSettingsWatcher implements SnykWatcherInterface {
   private async onChangeConfiguration(extension: ExtensionInterface, key: string): Promise<void> {
     if (key === 'snyk.advancedMode') {
       return extension.checkAdvancedMode();
+    } else if (key === 'snyk.codeEnabled') {
+      void extension.checkCodeEnabled();
+      return;
     }
+
     const extensionConfig = vscode.workspace.getConfiguration('snyk');
     const url: string | undefined = extensionConfig.get('url');
 


### PR DESCRIPTION
- Ensures extension is not restarted when "snyk.codeEnabled" setting is written
- Additional logging added
