### PR TITLE
fix: temporarily prevent rejecting Code API requests if CA check not passing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Snyk Vulnerability Scanner Changelog
 
+## [1.1.3]
+### Fixed
+
+- Ignore CA check temporarily before VS Code pushes fix for expired Let's Encrypt certificate. Bug: https://github.com/microsoft/vscode/issues/134244
+
 ## [1.1.2]
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snyk-vulnerability-scanner",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snyk-vulnerability-scanner",
-      "version": "1.1.1",
+      "version": "1.1.3",
       "dependencies": {
         "@itly/plugin-iteratively-node": "^2.3.1",
         "@itly/plugin-schema-validator": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snyk-vulnerability-scanner",
   "//": "Changing display name requires change in general.ts",
   "displayName": "Snyk Vulnerability Scanner",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Snyk finds bugs, security vulnerabilities, performance and API issues based on AI. Snyk's speed of analysis allow us to analyse your code in real time and deliver results when you hit the save button in Visual Studio Code. We support Java, JavaScript, and TypeScript",
   "icon": "images/readme/snyk_extension_icon.png",
   "publisher": "snyk-security",

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -62,6 +62,10 @@ class SnykExtension extends SnykLib implements IExtension {
   }
 
   public activate(context: vscode.ExtensionContext): void {
+    // Temporarily avoid CA check until VS Code pushes fix for the Electron bug: https://github.com/microsoft/vscode/issues/134244
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    (global as any).ignoreUnknownCA = true;
+
     this.context = context;
 
     this.statusBarItem.show();


### PR DESCRIPTION
Snyk VS Code extension is not working at the moment due to https://github.com/electron/electron/issues/31212 and https://github.com/microsoft/vscode/issues/134244.

Temporarily fix our extension by preventing rejecting Code API requests if CA check not passing.