### PR TITLE
fix: do not publish dev-related files [ROAD-404]

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,11 +1,28 @@
+# Build and testing
 .vscode/**
 .vscode-test/**
 out/test/**
 src/**
-.gitignore
-vsc-extension-quickstart.md
-**/tsconfig.json
-**/.eslintrc.json
+mocked_data/**
 **/*.map
 **/*.ts
-extension-test-mode.md
+.dccache
+.github/**
+
+# Configuration
+.gitignore
+tsconfig.json
+.eslintrc.json
+.prettierrc.js
+.editorconfig
+.itlyrc
+
+# Documentation
+README.preview.md
+development.md
+
+# Snyk CLI
+snyk-macos
+snyk-linux
+snyk-win.exe
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "marked": "^3.0.2",
         "open": "^7.4.2",
         "rxjs": "^7.3.0",
+        "string-argv": "^0.3.1",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -43,7 +44,6 @@
         "mocha": "^8.1.3",
         "prettier": "^2.1.1",
         "sinon": "^11.1.1",
-        "string-argv": "^0.3.1",
         "typescript": "^4.0.2",
         "vscode-test": "^1.4.0",
         "yalc": "^1.0.0-pre.44"
@@ -6527,7 +6527,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
       "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
-      "dev": true,
       "engines": {
         "node": ">=0.6.19"
       }
@@ -12309,8 +12308,7 @@
     "string-argv": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
-      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
-      "dev": true
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg=="
     },
     "string-width": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -335,8 +335,7 @@
     "sinon": "^11.1.1",
     "typescript": "^4.0.2",
     "vscode-test": "^1.4.0",
-    "yalc": "^1.0.0-pre.44",
-    "string-argv": "^0.3.1"
+    "yalc": "^1.0.0-pre.44"
   },
   "dependencies": {
     "@itly/plugin-iteratively-node": "^2.3.1",
@@ -350,6 +349,7 @@
     "open": "^7.4.2",
     "uuid": "^8.3.2",
     "rxjs": "^7.3.0",
-    "marked": "^3.0.2"
+    "marked": "^3.0.2",
+    "string-argv": "^0.3.1"
   }
 }

--- a/src/snyk/cli/cliExecutable.ts
+++ b/src/snyk/cli/cliExecutable.ts
@@ -1,10 +1,11 @@
+import * as fs from 'fs/promises';
 import path from 'path';
 import { Platform } from '../common/platform';
-import * as fs from 'fs/promises';
 import { Checksum } from './checksum';
 import { CliSupportedPlatform } from './supportedPlatforms';
 
 export class CliExecutable {
+  // If values updated, `.vscodeignore` to be changed.
   public static filenameSuffixes: Record<CliSupportedPlatform, string> = {
     linux: 'snyk-linux',
     win32: 'snyk-win.exe',


### PR DESCRIPTION
Currently dev related files are pushed to the Marketplace and distributed to the end-users. We shouldn't do it.