### PR TITLE
chore: release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Snyk Vulnerability Scanner Changelog
 
+## [1.2.1]
+
+### Fixed
+
+- Wrong casing for the emitted JS file that break extension on Linux and Windows machines.
+
 ## [1.2.0]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snyk-vulnerability-scanner",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snyk-vulnerability-scanner",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@itly/plugin-amplitude-node": "^2.5.0",
         "@itly/plugin-schema-validator": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snyk-vulnerability-scanner",
   "//": "Changing display name requires change in general.ts",
   "displayName": "Snyk Vulnerability Scanner",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Easily find and fix vulnerabilities in both your code and open source dependencies with fast and accurate scans.",
   "icon": "media/images/readme/snyk_extension_icon.png",
   "publisher": "snyk-security",


### PR DESCRIPTION
Since extension is published not bundled, modules are loaded from file system, thus prone to case sensitivity issues. Had to clean up the `out` directory locally that gets packaged, and release the patched version to Marketplace.

<img width="832" alt="Screenshot 2021-11-04 at 13 07 50" src="https://user-images.githubusercontent.com/2239563/140310846-10721b8f-41be-4023-9731-88d1389ccfe6.png">
