### PR TITLE
[VSCode] Remove the commit comments [ROAD-409]

### DIFF
--- a/media/views/snykCode/suggestion/suggestion.css
+++ b/media/views/snykCode/suggestion/suggestion.css
@@ -47,7 +47,6 @@ section { padding: 20px }
 
 #info-top { margin-bottom: 8px; }
 #example-top { margin-bottom: 16px; }
-#explanations-group { padding-top:16px }
 
 .arrow { display: inline-flex; vertical-align: middle; cursor: pointer; }
 .arrow.enabled { fill: #7754DB; color: #7754DB; }
@@ -63,7 +62,6 @@ section { padding: 20px }
 .example-line.added { background-color: #e6ffed; }
 .example-line.added>code { font-weight:600 }
 .example-line>code { padding-left: 30px; white-space: pre-wrap; color: #231F20; font-weight:400 }
-#explanations-top { margin-top: 16px; margin-bottom: 8px; }
 
 .vscode-dark #example { border-color: rgba(255,255,255,.075); background-color: rgba(0,0,0,.15)  }
 .vscode-dark .removed { background-color:rgba(201,60,55,0.2); color:#fff }

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
@@ -237,10 +237,6 @@ export class CodeSuggestionWebviewProvider extends WebviewProvider implements IC
             </div>
           </div>
           <div id="example"></div>
-          <div id="explanations-group">
-            <div id="explanations-top">Explanations from other repositories</div>
-            <div id="explanations"></div>
-          </div>
         </section>
         <section class="feedback-section delimiter-top">
           <div id="ignore-section">

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
@@ -280,18 +280,6 @@
       example.className = 'hidden';
     }
 
-    const explanationTop = document.getElementById('explanations-top')!;
-    explanationTop.className = suggestion.exampleCommitDescriptions.lenght ? '' : 'hidden';
-
-    const explanations = document.getElementById('explanations')!;
-    explanations.querySelectorAll('*').forEach(n => n.remove());
-    for (let e of suggestion.exampleCommitDescriptions) {
-      const exp = document.createElement('div');
-      exp.className = 'explanation font-light';
-      exp.innerHTML = e;
-      explanations.appendChild(exp);
-    }
-
     feedbackVisibility = 'close';
     // showCurrentFeedback();
   }


### PR DESCRIPTION
In the Issue Details panel, underneath the Example fixes there are the commit comments.
We need to remove them because they do not reflect the example fixes and confuse the users.