### PR TITLE
fix: Snyk Code issue to diagnostic mapping

### DIFF
--- a/src/snyk/common/views/webviewProvider.ts
+++ b/src/snyk/common/views/webviewProvider.ts
@@ -18,6 +18,12 @@ export abstract class WebviewProvider {
     this.panel = panel;
   }
 
+  protected async focusSecondEditorGroup(): Promise<void> {
+    // workaround for: https://github.com/microsoft/vscode/issues/71608
+    // when resolved, we can set showPanel back to sync execution.
+    await vscode.commands.executeCommand('workbench.action.focusSecondEditorGroup');
+  }
+
   protected disposePanel(): void {
     if (this.panel) this.panel.dispose();
   }

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -273,7 +273,10 @@ class SnykExtension extends SnykLib implements IExtension {
       vscode.commands.registerCommand(SNYK_SETMODE_COMMAND, this.commandController.setScanMode.bind(this)),
       vscode.commands.registerCommand(SNYK_SETTINGS_COMMAND, this.commandController.openSettings.bind(this)),
       vscode.commands.registerCommand(SNYK_DCIGNORE_COMMAND, this.commandController.createDCIgnore.bind(this)),
-      vscode.commands.registerCommand(SNYK_OPEN_ISSUE_COMMAND, this.commandController.openIssueCommand.bind(this)),
+      vscode.commands.registerCommand(
+        SNYK_OPEN_ISSUE_COMMAND,
+        this.commandController.openIssueCommand.bind(this.commandController),
+      ),
       vscode.commands.registerCommand(
         SNYK_SHOW_OUTPUT_COMMAND,
         this.commandController.showOutputChannel.bind(this.commandController),

--- a/src/snyk/snykCode/codeActions/disposableCodeActionsProvider.ts
+++ b/src/snyk/snykCode/codeActions/disposableCodeActionsProvider.ts
@@ -2,13 +2,16 @@
 import * as vscode from 'vscode';
 import { IAnalytics } from '../../common/analytics/itly';
 import { CodeActionAdapter, CodeActionKindAdapter } from '../../common/vscode/codeAction';
+import { Disposable } from '../../common/vscode/types';
 import { SnykIssuesActionProvider } from './issuesActionsProvider';
 
-export class DisposableCodeActionsProvider implements vscode.Disposable {
+export type CodeActionsCallbackFunctions = { [key: string]: (x: unknown) => any };
+
+export class DisposableCodeActionsProvider implements Disposable {
   private disposableProvider: vscode.Disposable | undefined;
   constructor(
     snykReview: vscode.DiagnosticCollection | undefined,
-    callbacks: { [key: string]: Function },
+    callbacks: CodeActionsCallbackFunctions,
     readonly analytics: IAnalytics,
   ) {
     this.registerProvider(snykReview, callbacks);
@@ -16,7 +19,7 @@ export class DisposableCodeActionsProvider implements vscode.Disposable {
 
   private registerProvider(
     snykReview: vscode.DiagnosticCollection | undefined,
-    callbacks: { [key: string]: Function },
+    callbacks: CodeActionsCallbackFunctions,
   ) {
     const provider = new SnykIssuesActionProvider(
       snykReview,

--- a/src/snyk/snykCode/codeService.ts
+++ b/src/snyk/snykCode/codeService.ts
@@ -13,6 +13,7 @@ import { IOpenerService } from '../common/services/openerService';
 import { IViewManagerService } from '../common/services/viewManagerService';
 import { ExtensionContext } from '../common/vscode/extensionContext';
 import { IVSCodeLanguages } from '../common/vscode/languages';
+import { Disposable } from '../common/vscode/types';
 import { IVSCodeWorkspace } from '../common/vscode/workspace';
 import SnykCodeAnalyzer from './analyzer/analyzer';
 import { Progress } from './analyzer/progress';
@@ -21,7 +22,7 @@ import { messages as analysisMessages } from './messages/analysis';
 import { ICodeSuggestionWebviewProvider } from './views/interfaces';
 import { CodeSuggestionWebviewProvider } from './views/suggestion/codeSuggestionWebviewProvider';
 
-export interface ISnykCodeService extends AnalysisStatusProvider {
+export interface ISnykCodeService extends AnalysisStatusProvider, Disposable {
   analyzer: ISnykCodeAnalyzer;
   analysisStatus: string;
   analysisProgress: string;
@@ -35,7 +36,6 @@ export interface ISnykCodeService extends AnalysisStatusProvider {
   checkCodeEnabled(): Promise<boolean>;
   enable(): Promise<boolean>;
   addChangedFile(filePath: string): void;
-  dispose(): void;
 }
 
 export class SnykCodeService extends AnalysisStatusProvider implements ISnykCodeService {
@@ -232,6 +232,7 @@ export class SnykCodeService extends AnalysisStatusProvider implements ISnykCode
 
   dispose(): void {
     this.progress.removeAllListeners();
+    this.analyzer.dispose();
   }
 
   private sleep = (duration: number) => new Promise(resolve => setTimeout(resolve, duration));

--- a/src/snyk/snykCode/hoverProvider/hoverProvider.ts
+++ b/src/snyk/snykCode/hoverProvider/hoverProvider.ts
@@ -3,14 +3,7 @@ import { IDE_NAME } from '../../common/constants/general';
 import { ILog } from '../../common/logger/interfaces';
 import { IHoverAdapter } from '../../common/vscode/hover';
 import { IVSCodeLanguages } from '../../common/vscode/languages';
-import {
-  DiagnosticCollection,
-  Disposable,
-  Position,
-  TextDocument,
-  Hover,
-  Diagnostic,
-} from '../../common/vscode/types';
+import { Diagnostic, DiagnosticCollection, Disposable, Hover, Position, TextDocument } from '../../common/vscode/types';
 import { IGNORE_TIP_FOR_USER } from '../constants/analysis';
 import { ISnykCodeAnalyzer } from '../interfaces';
 import { IssueUtils } from '../utils/issueUtils';
@@ -25,13 +18,14 @@ export class DisposableHoverProvider implements Disposable {
     private readonly analytics: IAnalytics,
   ) {}
 
-  register(snykReview: DiagnosticCollection | undefined, hoverAdapter: IHoverAdapter): void {
+  register(snykReview: DiagnosticCollection | undefined, hoverAdapter: IHoverAdapter): Disposable {
     this.hoverProvider = this.vscodeLanguages.registerHoverProvider(
       { scheme: 'file', language: '*' },
       {
         provideHover: this.getHover(snykReview, hoverAdapter),
       },
     );
+    return this;
   }
 
   getHover(snykReview: DiagnosticCollection | undefined, hoverAdapter: IHoverAdapter) {
@@ -49,7 +43,7 @@ export class DisposableHoverProvider implements Disposable {
   }
 
   private logIssueHoverIsDisplayed(issue: Diagnostic): void {
-    const suggestion = this.analyzer.findSuggestion(issue.message);
+    const suggestion = this.analyzer.findSuggestion(issue);
     if (!suggestion) {
       this.logger.debug('Failed to log hover displayed analytical event.');
       return;

--- a/src/snyk/snykCode/interfaces.ts
+++ b/src/snyk/snykCode/interfaces.ts
@@ -2,6 +2,7 @@ import { AnalysisResultLegacy, FilePath, FileSuggestion, Suggestion } from '@sny
 import * as vscode from 'vscode';
 import { DiagnosticCollection, TextDocument } from 'vscode';
 import { IExtension } from '../base/modules/interfaces';
+import { Disposable } from '../common/vscode/types';
 
 export type completeFileSuggestionType = ICodeSuggestion &
   FileSuggestion & {
@@ -37,12 +38,12 @@ export interface ISnykCodeResult extends AnalysisResultLegacy {
   suggestions: Readonly<ICodeSuggestions>;
 }
 
-export interface ISnykCodeAnalyzer {
+export interface ISnykCodeAnalyzer extends Disposable {
   codeSecurityReview: DiagnosticCollection | undefined;
   codeQualityReview: DiagnosticCollection | undefined;
   setAnalysisResults(results: AnalysisResultLegacy): void;
   getAnalysisResults(): Readonly<ISnykCodeResult>;
-  findSuggestion(suggestionName: string): Readonly<ICodeSuggestion | undefined>;
+  findSuggestion(diagnostic: vscode.Diagnostic): Readonly<ICodeSuggestion | undefined>;
   getFullSuggestion(
     suggestionId: string,
     uri: vscode.Uri,

--- a/src/snyk/snykCode/views/interfaces.ts
+++ b/src/snyk/snykCode/views/interfaces.ts
@@ -1,5 +1,5 @@
-import { IExtension } from '../../base/modules/interfaces';
 import * as vscode from 'vscode';
+import { IExtension } from '../../base/modules/interfaces';
 
 export interface ICodeSuggestionWebviewProvider {
   activate(extension: IExtension): void;
@@ -13,4 +13,5 @@ export type CodeIssueCommandArg = {
   range: vscode.Range;
   openUri?: vscode.Uri;
   openRange?: vscode.Range;
+  diagnostic: vscode.Diagnostic;
 };

--- a/src/snyk/snykCode/views/issueTreeProvider.ts
+++ b/src/snyk/snykCode/views/issueTreeProvider.ts
@@ -159,6 +159,7 @@ export class IssueTreeProvider extends AnalysisTreeNodeProvder {
                 message: d.message,
                 uri: uri,
                 range: d.range,
+                diagnostic: d,
               } as CodeIssueCommandArg,
             } as OpenIssueCommandArg,
           ],

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
@@ -47,15 +47,8 @@ export class CodeSuggestionWebviewProvider extends WebviewProvider implements IC
 
   async showPanel(suggestion: completeFileSuggestionType): Promise<void> {
     try {
-      if (
-        !vscode.window.activeTextEditor?.viewColumn ||
-        !this.panel?.viewColumn ||
-        this.panel.viewColumn !== vscode.ViewColumn.Two
-      ) {
-        // workaround for: https://github.com/microsoft/vscode/issues/71608
-        // when resolved, we can set showPanel back to sync execution.
-        await vscode.commands.executeCommand('workbench.action.focusSecondEditorGroup');
-      }
+      await this.focusSecondEditorGroup();
+
       if (this.panel) {
         this.panel.title = this.getTitle(suggestion);
         this.panel.reveal(vscode.ViewColumn.Two, true);

--- a/src/snyk/snykOss/views/suggestion/ossSuggestionWebviewProvider.ts
+++ b/src/snyk/snykOss/views/suggestion/ossSuggestionWebviewProvider.ts
@@ -34,15 +34,7 @@ export class OssSuggestionWebviewProvider extends WebviewProvider implements IOs
   }
 
   async showPanel(vulnerability: OssIssueCommandArg): Promise<void> {
-    if (
-      !vscode.window.activeTextEditor?.viewColumn ||
-      !this.panel?.viewColumn ||
-      this.panel.viewColumn !== vscode.ViewColumn.Two
-    ) {
-      // workaround for: https://github.com/microsoft/vscode/issues/71608
-      // when resolved, we can set showPanel back to sync execution.
-      await vscode.commands.executeCommand('workbench.action.focusSecondEditorGroup');
-    }
+    await this.focusSecondEditorGroup();
 
     if (this.panel) {
       this.panel.reveal(vscode.ViewColumn.Two, true);
@@ -90,7 +82,7 @@ export class OssSuggestionWebviewProvider extends WebviewProvider implements IOs
       ['dark-medium-severity', 'svg'],
       ['dark-low-severity', 'svg'],
     ].reduce((accumulator: Record<string, string>, [name, ext]) => {
-      const uri = this.getWebViewUri('media', 'images', `${name}.${ext}`); // todo move to media folder
+      const uri = this.getWebViewUri('media', 'images', `${name}.${ext}`);
       if (!uri) throw new Error('Image missing.');
       accumulator[name] = uri.toString();
       return accumulator;


### PR DESCRIPTION
This fixes not appearing webview due to wrong suggestion that is found when mapping diagnostics to suggestion results from Snyk Code. 

**Solution**
Since I we don't want to revisit the whole data model, as this would require large refactoring, an explicit map between reported suggestions and created diagnostics was added.
See `diagnosticSuggestion` member as part of Analyzer class.

As part of PR we mark disposables correctly and dispose them on extension deactivation, which didn't happen previously.