### PR TITLE
feat: add feature flags [ROAD-549]

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,8 @@
           "snyk.features.preview": {
             "type": "object",
             "default": {},
+            "title": "Preview feature toggles",
+            "description": "Preview features that are currently in development. Setting keys will be removed when features become stable.",
             "propertyNames": true,
             "properties": {
               "reportFalsePositives": {
@@ -168,9 +170,7 @@
                 "description": "Allows reporting false positives for Snyk Code suggestions",
                 "default": false
               }
-            },
-            "title": "Preview feature toggles",
-            "description": "Preview features that are currently in development. Setting keys will be removed when features become stable."
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -156,6 +156,21 @@
             "additionalProperties": false,
             "description": "Severity issues to display.",
             "scope": "window"
+          },
+          "snyk.features.preview": {
+            "type": "object",
+            "default": {},
+            "propertyNames": true,
+            "properties": {
+              "reportFalsePositives": {
+                "type": "boolean",
+                "title": "Enable report false positives",
+                "description": "Allows reporting false positives for Snyk Code suggestions",
+                "default": false
+              }
+            },
+            "title": "Preview feature toggles",
+            "description": "Preview features that are currently in development. Setting keys will be removed when features become stable."
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
             "properties": {
               "reportFalsePositives": {
                 "type": "boolean",
-                "title": "Enable report false positives",
+                "title": "Enable \"report false positives\"",
                 "description": "Allows reporting false positives for Snyk Code suggestions",
                 "default": false
               }

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -11,6 +11,7 @@ import {
   CODE_QUALITY_ENABLED_SETTING,
   CODE_SECURITY_ENABLED_SETTING,
   CONFIGURATION_IDENTIFIER,
+  FEATURES_PREVIEW_SETTING,
   OSS_ENABLED_SETTING,
   SEVERITY_FILTER_SETTING,
   TOKEN_SETTING,
@@ -35,6 +36,10 @@ export interface SeverityFilter {
 
   [severity: string]: boolean;
 }
+
+export type PreviewFeatures = {
+  reportFalsePositives: boolean | undefined;
+};
 
 export interface IConfiguration {
   isDevelopment: boolean;
@@ -278,6 +283,23 @@ export class Configuration implements IConfiguration {
 
   get organization(): string | undefined {
     return this.workspace.getConfiguration<string>(CONFIGURATION_IDENTIFIER, this.getConfigName(ADVANCED_ORGANIZATION));
+  }
+
+  get previewFeatures(): PreviewFeatures {
+    const defaulSetting: PreviewFeatures = {
+      reportFalsePositives: false,
+    };
+
+    const userSetting =
+      this.workspace.getConfiguration<PreviewFeatures>(
+        CONFIGURATION_IDENTIFIER,
+        this.getConfigName(FEATURES_PREVIEW_SETTING),
+      ) || {};
+
+    return {
+      ...defaulSetting,
+      ...userSetting,
+    };
   }
 
   getAdditionalCliParameters(): string | undefined {

--- a/src/snyk/common/constants/settings.ts
+++ b/src/snyk/common/constants/settings.ts
@@ -7,6 +7,7 @@ export const TOKEN_SETTING = `${CONFIGURATION_IDENTIFIER}.token`;
 export const OSS_ENABLED_SETTING = `${CONFIGURATION_IDENTIFIER}.features.openSourceSecurity`;
 export const CODE_SECURITY_ENABLED_SETTING = `${CONFIGURATION_IDENTIFIER}.features.codeSecurity`;
 export const CODE_QUALITY_ENABLED_SETTING = `${CONFIGURATION_IDENTIFIER}.features.codeQuality`;
+export const FEATURES_PREVIEW_SETTING = `${CONFIGURATION_IDENTIFIER}.features.preview`;
 
 export const YES_CRASH_REPORT_SETTING = `${CONFIGURATION_IDENTIFIER}.yesCrashReport`;
 export const YES_TELEMETRY_SETTING = `${CONFIGURATION_IDENTIFIER}.yesTelemetry`;

--- a/src/test/unit/common/configuration.test.ts
+++ b/src/test/unit/common/configuration.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { strictEqual } from 'assert';
+import { deepStrictEqual, strictEqual } from 'assert';
 import sinon from 'sinon';
-import { Configuration } from '../../../snyk/common/configuration/configuration';
-import { ADVANCED_CUSTOM_ENDPOINT } from '../../../snyk/common/constants/settings';
+import { Configuration, PreviewFeatures } from '../../../snyk/common/configuration/configuration';
+import { ADVANCED_CUSTOM_ENDPOINT, FEATURES_PREVIEW_SETTING } from '../../../snyk/common/constants/settings';
 import { IVSCodeWorkspace } from '../../../snyk/common/vscode/workspace';
 
 suite('Configuration', () => {
@@ -116,7 +116,29 @@ suite('Configuration', () => {
     strictEqual(configuration.snykOssApiEndpoint, customEndpoint);
   });
 
-  function stubWorkspaceConfiguration(configSetting: string, returnValue: string | undefined): IVSCodeWorkspace {
+  test('Preview features: not enabled', () => {
+    const previewFeatures = undefined;
+    const workspace = stubWorkspaceConfiguration(FEATURES_PREVIEW_SETTING, previewFeatures);
+
+    const configuration = new Configuration({}, workspace);
+
+    deepStrictEqual(configuration.previewFeatures, {
+      reportFalsePositives: false,
+    } as PreviewFeatures);
+  });
+
+  test('Preview features: some features enabled', () => {
+    const previewFeatures = {
+      reportFalsePositives: true,
+    } as PreviewFeatures;
+    const workspace = stubWorkspaceConfiguration(FEATURES_PREVIEW_SETTING, previewFeatures);
+
+    const configuration = new Configuration({}, workspace);
+
+    deepStrictEqual(configuration.previewFeatures, previewFeatures);
+  });
+
+  function stubWorkspaceConfiguration<T>(configSetting: string, returnValue: T | undefined): IVSCodeWorkspace {
     return {
       getConfiguration: (identifier: string, key: string) => {
         if (`${identifier}.${key}` === configSetting) return returnValue;


### PR DESCRIPTION
Feature flags will be part of settings configuration in VS Code extension. They will be stored under "snyk.features.preview" object-type setting, where keys are feature flags and values are bools indicating whether it's enabled or disabled. Absence of setting or a key of the object means it's disabled.

```
"snyk.features.preview": {
    "reportFalsePositives": false,
    "newGreatFeatureX": true
  }
```

They are visible in UI but not easily accessible to prevent users from playing with them and bringing their extension into possible broken state. Here's the screenshot of settings UI:
<img width="778" alt="Screenshot 2022-01-12 at 10 04 41" src="https://user-images.githubusercontent.com/2239563/149097091-1928f122-677e-41f9-930f-aa287bc9c13e.png">

Here's how it's surfaced within the corresponding JSON:
<img width="627" alt="Screenshot 2022-01-12 at 10 05 49" src="https://user-images.githubusercontent.com/2239563/149097292-a6562030-117b-405a-bafd-d2d5daada17c.png">

