### PR TITLE
feat: capture userId when reporting to Sentry [ROAD-471]

### DIFF
--- a/src/snyk/common/error/errorReporter.ts
+++ b/src/snyk/common/error/errorReporter.ts
@@ -4,6 +4,7 @@ import { Configuration, IConfiguration } from '../configuration/configuration';
 import { SnykConfiguration } from '../configuration/snykConfiguration';
 import { ILog } from '../logger/interfaces';
 import { Platform } from '../platform';
+import { User } from '../user';
 import { IVSCodeEnv } from '../vscode/env';
 import { OnUncaughtException } from './integrations/onUncaughtException';
 
@@ -77,11 +78,17 @@ export class ErrorReporter {
     }
   }
 
+  static identify(user: User): void {
+    Sentry.setUser({
+      id: user.authenticatedId,
+    });
+  }
+
   static flush(): Promise<boolean> {
     return Sentry.close(this.eventQueueTimeoutMs);
   }
 
-  private static getContexts(vscodeEnv: IVSCodeEnv, contexts?: Contexts) {
+  private static getContexts(vscodeEnv: IVSCodeEnv, contexts?: Contexts): Contexts {
     return {
       ...contexts,
       os: {

--- a/src/snyk/common/user.ts
+++ b/src/snyk/common/user.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { IAnalytics } from './analytics/itly';
 import { ISnykApiClient } from './api/apiСlient';
 import { MEMENTO_ANONYMOUS_ID } from './constants/globalState';
+import { ErrorReporter } from './error/errorReporter';
 import { ExtensionContext } from './vscode/extensionContext';
 
 export type UserDto = {
@@ -39,6 +40,7 @@ export class User {
       this._authenticatedId = user.id;
 
       await analytics.identify(this._authenticatedId); // map the anonymousId onto authenticatedId
+      ErrorReporter.identify(this);
     }
   }
 


### PR DESCRIPTION
This could help to determine how many users are affected by the reported error. In some scenarios we can establish contact to help them.