### PR TITLE
Fix README.md Broken Link to CLI Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ After the extension is installed, you can set the following configurations for t
 - **Advanced**
   - **Advanced mode**: toggles a panel to allow the user to manually control when the analysis should be run.
   - **Auto Scan Open Source Security**: sets severity level to display in the analysis result tree.
-  - **Additional Parameters**: sets parameters to be passed to Snyk CLI for Open Source Security tests. For the full list you can consult [this reference](https://docs.snyk.io/features/snyk-cli/guides-for-our-cli/cli-reference).
+  - **Additional Parameters**: sets parameters to be passed to Snyk CLI for Open Source Security tests. For the full list you can consult [this reference](https://docs.snyk.io/features/snyk-cli/cli-reference).
 
 ### Create a .dcignore file
 


### PR DESCRIPTION
Hello Snyk Team,

The Extension Configuration section currently has an out of date link to the current CLI Reference page: https://docs.snyk.io/features/snyk-cli/cli-reference. 

This PR updates the link to the correct url replacing this out of date url: https://docs.snyk.io/features/snyk-cli/guides-for-our-cli/cli-reference

Thanks,
Matt