### PR TITLE
feat: block LCE upload for Snyk Code [ROAD-712]

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,17 +205,22 @@
         {
           "id": "snyk.views.analysis.code.security",
           "name": "Code Security",
-          "when": "snyk:loggedIn && snyk:featuresSelected && snyk:codeEnabled && snyk:workspaceFound && !snyk:error"
+          "when": "snyk:loggedIn && snyk:featuresSelected && snyk:codeEnabled && !snyk:codeLocalEngineEnabled && snyk:workspaceFound && !snyk:error"
         },
         {
           "id": "snyk.views.analysis.code.quality",
           "name": "Code Quality",
-          "when": "snyk:loggedIn && snyk:featuresSelected && snyk:codeEnabled && snyk:workspaceFound && !snyk:error"
+          "when": "snyk:loggedIn && snyk:featuresSelected && snyk:codeEnabled && !snyk:codeLocalEngineEnabled && snyk:workspaceFound && !snyk:error"
         },
         {
           "id": "snyk.views.analysis.code.enablement",
           "name": "Code Security & Quality",
           "when": "snyk:loggedIn && snyk:featuresSelected && !snyk:codeEnabled && snyk:workspaceFound && !snyk:error"
+        },
+        {
+          "id": "snyk.views.analysis.code.localEngine",
+          "name": "Code Security & Quality",
+          "when": "snyk:loggedIn && snyk:featuresSelected && snyk:codeEnabled && snyk:codeLocalEngineEnabled && snyk:workspaceFound && !snyk:error"
         },
         {
           "id": "snyk.views.actions",
@@ -257,6 +262,10 @@
       {
         "view": "snyk.views.analysis.code.enablement",
         "contents": "Thanks for connecting with Snyk. ✅\n 👉 You are almost set 🤗.\n[Enable Snyk Code and start analysing](command:snyk.enableCode 'Upload code to Snyk')\nIt looks like your organization's configuration is disabled, that's why you are seeing this message. You can easily enable it by pressing the above button and switching it on.\nWe apologize for the inconvenience and please [contact us](https://snyk.io/contact-us/?utm_source=vsc) if you have any other questions or concerns!"
+      },
+      {
+        "view": "snyk.views.analysis.code.localEngine",
+        "contents": "Snyk Code is configured to use a Local Code Engine instance. This setup is not yet supported by the extension."
       },
       {
         "view": "snyk.views.welcome",
@@ -304,7 +313,7 @@
         },
         {
           "command": "snyk.dcignore",
-          "when": "!snyk:error && snyk:loggedIn && snyk:codeEnabled && snyk:workspaceFound"
+          "when": "!snyk:error && snyk:loggedIn && snyk:codeEnabled && !snyk:codeLocalEngineEnabled && snyk:workspaceFound"
         }
       ]
     },

--- a/src/snyk/base/modules/baseSnykModule.ts
+++ b/src/snyk/base/modules/baseSnykModule.ts
@@ -14,6 +14,7 @@ import { User } from '../../common/user';
 import { ExtensionContext } from '../../common/vscode/extensionContext';
 import { IWatcher } from '../../common/watchers/interfaces';
 import { ISnykCodeService } from '../../snykCode/codeService';
+import { CodeSettings, ICodeSettings } from '../../snykCode/codeSettings';
 import { FalsePositiveApi, IFalsePositiveApi } from '../../snykCode/falsePositive/api/falsePositiveApi';
 import SnykEditorsWatcher from '../../snykCode/watchers/editorsWatcher';
 import { OssService } from '../../snykOss/services/ossService';
@@ -48,6 +49,7 @@ export default abstract class BaseSnykModule implements IBaseSnykModule {
   protected snykApiClient: ISnykApiClient;
   protected falsePositiveApi: IFalsePositiveApi;
   snykCode: ISnykCodeService;
+  protected codeSettings: ICodeSettings;
 
   readonly loadingBadge: ILoadingBadge;
   protected user: User;
@@ -65,6 +67,7 @@ export default abstract class BaseSnykModule implements IBaseSnykModule {
     this.snykApiClient = new SnykApiClient(configuration);
     this.falsePositiveApi = new FalsePositiveApi(configuration);
     this.snykCodeErrorHandler = new SnykCodeErrorHandler(this.contextService, this.loadingBadge, Logger, this);
+    this.codeSettings = new CodeSettings(this.snykApiClient, this.contextService, configuration, this.openerService);
   }
 
   abstract runScan(): Promise<void>;

--- a/src/snyk/base/modules/snykLib.ts
+++ b/src/snyk/base/modules/snykLib.ts
@@ -72,9 +72,9 @@ export default class SnykLib extends BaseSnykModule implements ISnykLib {
   }
 
   async enableCode(): Promise<void> {
-    const wasEnabled = await this.snykCode.enable();
+    const wasEnabled = await this.codeSettings.enable();
     if (wasEnabled) {
-      await this.snykCode.checkCodeEnabled();
+      await this.codeSettings.checkCodeEnabled();
 
       Logger.info('Snyk Code was enabled.');
       try {
@@ -91,7 +91,7 @@ export default class SnykLib extends BaseSnykModule implements ISnykLib {
       return;
     }
 
-    const codeEnabled = await this.snykCode.checkCodeEnabled();
+    const codeEnabled = await this.codeSettings.checkCodeEnabled();
     if (!codeEnabled) {
       return;
     }

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -163,8 +163,12 @@ export class Configuration implements IConfiguration {
     await this.workspace.updateConfiguration(CONFIGURATION_IDENTIFIER, this.getConfigName(TOKEN_SETTING), token, true);
   }
 
+  static get source(): string {
+    return IDE_NAME_SHORT;
+  }
+
   get source(): string {
-    return this.processEnv.GITPOD_WORKSPACE_ID ? 'gitpod' : IDE_NAME_SHORT;
+    return Configuration.source;
   }
 
   getFeaturesConfiguration(): FeaturesConfiguration | undefined {

--- a/src/snyk/common/constants/views.ts
+++ b/src/snyk/common/constants/views.ts
@@ -17,6 +17,7 @@ export const SNYK_CONTEXT = {
   AUTHENTICATING: 'authenticating',
   FEATURES_SELECTED: 'featuresSelected',
   CODE_ENABLED: 'codeEnabled',
+  CODE_LOCAL_ENGINE_ENABLED: 'codeLocalEngineEnabled',
   WORKSPACE_FOUND: 'workspaceFound',
   ERROR: 'error',
   MODE: 'mode',

--- a/src/snyk/common/services/cliConfigService.ts
+++ b/src/snyk/common/services/cliConfigService.ts
@@ -11,7 +11,7 @@ export type SastSettings = {
 export async function getSastSettings(api: ISnykApiClient): Promise<SastSettings> {
   const { data } = await api.get<SastSettings>('cli-config/settings/sast', {
     headers: {
-      'x-snyk-ide': `vsc-${await Configuration.getVersion()}`,
+      'x-snyk-ide': `${Configuration.source}-${await Configuration.getVersion()}`,
     },
   });
   return data;

--- a/src/snyk/common/services/cliConfigService.ts
+++ b/src/snyk/common/services/cliConfigService.ts
@@ -1,10 +1,18 @@
 import { ISnykApiClient } from '../api/apiСlient';
+import { Configuration } from '../configuration/configuration';
 
 export type SastSettings = {
   sastEnabled: boolean;
+  localCodeEngine: {
+    enabled: boolean;
+  };
 };
 
 export async function getSastSettings(api: ISnykApiClient): Promise<SastSettings> {
-  const { data } = await api.get<SastSettings>('cli-config/settings/sast');
+  const { data } = await api.get<SastSettings>('cli-config/settings/sast', {
+    headers: {
+      'x-snyk-ide': `vsc-${await Configuration.getVersion()}`,
+    },
+  });
   return data;
 }

--- a/src/snyk/common/vscode/uri.ts
+++ b/src/snyk/common/vscode/uri.ts
@@ -1,0 +1,12 @@
+import * as vscode from 'vscode';
+import { Uri } from './types';
+
+export interface IUriAdapter {
+  file(path: string): Uri;
+}
+
+export class UriAdapter implements IUriAdapter {
+  file(path: string): Uri {
+    return vscode.Uri.file(path);
+  }
+}

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -48,6 +48,7 @@ import { vsCodeEnv } from './common/vscode/env';
 import { extensionContext } from './common/vscode/extensionContext';
 import { vsCodeLanguages, VSCodeLanguages } from './common/vscode/languages';
 import { ThemeColorAdapter } from './common/vscode/theme';
+import { UriAdapter } from './common/vscode/uri';
 import { vsCodeWindow } from './common/vscode/window';
 import { vsCodeWorkspace } from './common/vscode/workspace';
 import SettingsWatcher from './common/watchers/settingsWatcher';
@@ -113,18 +114,16 @@ class SnykExtension extends SnykLib implements IExtension {
     this.snykCode = new SnykCodeService(
       this.context,
       configuration,
-      this.openerService,
       this.viewManagerService,
-      this.contextService,
       vsCodeWorkspace,
       vsCodeWindow,
       this.user,
-      this.snykApiClient,
       this.falsePositiveApi,
       Logger,
       this.analytics,
       new VSCodeLanguages(),
       this.snykCodeErrorHandler,
+      new UriAdapter(),
     );
 
     this.cliDownloadService = new CliDownloadService(this.context, new StaticCliApi(), vsCodeWindow, Logger);

--- a/src/snyk/snykCode/codeService.ts
+++ b/src/snyk/snykCode/codeService.ts
@@ -18,6 +18,7 @@ import { IWebViewProvider } from '../common/views/webviewProvider';
 import { ExtensionContext } from '../common/vscode/extensionContext';
 import { IVSCodeLanguages } from '../common/vscode/languages';
 import { Disposable } from '../common/vscode/types';
+import { IUriAdapter } from '../common/vscode/uri';
 import { IVSCodeWindow } from '../common/vscode/window';
 import { IVSCodeWorkspace } from '../common/vscode/workspace';
 import SnykCodeAnalyzer from './analyzer/analyzer';
@@ -46,8 +47,6 @@ export interface ISnykCodeService extends AnalysisStatusProvider, Disposable {
   startAnalysis(paths: string[], manual: boolean, reportTriggeredEvent: boolean): Promise<void>;
   updateStatus(status: string, progress: string): void;
   errorEncountered(error: Error): void;
-  checkCodeEnabled(): Promise<boolean>;
-  enable(): Promise<boolean>;
   addChangedFile(filePath: string): void;
   activateWebviewProviders(): void;
   reportFalsePositive(falsePositive: FalsePositive): Promise<void>;
@@ -69,21 +68,19 @@ export class SnykCodeService extends AnalysisStatusProvider implements ISnykCode
   constructor(
     readonly extensionContext: ExtensionContext,
     private readonly config: IConfiguration,
-    private readonly openerService: IOpenerService,
     private readonly viewManagerService: IViewManagerService,
-    private readonly contextService: IContextService,
     private readonly workspace: IVSCodeWorkspace,
     readonly window: IVSCodeWindow,
     private readonly user: User,
-    private readonly snykApiClient: ISnykApiClient,
     private readonly falsePositiveApi: IFalsePositiveApi,
     private readonly logger: ILog,
     private readonly analytics: IAnalytics,
     readonly languages: IVSCodeLanguages,
     private readonly errorHandler: ISnykCodeErrorHandler,
+    private readonly uriAdapter: IUriAdapter,
   ) {
     super();
-    this.analyzer = new SnykCodeAnalyzer(logger, languages, analytics, errorHandler);
+    this.analyzer = new SnykCodeAnalyzer(logger, languages, analytics, errorHandler, this.uriAdapter);
 
     this.falsePositiveProvider = new FalsePositiveWebviewProvider(this, this.window, extensionContext, this.logger);
     this.suggestionProvider = new CodeSuggestionWebviewProvider(
@@ -224,44 +221,6 @@ export class SnykCodeService extends AnalysisStatusProvider implements ISnykCode
     this.logger.error(`${analysisMessages.failed} ${JSON.stringify(error)}`);
   }
 
-  async checkCodeEnabled(): Promise<boolean> {
-    const enabled = await this.isEnabled();
-
-    await this.contextService.setContext(SNYK_CONTEXT.CODE_ENABLED, enabled);
-
-    return enabled;
-  }
-
-  private async isEnabled(): Promise<boolean> {
-    const settings = await getSastSettings(this.snykApiClient);
-    return settings.sastEnabled;
-  }
-
-  async enable(): Promise<boolean> {
-    let settings = await getSastSettings(this.snykApiClient);
-    if (settings.sastEnabled) {
-      return true;
-    }
-
-    if (this.config.snykCodeUrl != null) {
-      await this.openerService.openBrowserUrl(this.config.snykCodeUrl);
-    }
-
-    // Poll for changed settings (65 sec)
-    for (let i = 2; i < 12; i += 1) {
-      // eslint-disable-next-line no-await-in-loop
-      await this.sleep(i * 1000);
-
-      // eslint-disable-next-line no-await-in-loop
-      settings = await getSastSettings(this.snykApiClient);
-      if (settings.sastEnabled) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
   addChangedFile(filePath: string): void {
     this.changedFiles.add(filePath);
   }
@@ -283,6 +242,4 @@ export class SnykCodeService extends AnalysisStatusProvider implements ISnykCode
     this.progress.removeAllListeners();
     this.analyzer.dispose();
   }
-
-  private sleep = (duration: number) => new Promise(resolve => setTimeout(resolve, duration));
 }

--- a/src/snyk/snykCode/codeService.ts
+++ b/src/snyk/snykCode/codeService.ts
@@ -1,17 +1,12 @@
 import { analyzeFolders, extendAnalysis, FileAnalysis } from '@snyk/code-client';
 import { AnalysisStatusProvider } from '../common/analysis/statusProvider';
 import { IAnalytics, SupportedAnalysisProperties } from '../common/analytics/itly';
-import { ISnykApiClient } from '../common/api/apiСlient';
 import { IConfiguration } from '../common/configuration/configuration';
 import { IDE_NAME } from '../common/constants/general';
-import { SNYK_CONTEXT } from '../common/constants/views';
 import { ErrorHandler } from '../common/error/errorHandler';
 import { ISnykCodeErrorHandler } from '../common/error/snykCodeErrorHandler';
 import { ILog } from '../common/logger/interfaces';
 import { Logger } from '../common/logger/logger';
-import { getSastSettings } from '../common/services/cliConfigService';
-import { IContextService } from '../common/services/contextService';
-import { IOpenerService } from '../common/services/openerService';
 import { IViewManagerService } from '../common/services/viewManagerService';
 import { User } from '../common/user';
 import { IWebViewProvider } from '../common/views/webviewProvider';

--- a/src/snyk/snykCode/codeSettings.ts
+++ b/src/snyk/snykCode/codeSettings.ts
@@ -1,0 +1,62 @@
+import { ISnykApiClient } from '../common/api/apiСlient';
+import { IConfiguration } from '../common/configuration/configuration';
+import { SNYK_CONTEXT } from '../common/constants/views';
+import { getSastSettings, SastSettings } from '../common/services/cliConfigService';
+import { IContextService } from '../common/services/contextService';
+import { IOpenerService } from '../common/services/openerService';
+
+export interface ICodeSettings {
+  checkCodeEnabled(): Promise<boolean>;
+  enable(): Promise<boolean>;
+}
+
+export class CodeSettings implements ICodeSettings {
+  constructor(
+    private readonly snykApiClient: ISnykApiClient,
+    private readonly contextService: IContextService,
+    private readonly config: IConfiguration,
+    private readonly openerService: IOpenerService,
+  ) {}
+
+  async checkCodeEnabled(): Promise<boolean> {
+    const settings = await this.getSastSettings();
+    await this.contextService.setContext(SNYK_CONTEXT.CODE_ENABLED, settings.sastEnabled);
+    await this.contextService.setContext(
+      SNYK_CONTEXT.CODE_LOCAL_ENGINE_ENABLED,
+      settings.localCodeEngine.enabled ?? false,
+    );
+
+    return settings.sastEnabled && !settings.localCodeEngine.enabled;
+  }
+
+  async enable(): Promise<boolean> {
+    let settings = await this.getSastSettings();
+    if (settings.sastEnabled) {
+      return true;
+    }
+
+    if (this.config.snykCodeUrl != null) {
+      await this.openerService.openBrowserUrl(this.config.snykCodeUrl);
+    }
+
+    // Poll for changed settings (65 sec)
+    for (let i = 2; i < 12; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await this.sleep(i * 1000);
+
+      // eslint-disable-next-line no-await-in-loop
+      settings = await this.getSastSettings();
+      if (settings.sastEnabled) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  getSastSettings(): Promise<SastSettings> {
+    return getSastSettings(this.snykApiClient);
+  }
+
+  private sleep = (duration: number) => new Promise(resolve => setTimeout(resolve, duration));
+}

--- a/src/test/unit/common/services/cliConfigService.test.ts
+++ b/src/test/unit/common/services/cliConfigService.test.ts
@@ -25,7 +25,7 @@ suite('CLI Config Service', () => {
     strictEqual(
       getFake.calledWith(sinon.match.any, {
         headers: {
-          'x-snyk-ide': `vsc-${await Configuration.getVersion()}`,
+          'x-snyk-ide': `${Configuration.source}-${await Configuration.getVersion()}`,
         },
       }),
       true,

--- a/src/test/unit/common/services/cliConfigService.test.ts
+++ b/src/test/unit/common/services/cliConfigService.test.ts
@@ -1,0 +1,34 @@
+import { strictEqual } from 'assert';
+import sinon from 'sinon';
+import { ISnykApiClient } from '../../../../snyk/common/api/apiСlient';
+import { Configuration } from '../../../../snyk/common/configuration/configuration';
+import { getSastSettings } from '../../../../snyk/common/services/cliConfigService';
+
+suite('CLI Config Service', () => {
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('IDE header is passed to settings endpoint', async () => {
+    // arrange
+    const getFake = sinon.stub().returns({
+      data: {},
+    });
+    const apiClient: ISnykApiClient = {
+      get: getFake,
+    };
+
+    // act
+    await getSastSettings(apiClient);
+
+    // assert
+    strictEqual(
+      getFake.calledWith(sinon.match.any, {
+        headers: {
+          'x-snyk-ide': `vsc-${await Configuration.getVersion()}`,
+        },
+      }),
+      true,
+    );
+  });
+});

--- a/src/test/unit/snykCode/codeSettings.test.ts
+++ b/src/test/unit/snykCode/codeSettings.test.ts
@@ -1,0 +1,75 @@
+import { strictEqual } from 'assert';
+import sinon, { SinonSpy } from 'sinon';
+import { ISnykApiClient } from '../../../snyk/common/api/apiСlient';
+import { IConfiguration } from '../../../snyk/common/configuration/configuration';
+import { SNYK_CONTEXT } from '../../../snyk/common/constants/views';
+import { IContextService } from '../../../snyk/common/services/contextService';
+import { IOpenerService } from '../../../snyk/common/services/openerService';
+import { CodeSettings, ICodeSettings } from '../../../snyk/snykCode/codeSettings';
+
+suite('Snyk Code Settings', () => {
+  let settings: ICodeSettings;
+  let setContextFake: SinonSpy;
+
+  setup(() => {
+    setContextFake = sinon.fake();
+
+    const contextService: IContextService = {
+      setContext: setContextFake,
+      shouldShowCodeAnalysis: false,
+      shouldShowOssAnalysis: false,
+      viewContext: {},
+    };
+
+    settings = new CodeSettings({} as ISnykApiClient, contextService, {} as IConfiguration, {} as IOpenerService);
+  });
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('Code is disabled when SAST is disabled', async () => {
+    sinon.stub(CodeSettings.prototype, 'getSastSettings').resolves({
+      sastEnabled: false,
+      localCodeEngine: {
+        enabled: false,
+      },
+    });
+
+    const codeEnabled = await settings.checkCodeEnabled();
+
+    strictEqual(codeEnabled, false);
+    strictEqual(setContextFake.calledWith(SNYK_CONTEXT.CODE_ENABLED, false), true);
+    strictEqual(setContextFake.calledWith(SNYK_CONTEXT.CODE_LOCAL_ENGINE_ENABLED, false), true);
+  });
+
+  test('Code is enabled when SAST is enabled and LCE is disabled', async () => {
+    sinon.stub(CodeSettings.prototype, 'getSastSettings').resolves({
+      sastEnabled: true,
+      localCodeEngine: {
+        enabled: false,
+      },
+    });
+
+    const codeEnabled = await settings.checkCodeEnabled();
+
+    strictEqual(codeEnabled, true);
+    strictEqual(setContextFake.calledWith(SNYK_CONTEXT.CODE_ENABLED, true), true);
+    strictEqual(setContextFake.calledWith(SNYK_CONTEXT.CODE_LOCAL_ENGINE_ENABLED, false), true);
+  });
+
+  test('Code is disabled when LCE is enabled', async () => {
+    sinon.stub(CodeSettings.prototype, 'getSastSettings').resolves({
+      sastEnabled: true,
+      localCodeEngine: {
+        enabled: true,
+      },
+    });
+
+    const codeEnabled = await settings.checkCodeEnabled();
+
+    strictEqual(codeEnabled, false);
+    strictEqual(setContextFake.calledWith(SNYK_CONTEXT.CODE_ENABLED, true), true);
+    strictEqual(setContextFake.calledWith(SNYK_CONTEXT.CODE_LOCAL_ENGINE_ENABLED, true), true);
+  });
+});


### PR DESCRIPTION
I've started making `src/snyk/snykCode/analyzer/analyzer.ts` unit-testable but then realised it's not only analyzer that needs to invert dependencies but also quite some other classes `codeService.ts` depends on, thus extracted SAST enablement logic in a separate class instead. I've preserved changes to `analyzer.ts` since it's another small step forward to allow unit testing for `codeService.ts`.


<img width="396" alt="Screenshot 2022-02-15 at 17 33 41" src="https://user-images.githubusercontent.com/2239563/154106243-fbdad165-8f81-4abb-ad94-c8cf8e2a0483.png">
