### PR TITLE
fix: prepublish step with missing CSS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -341,7 +341,7 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "tsc -p ./",
+    "vscode:prepublish": "tsc -p ./ && sass media --no-source-map",
     "build": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "watch-resources": "sass media --no-source-map --watch",


### PR DESCRIPTION
CSS files are not published in Preview version currently. This PR addresses this issue.

[Bug reported](https://snyk.slack.com/archives/C01FA88CUU9/p1645093151116409?thread_ts=1645021672.367459&cid=C01FA88CUU9)