### PR TITLE
fix: Failed to get remote bundle reports from Snyk Code [ROAD-683]

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,11 +236,6 @@
     "viewsWelcome": [
       {
         "view": "snyk.views.welcome",
-        "contents": "Snyk is temporarily unavailable\nWe are automatically retrying to connect...",
-        "when": "snyk:error == 'transient'"
-      },
-      {
-        "view": "snyk.views.welcome",
         "contents": "Snyk has encountered a problem. Please restart the extension: \n[Restart](command:snyk.start 'Restart Snyk')\nIf the error persists, please check your [settings](command:snyk.settings) and [contact us](https://snyk.io/contact-us/?utm_source=vsc)!",
         "when": "snyk:error == 'blocking'"
       },

--- a/src/snyk/base/modules/baseSnykModule.ts
+++ b/src/snyk/base/modules/baseSnykModule.ts
@@ -3,7 +3,7 @@ import { IAnalytics } from '../../common/analytics/itly';
 import { ISnykApiClient, SnykApiClient } from '../../common/api/apiСlient';
 import { CommandController } from '../../common/commands/commandController';
 import { configuration } from '../../common/configuration/instance';
-import { ISnykCodeErrorHandler, SnykCodeErrorHandler } from '../../common/error/snykCodeErrorHandler';
+import { ISnykCodeErrorHandler, SnykCodeErrorHandler } from '../../snykCode/error/snykCodeErrorHandler';
 import { ExperimentService } from '../../common/experiment/services/experimentService';
 import { Logger } from '../../common/logger/logger';
 import { ContextService, IContextService } from '../../common/services/contextService';
@@ -66,7 +66,7 @@ export default abstract class BaseSnykModule implements IBaseSnykModule {
     this.loadingBadge = new LoadingBadge();
     this.snykApiClient = new SnykApiClient(configuration);
     this.falsePositiveApi = new FalsePositiveApi(configuration);
-    this.snykCodeErrorHandler = new SnykCodeErrorHandler(this.contextService, this.loadingBadge, Logger, this);
+    this.snykCodeErrorHandler = new SnykCodeErrorHandler(this.contextService, this.loadingBadge, Logger, this, configuration);
     this.codeSettings = new CodeSettings(this.snykApiClient, this.contextService, configuration, this.openerService);
   }
 

--- a/src/snyk/base/modules/interfaces.ts
+++ b/src/snyk/base/modules/interfaces.ts
@@ -1,8 +1,8 @@
-import * as vscode from 'vscode';
 import { IContextService } from '../../common/services/contextService';
 import { IOpenerService } from '../../common/services/openerService';
 import { IViewManagerService } from '../../common/services/viewManagerService';
 import { ExtensionContext } from '../../common/vscode/extensionContext';
+import { ExtensionContext as VSCodeExtensionContext } from '../../common/vscode/types';
 import { ISnykCodeService } from '../../snykCode/codeService';
 import { IStatusBarItem } from '../statusBarItem/statusBarItem';
 import { ILoadingBadge } from '../views/loadingBadge';
@@ -28,7 +28,7 @@ export interface ISnykLib {
 
 export interface IExtension extends IBaseSnykModule, ISnykLib {
   context: ExtensionContext | undefined;
-  activate(context: vscode.ExtensionContext): void;
+  activate(context: VSCodeExtensionContext): void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/snyk/base/services/authenticationService.ts
+++ b/src/snyk/base/services/authenticationService.ts
@@ -2,7 +2,7 @@ import { checkSession, getIpFamily as getNetworkFamily, IpFamily, startSession }
 import { IAnalytics } from '../../common/analytics/itly';
 import { IConfiguration } from '../../common/configuration/configuration';
 import { SNYK_CONTEXT } from '../../common/constants/views';
-import { ISnykCodeErrorHandler } from '../../common/error/snykCodeErrorHandler';
+import { ISnykCodeErrorHandler } from '../../snykCode/error/snykCodeErrorHandler';
 import { ILog } from '../../common/logger/interfaces';
 import { IContextService } from '../../common/services/contextService';
 import { IOpenerService } from '../../common/services/openerService';

--- a/src/snyk/common/constants/views.ts
+++ b/src/snyk/common/constants/views.ts
@@ -26,7 +26,6 @@ export const SNYK_CONTEXT = {
 };
 
 export const SNYK_ERROR_CODES = {
-  TRANSIENT: 'transient',
   BLOCKING: 'blocking',
 };
 

--- a/src/snyk/common/error/errorHandler.ts
+++ b/src/snyk/common/error/errorHandler.ts
@@ -27,7 +27,8 @@ export class ErrorHandler {
    * Should be used to log locally and report error event remotely.
    */
   static handle(error: Error, logger: ILog, message?: string): void {
-    logger.error(message ? `${message} ${error}` : error.toString());
+    const errorStr = JSON.stringify(error, Object.getOwnPropertyNames(error));
+    logger.error(message ? `${message}. ${errorStr}` : errorStr);
     ErrorReporter.capture(error);
   }
 }

--- a/src/snyk/common/messages/errors.ts
+++ b/src/snyk/common/messages/errors.ts
@@ -5,7 +5,6 @@ export const errorsLogs = {
   failedAnalysis: 'Failed executing analysis',
   failedExecution: 'Failed extension pipeline execution',
   failedExecutionDebounce: 'Failed extension pipeline execution after debounce',
-  failedExecutionTransient: 'Failed extension pipeline execution after transient error',
   undefinedError: 'Unrecognized error',
   watchFileBeforeExtendBundle: 'Failed on watching file changes before extending bundle',
   updateReviewPositions: 'Failed to update review results positions while editing file',

--- a/src/snyk/common/vscode/types.ts
+++ b/src/snyk/common/vscode/types.ts
@@ -27,3 +27,4 @@ export type DecorationOptions = vscode.DecorationOptions;
 export type ThemeColor = vscode.ThemeColor;
 export type ThemableDecorationInstanceRenderOptions = vscode.ThemableDecorationInstanceRenderOptions;
 export type CodeActionProviderMetadata = vscode.CodeActionProviderMetadata;
+export type ExtensionContext = vscode.ExtensionContext;

--- a/src/snyk/snykCode/analyzer/analyzer.ts
+++ b/src/snyk/snykCode/analyzer/analyzer.ts
@@ -1,7 +1,7 @@
 import { AnalysisResultLegacy, FilePath, FileSuggestion } from '@snyk/code-client';
 import { IExtension } from '../../base/modules/interfaces';
 import { IAnalytics } from '../../common/analytics/itly';
-import { ISnykCodeErrorHandler } from '../../common/error/snykCodeErrorHandler';
+import { ISnykCodeErrorHandler } from '../error/snykCodeErrorHandler';
 import { ILog } from '../../common/logger/interfaces';
 import { errorsLogs } from '../../common/messages/errors';
 import { HoverAdapter } from '../../common/vscode/hover';

--- a/src/snyk/snykCode/messages/analysis.ts
+++ b/src/snyk/snykCode/messages/analysis.ts
@@ -2,4 +2,6 @@ export const messages = {
   started: 'Code analysis started.',
   finished: 'Code analysis finished.',
   failed: 'Code analysis failed.',
+  temporaryFailed: 'Snyk Code is temporarily unavailable.',
+  retry: 'We are automatically retrying to connect...'
 };

--- a/src/snyk/snykCode/views/issueTreeProvider.ts
+++ b/src/snyk/snykCode/views/issueTreeProvider.ts
@@ -7,6 +7,7 @@ import { AnalysisTreeNodeProvder } from '../../common/views/analysisTreeNodeProv
 import { INodeIcon, NODE_ICONS, TreeNode } from '../../common/views/treeNode';
 import { ISnykCodeService } from '../codeService';
 import { SNYK_SEVERITIES } from '../constants/analysis';
+import { messages } from '../messages/analysis';
 import { getSnykSeverity } from '../utils/analysisUtils';
 import { CodeIssueCommandArg } from './interfaces';
 
@@ -46,7 +47,9 @@ export class IssueTreeProvider extends AnalysisTreeNodeProvder {
     let nIssues = 0;
     if (!this.contextService.shouldShowCodeAnalysis) return review;
 
-    if (this.snykCode.hasError) {
+    if (this.snykCode.hasTransientError) {
+      return this.getTransientErrorTreeNodes();
+    } else if (this.snykCode.hasError) {
       return [this.getErrorEncounteredTreeNode()];
     }
 
@@ -170,5 +173,22 @@ export class IssueTreeProvider extends AnalysisTreeNodeProvder {
     });
 
     return [nodes, severityCounts];
+  }
+
+  private getTransientErrorTreeNodes(): TreeNode[] {
+    return [
+      new TreeNode({
+        text: messages.temporaryFailed,
+        internal: {
+          isError: true,
+        },
+      }),
+      new TreeNode({
+        text: messages.retry,
+        internal: {
+          isError: true,
+        },
+      }),
+    ];
   }
 }

--- a/src/test/unit/base/services/authenticationService.test.ts
+++ b/src/test/unit/base/services/authenticationService.test.ts
@@ -7,7 +7,7 @@ import { IBaseSnykModule } from '../../../../snyk/base/modules/interfaces';
 import { AuthenticationService } from '../../../../snyk/base/services/authenticationService';
 import { IAnalytics } from '../../../../snyk/common/analytics/itly';
 import { IConfiguration } from '../../../../snyk/common/configuration/configuration';
-import { ISnykCodeErrorHandler } from '../../../../snyk/common/error/snykCodeErrorHandler';
+import { ISnykCodeErrorHandler } from '../../../../snyk/snykCode/error/snykCodeErrorHandler';
 import { IContextService } from '../../../../snyk/common/services/contextService';
 import { IOpenerService } from '../../../../snyk/common/services/openerService';
 import { LoggerMock } from '../../mocks/logger.mock';

--- a/src/test/unit/snykCode/error/snykCodeErrorHandler.test.ts
+++ b/src/test/unit/snykCode/error/snykCodeErrorHandler.test.ts
@@ -1,0 +1,45 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { strictEqual } from 'assert';
+import sinon from 'sinon';
+import { IBaseSnykModule } from '../../../../snyk/base/modules/interfaces';
+import { ILoadingBadge } from '../../../../snyk/base/views/loadingBadge';
+import { IConfiguration } from '../../../../snyk/common/configuration/configuration';
+import { CONNECTION_ERROR_RETRY_INTERVAL } from '../../../../snyk/common/constants/general';
+import { IContextService } from '../../../../snyk/common/services/contextService';
+import { SnykCodeErrorHandler } from '../../../../snyk/snykCode/error/snykCodeErrorHandler';
+import { LoggerMock } from '../../mocks/logger.mock';
+
+suite('Snyk Code Error Handler', () => {
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('Retries scan if "Failed to get remote bundle" is processed', async function () {
+    // arrange
+    this.timeout(CONNECTION_ERROR_RETRY_INTERVAL + 2000);
+
+    const runCodeScanFake = sinon.stub().resolves();
+    const baseSnykModule = ({
+      runCodeScan: runCodeScanFake,
+    } as unknown) as IBaseSnykModule;
+    const handler = new SnykCodeErrorHandler(
+      {} as IContextService,
+      {} as ILoadingBadge,
+      new LoggerMock(),
+      baseSnykModule,
+      {} as IConfiguration,
+    );
+    const error = new Error('Failed to get remote bundle');
+
+    // act
+    await handler.processError(error, undefined, () => null);
+
+    // assert
+    return new Promise((resolve, _) => {
+      setTimeout(() => {
+        strictEqual(runCodeScanFake.called, true);
+        resolve();
+      }, CONNECTION_ERROR_RETRY_INTERVAL);
+    });
+  });
+});


### PR DESCRIPTION
- I've wired existing retry strategy for transient errors.
- I've also replaced the general transient view with specific tree node in "Code Security & Quality" view. The old "general" view was there since Snyk acquired Deepcode and is not relevant any more, since Snyk Code is one of multiple product integrations nowadays.
- Fixed log message in the output channel to have enough verbosity and not report empty objects `{}`

<img width="475" alt="Screenshot 2022-02-18 at 17 25 35" src="https://user-images.githubusercontent.com/2239563/154722401-8ded2927-caa8-438d-954f-090cdd64ac6f.png">
<img width="1309" alt="Screenshot 2022-02-18 at 17 27 36" src="https://user-images.githubusercontent.com/2239563/154722851-cc3ff92c-a5de-4e59-87b1-dbca775846e8.png">
 