### PR TITLE
fix: potential webview state deserialization [ROAD-605]

### DIFF
--- a/src/snyk/common/views/webviewPanelSerializer.ts
+++ b/src/snyk/common/views/webviewPanelSerializer.ts
@@ -9,7 +9,11 @@ export class WebviewPanelSerializer<Provider extends WebviewProvider<State>, Sta
       return Promise.resolve();
     }
 
+    // Reset the webview options so we use latest uri for `localResourceRoots`.
+    webviewPanel.webview.options = this.provider.getWebviewOptions();
+
     this.provider.restorePanel(webviewPanel);
+
     return this.provider.showPanel(state);
   }
 }

--- a/src/snyk/common/views/webviewProvider.ts
+++ b/src/snyk/common/views/webviewProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ILog } from '../logger/interfaces';
 import { Logger } from '../logger/logger';
 import { ExtensionContext } from '../vscode/extensionContext';
-import { Uri, WebviewOptions } from '../vscode/types';
+import { WebviewOptions } from '../vscode/types';
 
 export interface IWebViewProvider<ViewModel> {
   activate(): void;

--- a/src/snyk/common/views/webviewProvider.ts
+++ b/src/snyk/common/views/webviewProvider.ts
@@ -2,11 +2,13 @@ import * as vscode from 'vscode';
 import { ILog } from '../logger/interfaces';
 import { Logger } from '../logger/logger';
 import { ExtensionContext } from '../vscode/extensionContext';
+import { Uri, WebviewOptions } from '../vscode/types';
 
 export interface IWebViewProvider<ViewModel> {
   activate(): void;
   disposePanel(): void;
   showPanel(suggestion: ViewModel, ...args: unknown[]): Promise<void>;
+  getWebviewOptions(): WebviewOptions;
 }
 
 export abstract class WebviewProvider<ViewModel> implements IWebViewProvider<ViewModel> {
@@ -31,6 +33,13 @@ export abstract class WebviewProvider<ViewModel> implements IWebViewProvider<Vie
     // workaround for: https://github.com/microsoft/vscode/issues/71608
     // when resolved, we can set showPanel back to sync execution.
     await vscode.commands.executeCommand('workbench.action.focusSecondEditorGroup');
+  }
+
+  getWebviewOptions(): WebviewOptions {
+    return {
+      localResourceRoots: [this.context.getExtensionUri()],
+      enableScripts: true,
+    };
   }
 
   disposePanel(): void {

--- a/src/snyk/common/vscode/types.ts
+++ b/src/snyk/common/vscode/types.ts
@@ -28,3 +28,4 @@ export type ThemeColor = vscode.ThemeColor;
 export type ThemableDecorationInstanceRenderOptions = vscode.ThemableDecorationInstanceRenderOptions;
 export type CodeActionProviderMetadata = vscode.CodeActionProviderMetadata;
 export type ExtensionContext = vscode.ExtensionContext;
+export type WebviewOptions = vscode.WebviewOptions;

--- a/src/snyk/snykCode/views/falsePositive/falsePositiveWebviewProvider.ts
+++ b/src/snyk/snykCode/views/falsePositive/falsePositiveWebviewProvider.ts
@@ -64,10 +64,7 @@ export class FalsePositiveWebviewProvider extends WebviewProvider<FalsePositiveW
             viewColumn: vscode.ViewColumn.One,
             preserveFocus: true,
           },
-          {
-            enableScripts: true,
-            localResourceRoots: [this.context.getExtensionUri()],
-          },
+          this.getWebviewOptions(),
         );
       }
 

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
@@ -76,10 +76,7 @@ export class CodeSuggestionWebviewProvider
             viewColumn: vscode.ViewColumn.Two,
             preserveFocus: true,
           },
-          {
-            localResourceRoots: [this.context.getExtensionUri()],
-            enableScripts: true,
-          },
+          this.getWebviewOptions(),
         );
       }
 

--- a/src/snyk/snykOss/views/suggestion/ossSuggestionWebviewProvider.ts
+++ b/src/snyk/snykOss/views/suggestion/ossSuggestionWebviewProvider.ts
@@ -5,7 +5,7 @@ import { ErrorHandler } from '../../../common/error/errorHandler';
 import { ILog } from '../../../common/logger/interfaces';
 import { getNonce } from '../../../common/views/nonce';
 import { WebviewPanelSerializer } from '../../../common/views/webviewPanelSerializer';
-import { IWebViewProvider, WebviewProvider } from '../../../common/views/webviewProvider';
+import { WebviewProvider } from '../../../common/views/webviewProvider';
 import { ExtensionContext } from '../../../common/vscode/extensionContext';
 import { IVSCodeWindow } from '../../../common/vscode/window';
 import { messages as errorMessages } from '../../messages/error';
@@ -49,10 +49,7 @@ export class OssSuggestionWebviewProvider extends WebviewProvider<OssIssueComman
             viewColumn: vscode.ViewColumn.Two,
             preserveFocus: true,
           },
-          {
-            enableScripts: true,
-            localResourceRoots: [this.context.getExtensionUri()],
-          },
+          this.getWebviewOptions(),
         );
       }
 


### PR DESCRIPTION
I've noticed that some people are still getting empty webview without JS and images loaded even after https://github.com/snyk/vscode-extension/pull/151. Did get this issue myself again.

It seems this could stem from [this issue](https://github.com/microsoft/vscode/issues/114659). I've applied the same fix as [in PR](https://github.com/microsoft/vscode-extension-samples/pull/376) for the sample webview code in `vscode-samples` repo. Hope this resolves the issue forever.

cc @deepcodeg 