### PR TITLE
fix: remove the duration from analysis tree [ROAD-312]

### DIFF
--- a/src/snyk/common/messages/analysisMessages.ts
+++ b/src/snyk/common/messages/analysisMessages.ts
@@ -2,6 +2,5 @@ export const messages = {
   scanFailed: 'Scan failed',
   clickToProblem: 'Click here to see the problem.',
   allSeverityFiltersDisabled: 'Please enable severity filters to see the results.',
-  duration: (sDuration: number, time: string, day: string): string =>
-    `Analysis took ${sDuration}s, finished at ${time}, ${day}`,
+  duration: (time: string, day: string): string => `Analysis finished at ${time}, ${day}`,
 };

--- a/src/snyk/common/views/analysisTreeNodeProvider.ts
+++ b/src/snyk/common/views/analysisTreeNodeProvider.ts
@@ -37,13 +37,12 @@ export abstract class AnalysisTreeNodeProvder extends TreeNodeProvider {
   };
 
   protected getDurationTreeNode(): TreeNode {
-    const sDuration = Math.round((this.statusProvider.lastAnalysisDuration / 1000 + Number.EPSILON) * 100) / 100;
     const ts = new Date(this.statusProvider.lastAnalysisTimestamp);
     const time = ts.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     const day = ts.toLocaleDateString([], { year: '2-digit', month: '2-digit', day: '2-digit' });
 
     return new TreeNode({
-      text: messages.duration(sDuration, time, day),
+      text: messages.duration(time, day),
     });
   }
 


### PR DESCRIPTION
Removing the time stat from the analysis tree and just simply displaying the date and time the analysis finished at.

Changed from `Analysis took <duration>, finished at <time>,<date>` to `Analysis finished at <time>,<date>`.