### PR TITLE
fix: respect proxy environments [ROAD-722]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,10 @@
         "analytics-node": "^4.0.1",
         "axios": "^0.21.1",
         "glob": "^7.2.0",
+        "global-agent": "^3.0.0",
         "htmlparser2": "^7.2.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
         "lodash": "^4.17.21",
         "marked": "^3.0.2",
         "open": "^7.4.2",
@@ -37,6 +40,7 @@
         "@types/babel__traverse": "^7.12.2",
         "@types/find-package-json": "^1.2.2",
         "@types/glob": "^7.1.3",
+        "@types/global-agent": "^2.1.1",
         "@types/lodash": "^4.14.161",
         "@types/marked": "^3.0.0",
         "@types/mocha": "^8.0.3",
@@ -1518,12 +1522,11 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/@types/analytics-node": {
@@ -1569,6 +1572,12 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/global-agent": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/global-agent/-/global-agent-2.1.1.tgz",
+      "integrity": "sha512-sVox8Phk1UKgP6LQPAdeRxfww6vHKt7Bf59dXzYLsQBUEMEn8S10a+ESp/yO0i4fJ3WS4+CIuz42hgJcuA+3mA==",
+      "dev": true
     },
     "node_modules/@types/inquirer": {
       "version": "7.3.1",
@@ -2274,6 +2283,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -3000,7 +3014,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "dependencies": {
         "object-keys": "^1.0.12"
       },
@@ -3040,6 +3053,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/diff": {
       "version": "5.0.0",
@@ -3280,6 +3298,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -4152,6 +4175,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
     "node_modules/globals": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.7.0.tgz",
@@ -4177,6 +4216,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
+      "integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/globby": {
@@ -4379,12 +4432,11 @@
       }
     },
     "node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "dependencies": {
-        "@tootallnate/once": "1",
+        "@tootallnate/once": "2",
         "agent-base": "6",
         "debug": "4"
       },
@@ -4892,6 +4944,11 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
     "node_modules/json5": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -5081,7 +5138,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5122,6 +5178,28 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/matcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/md5": {
@@ -5650,7 +5728,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6628,6 +6705,27 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/roarr/node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -6723,7 +6821,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -6733,6 +6830,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "node_modules/send": {
       "version": "0.17.2",
@@ -6787,6 +6889,31 @@
       "dependencies": {
         "body-parser": "^1.19.0",
         "express": "^4.17.1"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serialize-javascript": {
@@ -7594,6 +7721,29 @@
         "node": ">=8.9.3"
       }
     },
+    "node_modules/vscode-test/node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/vscode-test/node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/vue-parser": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/vue-parser/-/vue-parser-1.1.6.tgz",
@@ -7833,8 +7983,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -9086,10 +9235,9 @@
       }
     },
     "@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
     },
     "@types/analytics-node": {
       "version": "3.1.4",
@@ -9134,6 +9282,12 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "@types/global-agent": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/global-agent/-/global-agent-2.1.1.tgz",
+      "integrity": "sha512-sVox8Phk1UKgP6LQPAdeRxfww6vHKt7Bf59dXzYLsQBUEMEn8S10a+ESp/yO0i4fJ3WS4+CIuz42hgJcuA+3mA==",
+      "dev": true
     },
     "@types/inquirer": {
       "version": "7.3.1",
@@ -9675,6 +9829,11 @@
           "dev": true
         }
       }
+    },
+    "boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -10232,7 +10391,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -10260,6 +10418,11 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
       "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
       "dev": true
+    },
+    "detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "diff": {
       "version": "5.0.0",
@@ -10439,6 +10602,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
     },
     "escalade": {
       "version": "3.1.1",
@@ -11121,6 +11289,19 @@
         "is-glob": "^4.0.1"
       }
     },
+    "global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "requires": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      }
+    },
     "globals": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.7.0.tgz",
@@ -11136,6 +11317,14 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
+      }
+    },
+    "globalthis": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
+      "integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
+      "requires": {
+        "define-properties": "^1.1.3"
       }
     },
     "globby": {
@@ -11287,12 +11476,11 @@
       }
     },
     "http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "requires": {
-        "@tootallnate/once": "1",
+        "@tootallnate/once": "2",
         "agent-base": "6",
         "debug": "4"
       }
@@ -11658,6 +11846,11 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
     "json5": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -11826,7 +12019,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -11852,6 +12044,21 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.2.tgz",
       "integrity": "sha512-TMJQQ79Z0e3rJYazY0tIoMsFzteUGw9fB3FD+gzuIT3zLuG9L9ckIvUfF51apdJkcqc208jJN2KbtPbOvXtbjA=="
+    },
+    "matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "requires": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
+      }
     },
     "md5": {
       "version": "2.3.0",
@@ -12247,8 +12454,7 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-treeify": {
       "version": "1.1.33",
@@ -12977,6 +13183,26 @@
         "glob": "^7.1.3"
       }
     },
+    "roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "requires": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+        }
+      }
+    },
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -13037,10 +13263,14 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "send": {
       "version": "0.17.2",
@@ -13096,6 +13326,21 @@
       "requires": {
         "body-parser": "^1.19.0",
         "express": "^4.17.1"
+      }
+    },
+    "serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "requires": {
+        "type-fest": "^0.13.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
+        }
       }
     },
     "serialize-javascript": {
@@ -13747,6 +13992,25 @@
         "https-proxy-agent": "^5.0.0",
         "rimraf": "^3.0.2",
         "unzipper": "^0.10.11"
+      },
+      "dependencies": {
+        "@tootallnate/once": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+          "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+          "dev": true
+        },
+        "http-proxy-agent": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+          "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+          "dev": true,
+          "requires": {
+            "@tootallnate/once": "1",
+            "agent-base": "6",
+            "debug": "4"
+          }
+        }
       }
     },
     "vue-parser": {
@@ -13937,8 +14201,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -377,6 +377,7 @@
     "@types/vscode": "^1.48.0",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",
+    "concurrently": "^7.0.0",
     "eslint": "^7.8.1",
     "eslint-config-prettier": "^6.11.0",
     "eslint-import-resolver-typescript": "^2.4.0",
@@ -389,8 +390,7 @@
     "sinon": "^11.1.1",
     "typescript": "^4.3.4",
     "vscode-test": "^1.4.0",
-    "yalc": "^1.0.0-pre.44",
-    "concurrently": "^7.0.0"
+    "yalc": "^1.0.0-pre.44"
   },
   "dependencies": {
     "@amplitude/experiment-node-server": "^1.0.2",
@@ -408,6 +408,8 @@
     "axios": "^0.21.1",
     "glob": "^7.2.0",
     "htmlparser2": "^7.2.0",
+    "http-proxy-agent": "^5.0.0",
+    "https-proxy-agent": "^5.0.0",
     "lodash": "^4.17.21",
     "marked": "^3.0.2",
     "open": "^7.4.2",

--- a/src/snyk/base/modules/baseSnykModule.ts
+++ b/src/snyk/base/modules/baseSnykModule.ts
@@ -24,6 +24,7 @@ import { ScanModeService } from '../services/scanModeService';
 import SnykStatusBarItem, { IStatusBarItem } from '../statusBarItem/statusBarItem';
 import { ILoadingBadge, LoadingBadge } from '../views/loadingBadge';
 import { IBaseSnykModule } from './interfaces';
+import { vsCodeWorkspace } from '../../common/vscode/workspace';
 
 export default abstract class BaseSnykModule implements IBaseSnykModule {
   context: ExtensionContext;
@@ -64,8 +65,8 @@ export default abstract class BaseSnykModule implements IBaseSnykModule {
     this.openerService = new OpenerService();
     this.scanModeService = new ScanModeService(this.contextService, configuration);
     this.loadingBadge = new LoadingBadge();
-    this.snykApiClient = new SnykApiClient(configuration);
-    this.falsePositiveApi = new FalsePositiveApi(configuration);
+    this.snykApiClient = new SnykApiClient(configuration, vsCodeWorkspace);
+    this.falsePositiveApi = new FalsePositiveApi(configuration, vsCodeWorkspace);
     this.snykCodeErrorHandler = new SnykCodeErrorHandler(this.contextService, this.loadingBadge, Logger, this, configuration);
     this.codeSettings = new CodeSettings(this.snykApiClient, this.contextService, configuration, this.openerService);
   }

--- a/src/snyk/cli/services/cliService.ts
+++ b/src/snyk/cli/services/cliService.ts
@@ -69,7 +69,7 @@ export abstract class CliService<CliResult> extends AnalysisStatusProvider {
       throw new Error('No workspace was opened.');
     }
 
-    this.cliProcess = new CliProcess(this.logger, this.config);
+    this.cliProcess = new CliProcess(this.logger, this.config, this.workspace);
     const args = this.buildArguments(foldersToTest);
 
     let output: string;

--- a/src/snyk/common/api/apiСlient.ts
+++ b/src/snyk/common/api/apiСlient.ts
@@ -1,5 +1,7 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { IConfiguration } from '../configuration/configuration';
+import { getAxiosProxyConfig } from '../proxy';
+import { IVSCodeWorkspace } from '../vscode/workspace';
 import { DEFAULT_API_HEADERS } from './headers';
 
 export interface ISnykApiClient {
@@ -9,7 +11,7 @@ export interface ISnykApiClient {
 export class SnykApiClient implements ISnykApiClient {
   private instance: AxiosInstance | null = null;
 
-  constructor(private readonly configuration: IConfiguration) {}
+  constructor(private readonly configuration: IConfiguration, private readonly workspace: IVSCodeWorkspace) {}
 
   private get http(): AxiosInstance {
     return this.instance != null ? this.instance : this.initHttp();
@@ -19,6 +21,7 @@ export class SnykApiClient implements ISnykApiClient {
     const http = axios.create({
       headers: DEFAULT_API_HEADERS,
       responseType: 'json',
+      ...getAxiosProxyConfig(this.workspace),
     });
 
     http.interceptors.response.use(

--- a/src/snyk/common/proxy.ts
+++ b/src/snyk/common/proxy.ts
@@ -1,0 +1,45 @@
+import { AxiosRequestConfig } from 'axios';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import * as url from 'url';
+import { IVSCodeWorkspace } from './vscode/workspace';
+
+export function getHttpsProxyAgent(
+  workspace: IVSCodeWorkspace,
+  processEnv: NodeJS.ProcessEnv = process.env,
+): HttpsProxyAgent | undefined {
+  let proxy: string | undefined = getVsCodeProxy(workspace);
+  if (!proxy) {
+    proxy = processEnv.HTTPS_PROXY || processEnv.https_proxy || processEnv.HTTP_PROXY || processEnv.http_proxy;
+    if (!proxy) {
+      return undefined; // No proxy
+    }
+  }
+
+  // Basic sanity checking on proxy url
+  const proxyUrl = url.parse(proxy);
+  if (proxyUrl.protocol !== 'https:' && proxyUrl.protocol !== 'http:') {
+    return undefined;
+  }
+
+  const strictProxy = workspace.getConfiguration<boolean>('http', 'proxyStrictSSL') ?? true;
+  const proxyOptions = {
+    host: proxyUrl.hostname,
+    port: proxyUrl.port ? parseInt(proxyUrl.port, 10) : null,
+    auth: proxyUrl.auth,
+    rejectUnauthorized: strictProxy,
+  };
+
+  return new HttpsProxyAgent(proxyOptions);
+}
+
+export function getVsCodeProxy(workspace: IVSCodeWorkspace): string | undefined {
+  return workspace.getConfiguration<string>('http', 'proxy');
+}
+
+export function getAxiosProxyConfig(workspace: IVSCodeWorkspace): AxiosRequestConfig {
+  return {
+    proxy: false,
+    httpAgent: getHttpsProxyAgent(workspace),
+    httpsAgent: getHttpsProxyAgent(workspace),
+  };
+}

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -56,6 +56,7 @@ import { IgnoreCommand } from './snykCode/codeActions/ignoreCommand';
 import { SnykCodeService } from './snykCode/codeService';
 import { CodeQualityIssueTreeProvider } from './snykCode/views/qualityIssueTreeProvider';
 import { CodeSecurityIssueTreeProvider } from './snykCode/views/securityIssueTreeProvider';
+import { NpmTestApi } from './snykOss/api/npmTestApi';
 import { EditorDecorator } from './snykOss/editor/editorDecorator';
 import { OssService } from './snykOss/services/ossService';
 import { NpmModuleInfoFetchService } from './snykOss/services/vulnerabilityCount/npmModuleInfoFetchService';
@@ -126,7 +127,12 @@ class SnykExtension extends SnykLib implements IExtension {
       new UriAdapter(),
     );
 
-    this.cliDownloadService = new CliDownloadService(this.context, new StaticCliApi(), vsCodeWindow, Logger);
+    this.cliDownloadService = new CliDownloadService(
+      this.context,
+      new StaticCliApi(vsCodeWorkspace),
+      vsCodeWindow,
+      Logger,
+    );
     this.ossService = new OssService(
       this.context,
       Logger,
@@ -233,7 +239,11 @@ class SnykExtension extends SnykLib implements IExtension {
 
     this.initCliDownload();
 
-    const npmModuleInfoFetchService = new NpmModuleInfoFetchService(configuration, Logger);
+    const npmModuleInfoFetchService = new NpmModuleInfoFetchService(
+      configuration,
+      Logger,
+      new NpmTestApi(Logger, vsCodeWorkspace),
+    );
     this.ossVulnerabilityCountService = new OssVulnerabilityCountService(
       vsCodeWorkspace,
       vsCodeWindow,

--- a/src/snyk/snykCode/codeService.ts
+++ b/src/snyk/snykCode/codeService.ts
@@ -4,7 +4,6 @@ import { IAnalytics, SupportedAnalysisProperties } from '../common/analytics/itl
 import { FeaturesConfiguration, IConfiguration } from '../common/configuration/configuration';
 import { IDE_NAME } from '../common/constants/general';
 import { ErrorHandler } from '../common/error/errorHandler';
-import { ISnykCodeErrorHandler } from './error/snykCodeErrorHandler';
 import { ILog } from '../common/logger/interfaces';
 import { Logger } from '../common/logger/logger';
 import { IViewManagerService } from '../common/services/viewManagerService';
@@ -18,6 +17,7 @@ import { IVSCodeWindow } from '../common/vscode/window';
 import { IVSCodeWorkspace } from '../common/vscode/workspace';
 import SnykCodeAnalyzer from './analyzer/analyzer';
 import { Progress } from './analyzer/progress';
+import { ISnykCodeErrorHandler } from './error/snykCodeErrorHandler';
 import { IFalsePositiveApi } from './falsePositive/api/falsePositiveApi';
 import { FalsePositive } from './falsePositive/falsePositive';
 import { ISnykCodeAnalyzer } from './interfaces';

--- a/src/snyk/snykOss/api/npmTestApi.ts
+++ b/src/snyk/snykOss/api/npmTestApi.ts
@@ -2,22 +2,24 @@ import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { DEFAULT_API_HEADERS } from '../../common/api/headers';
 import { configuration } from '../../common/configuration/instance';
 import { ILog } from '../../common/logger/interfaces';
-import { Logger } from '../../common/logger/logger';
+import { getAxiosProxyConfig } from '../../common/proxy';
+import { IVSCodeWorkspace } from '../../common/vscode/workspace';
 
-class NpmTestApi {
+export class NpmTestApi {
   private instance: AxiosInstance | null = null;
 
-  constructor(private readonly logger: ILog) {}
+  constructor(private readonly logger: ILog, private readonly workspace: IVSCodeWorkspace) {}
 
   private get http(): AxiosInstance {
     return this.instance != null ? this.instance : this.initHttp();
   }
 
-  initHttp() {
+  initHttp(): AxiosInstance {
     const http = axios.create({
       headers: DEFAULT_API_HEADERS,
       responseType: 'json',
       baseURL: configuration.authHost + '/test',
+      ...getAxiosProxyConfig(this.workspace),
     });
 
     http.interceptors.response.use(
@@ -36,5 +38,3 @@ class NpmTestApi {
     return this.http.get<T, R>(url, config);
   }
 }
-
-export const npmTestApi = new NpmTestApi(Logger);

--- a/src/snyk/snykOss/services/vulnerabilityCount/npmModuleInfoFetchService.ts
+++ b/src/snyk/snykOss/services/vulnerabilityCount/npmModuleInfoFetchService.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { IConfiguration } from '../../../common/configuration/configuration';
 import { ILog } from '../../../common/logger/interfaces';
-import { npmTestApi } from '../../api/npmTestApi';
+import { NpmTestApi } from '../../api/npmTestApi';
 import { ImportedModule, TestedImportedModule } from './importedModule';
 
 export type NpmRegistryPackage = {
@@ -25,7 +25,7 @@ export class NpmModuleInfoFetchService {
   private npmPackageCache = new Map<string, NpmRegistryPackage>();
   private vulnerabilityCache = new Map<string, Promise<NpmTestApiResult> | NpmTestApiResult>();
 
-  constructor(private readonly config: IConfiguration, private readonly logger: ILog) {}
+  constructor(private readonly config: IConfiguration, private readonly logger: ILog, private readonly npmTestApi: NpmTestApi) {}
 
   async getModuleVulnerabilityInfo(module: ImportedModule): Promise<TestedImportedModule> {
     const key = this.getVulnerabilityCacheKey(module);
@@ -91,7 +91,7 @@ export class NpmModuleInfoFetchService {
   private async test(npmPackage: NpmRegistryPackage): Promise<NpmTestApiResult> {
     const utm = `utm_medium=${this.config.source}&utm_source=${this.config.source}&utm_campaign=${this.config.source}`;
 
-    const result = await npmTestApi.get<NpmTestApiResult>(
+    const result = await this.npmTestApi.get<NpmTestApiResult>(
       `/npm/${npmPackage.name}/${npmPackage.version}?${utm}&type=json`,
     );
 

--- a/src/test/unit/cli/process.test.ts
+++ b/src/test/unit/cli/process.test.ts
@@ -1,29 +1,42 @@
 import { strictEqual } from 'assert';
+import sinon from 'sinon';
 import { CLI_INTEGRATION_NAME } from '../../../snyk/cli/contants/integration';
 import { CliProcess } from '../../../snyk/cli/process';
 import { Configuration, IConfiguration } from '../../../snyk/common/configuration/configuration';
 import { ILog } from '../../../snyk/common/logger/interfaces';
+import { IVSCodeWorkspace } from '../../../snyk/common/vscode/workspace';
 import { LoggerMock } from '../mocks/logger.mock';
 
 suite('CliProcess', () => {
   let logger: ILog;
+  const emptyWorkspace = ({
+    getConfiguration: () => undefined,
+  } as unknown) as IVSCodeWorkspace;
 
   setup(() => {
     logger = new LoggerMock();
   });
 
   test('Sets DISABLE_ANALYTICS when telemetry is off ', async () => {
-    const process = new CliProcess(logger, {
-      shouldReportEvents: false,
-    } as IConfiguration);
+    const process = new CliProcess(
+      logger,
+      {
+        shouldReportEvents: false,
+      } as IConfiguration,
+      emptyWorkspace,
+    );
     const vars = await process.getProcessEnv();
     strictEqual(Object.keys(vars).includes('SNYK_CFG_DISABLE_ANALYTICS'), true);
   });
 
   test("Doesn't set DISABLE_ANALYTICS when telemetry is on ", async () => {
-    const process = new CliProcess(logger, {
-      shouldReportEvents: true,
-    } as IConfiguration);
+    const process = new CliProcess(
+      logger,
+      {
+        shouldReportEvents: true,
+      } as IConfiguration,
+      emptyWorkspace,
+    );
     const vars = await process.getProcessEnv();
 
     strictEqual(Object.keys(vars).includes('SNYK_CFG_DISABLE_ANALYTICS'), false);
@@ -33,11 +46,15 @@ suite('CliProcess', () => {
     const token = 'fake-token';
     const snykOssApiEndpoint = 'https://snyk.io/api/';
     const organization = 'test-org';
-    const process = new CliProcess(logger, {
-      token: token,
-      snykOssApiEndpoint: snykOssApiEndpoint,
-      organization: organization,
-    } as IConfiguration);
+    const process = new CliProcess(
+      logger,
+      {
+        token: token,
+        snykOssApiEndpoint: snykOssApiEndpoint,
+        organization: organization,
+      } as IConfiguration,
+      emptyWorkspace,
+    );
 
     const envVars = await process.getProcessEnv();
 
@@ -46,5 +63,29 @@ suite('CliProcess', () => {
     strictEqual(envVars['SNYK_TOKEN'], token);
     strictEqual(envVars['SNYK_API'], snykOssApiEndpoint);
     strictEqual(envVars['SNYK_CFG_ORG'], organization);
+  });
+
+  test('Sets correct proxy variable', async () => {
+    // arrange
+    const proxy = 'http://my.proxy.com:8080';
+    const getConfiguration = sinon.stub();
+    getConfiguration.withArgs('http', 'proxy').returns(proxy);
+
+    const process = new CliProcess(
+      logger,
+      {
+        shouldReportEvents: true,
+      } as IConfiguration,
+      ({
+        getConfiguration: getConfiguration,
+      } as unknown) as IVSCodeWorkspace,
+    );
+
+    // act
+    const vars = await process.getProcessEnv();
+
+    // assert
+    strictEqual(vars['HTTPS_PROXY'], proxy);
+    strictEqual(vars['HTTP_PROXY'], proxy);
   });
 });

--- a/src/test/unit/common/proxy.test.ts
+++ b/src/test/unit/common/proxy.test.ts
@@ -1,0 +1,78 @@
+/* eslint-disable camelcase */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import assert from 'assert';
+import sinon from 'sinon';
+import { getHttpsProxyAgent } from '../../../snyk/common/proxy';
+import { IVSCodeWorkspace } from '../../../snyk/common/vscode/workspace';
+
+suite('Proxy', () => {
+  // Proxy settings
+  const host = 'my.proxy.com';
+  const port = 8080;
+  const auth = 'user:password';
+  const proxy = `https://${auth}@${host}:${port}`;
+  const proxyStrictSSL = true;
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('No proxy set', () => {
+    const getConfiguration = sinon.stub();
+    getConfiguration.withArgs('http', 'proxy').returns(undefined);
+
+    const workspace = ({
+      getConfiguration,
+    } as unknown) as IVSCodeWorkspace;
+
+    const agent = getHttpsProxyAgent(workspace);
+
+    assert.strictEqual(agent, undefined);
+  });
+
+  test('Proxy is set in VS Code settings', () => {
+    const getConfiguration = sinon.stub();
+    getConfiguration.withArgs('http', 'proxy').returns(proxy);
+    getConfiguration.withArgs('http', 'proxyStrictSSL').returns(proxyStrictSSL);
+
+    const workspace = ({
+      getConfiguration,
+    } as unknown) as IVSCodeWorkspace;
+
+    const agent = getHttpsProxyAgent(workspace);
+
+    // @ts-ignore: cannot test options otherwise
+    assert.deepStrictEqual(agent?.proxy.host, host);
+    // @ts-ignore: cannot test options otherwise
+    assert.deepStrictEqual(agent?.proxy.port, port);
+    // @ts-ignore: cannot test options otherwise
+    assert.deepStrictEqual(agent?.proxy.auth, auth);
+    // @ts-ignore: cannot test options otherwise
+    assert.deepStrictEqual(agent?.proxy.rejectUnauthorized, proxyStrictSSL);
+  });
+
+  test('Proxy is set in environment', () => {
+    const getConfiguration = sinon.stub();
+    getConfiguration.withArgs('http', 'proxy').returns(undefined);
+    getConfiguration.withArgs('http', 'proxyStrictSSL').returns(proxyStrictSSL);
+
+    const workspace = ({
+      getConfiguration,
+    } as unknown) as IVSCodeWorkspace;
+
+    const agent = getHttpsProxyAgent(workspace, {
+      https_proxy: proxy,
+      http_proxy: proxy,
+    });
+
+    // @ts-ignore: cannot test options otherwise
+    assert.deepStrictEqual(agent?.proxy.host, host);
+    // @ts-ignore: cannot test options otherwise
+    assert.deepStrictEqual(agent?.proxy.port, port);
+    // @ts-ignore: cannot test options otherwise
+    assert.deepStrictEqual(agent?.proxy.auth, auth);
+    // @ts-ignore: cannot test options otherwise
+    assert.deepStrictEqual(agent?.proxy.rejectUnauthorized, proxyStrictSSL);
+  });
+});


### PR DESCRIPTION
This PR enables passing proxy configuration to all network requests for the following scenarios:
1. Environment is set up using proxy variables
2. Proxy is added manually in VS Code settings.

All calls that are issued from within the extension codebase, `code-client` dependency as well as Snyk CLI now respect the above setups.