### PR TITLE
fix: allow running extension without snyk.config.local.json values in development [ROAD-714]

### DIFF
--- a/src/snyk/common/analytics/itly.ts
+++ b/src/snyk/common/analytics/itly.ts
@@ -1,5 +1,4 @@
 import SegmentPlugin from '@itly/plugin-segment-node';
-import path from 'path';
 import itly, {
   AnalysisIsReadyProperties,
   AnalysisIsTriggeredProperties as _AnalysisIsTriggeredProperties,
@@ -35,9 +34,9 @@ export type QuickFixIsDisplayedProperties = _QuickFixIsDisplayedProperties & {
 };
 
 export interface IAnalytics {
-  load(): Promise<Iteratively | null>;
+  load(): Iteratively | null;
   flush(): Promise<void>;
-  setShouldReportEvents(shouldReportEvents: boolean): Promise<void>;
+  setShouldReportEvents(shouldReportEvents: boolean): void;
   identify(userId: string): Promise<void>;
   logIssueInTreeIsClicked(properties: IssueInTreeIsClickedProperties): void;
   logAnalysisIsReady(properties: AnalysisIsReadyProperties): void;
@@ -61,32 +60,32 @@ export class Iteratively implements IAnalytics {
   private readonly ide = IDE_NAME;
 
   private loaded = false;
-  private configsPath = '../../../..';
 
   constructor(
     private readonly user: User,
     private logger: ILog,
     private shouldReportEvents: boolean,
     private isDevelopment: boolean,
+    private snykConfiguration?: SnykConfiguration,
   ) {}
 
-  async setShouldReportEvents(shouldReportEvents: boolean): Promise<void> {
+  setShouldReportEvents(shouldReportEvents: boolean): void {
     this.shouldReportEvents = shouldReportEvents;
-    await this.load();
+    this.load();
   }
 
-  async load(): Promise<Iteratively | null> {
+  load(): Iteratively | null {
     if (!this.shouldReportEvents) {
       return null;
     }
 
-    const snykConfiguration = await SnykConfiguration.get(path.join(this.configsPath), this.isDevelopment);
-    if (!snykConfiguration.segmentWriteKey) {
+    const segmentWriteKey = this.snykConfiguration?.segmentWriteKey;
+    if (!segmentWriteKey) {
       this.logger.debug('Segment analytics write key is empty. No analytics will be collected.');
       return this;
     }
 
-    const segment = new SegmentPlugin(snykConfiguration.segmentWriteKey);
+    const segment = new SegmentPlugin(segmentWriteKey);
     const isDevelopment = this.isDevelopment;
 
     if (!this.loaded) {

--- a/src/snyk/common/experiment/services/experimentService.ts
+++ b/src/snyk/common/experiment/services/experimentService.ts
@@ -3,7 +3,6 @@ import { IConfiguration } from '../../configuration/configuration';
 import { SnykConfiguration } from '../../configuration/snykConfiguration';
 import { ILog } from '../../logger/interfaces';
 import { User } from '../../user';
-import { ExtensionContext } from '../../vscode/extensionContext';
 
 export enum ExperimentKey {
   UpdateCopyOnWelcomeView = 'vscode-update-copy-on-welcome-view',
@@ -15,26 +14,23 @@ export class ExperimentService {
 
   constructor(
     private readonly user: User,
-    private readonly extensionContext: ExtensionContext,
     private readonly logger: ILog,
     private readonly configuration: IConfiguration,
+    private readonly snykConfiguration?: SnykConfiguration,
   ) {}
 
-  async load(): Promise<boolean> {
+  load(): boolean {
     if (!this.canExperiment) {
       return false;
     }
 
-    const snykConfiguration = await SnykConfiguration.get(
-      this.extensionContext.extensionPath,
-      this.configuration.isDevelopment,
-    );
-
-    if (!snykConfiguration.amplitudeExperimentApiKey) {
+    const amplitudeExperimentApiKey = this.snykConfiguration?.amplitudeExperimentApiKey;
+    if (!amplitudeExperimentApiKey) {
       this.logger.debug('Segment analytics write key is empty. No analytics will be collected.');
+      return false;
     }
 
-    this.client = Experiment.initialize(snykConfiguration.amplitudeExperimentApiKey);
+    this.client = Experiment.initialize(amplitudeExperimentApiKey);
     return true;
   }
 

--- a/src/snyk/common/watchers/settingsWatcher.ts
+++ b/src/snyk/common/watchers/settingsWatcher.ts
@@ -24,7 +24,7 @@ class SettingsWatcher implements IWatcher {
     if (key === ADVANCED_ADVANCED_MODE_SETTING) {
       return extension.checkAdvancedMode();
     } else if (key === YES_TELEMETRY_SETTING) {
-      return await this.analytics.setShouldReportEvents(configuration.shouldReportEvents);
+      return this.analytics.setShouldReportEvents(configuration.shouldReportEvents);
     } else if (key === OSS_ENABLED_SETTING) {
       extension.viewManagerService.refreshOssView();
     } else if (key === CODE_SECURITY_ENABLED_SETTING || key === CODE_QUALITY_ENABLED_SETTING) {
@@ -62,11 +62,7 @@ class SettingsWatcher implements IWatcher {
           try {
             await this.onChangeConfiguration(extension, change);
           } catch (error) {
-            ErrorHandler.handle(
-              error,
-              this.logger,
-              `${errorsLogs.configWatcher}. Configuration key: ${change}`,
-            );
+            ErrorHandler.handle(error, this.logger, `${errorsLogs.configWatcher}. Configuration key: ${change}`);
           }
         }
       },

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -70,25 +70,41 @@ class SnykExtension extends SnykLib implements IExtension {
     extensionContext.setContext(vscodeContext);
     this.context = extensionContext;
 
-    await ErrorReporter.init(
-      configuration,
-      await SnykConfiguration.get(extensionContext.extensionPath, configuration.isDevelopment),
-      extensionContext.extensionPath,
-      vsCodeEnv,
-      Logger,
-    );
+    const snykConfiguration = await this.getSnykConfiguration();
+    if (snykConfiguration) {
+      await ErrorReporter.init(configuration, snykConfiguration, extensionContext.extensionPath, vsCodeEnv, Logger);
+    }
 
     try {
-      await this.initializeExtension(vscodeContext);
+      await this.initializeExtension(vscodeContext, snykConfiguration);
     } catch (e) {
       ErrorHandler.handle(e, Logger);
     }
   }
 
-  private async initializeExtension(vscodeContext: vscode.ExtensionContext) {
+  private async getSnykConfiguration(): Promise<SnykConfiguration | undefined> {
+    try {
+      const snykConfiguration = await SnykConfiguration.get(
+        extensionContext.extensionPath,
+        configuration.isDevelopment,
+      );
+
+      return snykConfiguration;
+    } catch (e) {
+      ErrorHandler.handle(e, Logger);
+    }
+  }
+
+  private async initializeExtension(vscodeContext: vscode.ExtensionContext, snykConfiguration?: SnykConfiguration) {
     this.user = await User.getAnonymous(this.context);
 
-    this.analytics = new Iteratively(this.user, Logger, configuration.shouldReportEvents, configuration.isDevelopment);
+    this.analytics = new Iteratively(
+      this.user,
+      Logger,
+      configuration.shouldReportEvents,
+      configuration.isDevelopment,
+      snykConfiguration,
+    );
 
     this.settingsWatcher = new SettingsWatcher(this.analytics, Logger);
     this.notificationService = new NotificationService(
@@ -225,9 +241,9 @@ class SnykExtension extends SnykLib implements IExtension {
 
     this.checkAdvancedMode().catch(err => ErrorReporter.capture(err));
 
-    await this.analytics.load();
-    this.experimentService = new ExperimentService(this.user, this.context, Logger, configuration);
-    await this.experimentService.load();
+    this.analytics.load();
+    this.experimentService = new ExperimentService(this.user, Logger, configuration, snykConfiguration);
+    this.experimentService.load();
 
     this.logPluginIsInstalled();
 

--- a/src/test/unit/common/experiment/services/experimentService.test.ts
+++ b/src/test/unit/common/experiment/services/experimentService.test.ts
@@ -4,16 +4,13 @@ import { IConfiguration } from '../../../../../snyk/common/configuration/configu
 import { SnykConfiguration } from '../../../../../snyk/common/configuration/snykConfiguration';
 import { ExperimentKey, ExperimentService } from '../../../../../snyk/common/experiment/services/experimentService';
 import { User } from '../../../../../snyk/common/user';
-import { ExtensionContext } from '../../../../../snyk/common/vscode/extensionContext';
 import { LoggerMock } from '../../../mocks/logger.mock';
 
 suite('ExperimentService', () => {
   let user: User;
-  let extensionContext: ExtensionContext;
 
   setup(() => {
     user = new User(undefined, undefined);
-    extensionContext = {} as ExtensionContext;
 
     sinon.stub(SnykConfiguration, 'get').resolves({
       amplitudeExperimentApiKey: 'test',
@@ -25,13 +22,13 @@ suite('ExperimentService', () => {
     sinon.restore();
   });
 
-  test("Doesn't load when event reporting is off", async () => {
+  test("Doesn't load when event reporting is off", () => {
     const config = ({
       shouldReportEvents: false,
     } as unknown) as IConfiguration;
 
-    const service = new ExperimentService(user, extensionContext, new LoggerMock(), config);
-    const loaded = await service.load();
+    const service = new ExperimentService(user, new LoggerMock(), config);
+    const loaded = service.load();
 
     strictEqual(loaded, false);
   });
@@ -41,7 +38,7 @@ suite('ExperimentService', () => {
       shouldReportEvents: false,
     } as unknown) as IConfiguration;
 
-    const service = new ExperimentService(user, extensionContext, new LoggerMock(), config);
+    const service = new ExperimentService(user, new LoggerMock(), config);
 
     const isUserPartOfExperiment = await service.isUserPartOfExperiment(ExperimentKey.UpdateCopyOnWelcomeView);
 

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -129,7 +129,7 @@ async function reportUninstall(): Promise<void> {
   const user = new User(undefined, authenticatedUserId);
 
   const analytics = new Iteratively(user, new UninstallLogger(), yesTelemetry, !!process.env.SNYK_VSCE_DEVELOPMENT);
-  await analytics.load();
+  analytics.load();
 
   // Report and flush the uninstall event
   analytics.logPluginIsUninstalled();


### PR DESCRIPTION
Currently if you do not have `snyk.config.local.json` configuration file populated with correct API keys in order to run extension in development mode the extension throws an error and does not successfully startup.

This PR fixes that by isolating the error reporting configuration piece and allowing the extension to startup successfully without needing to have all the reporting keys available.