### PR TITLE
fix: navigating user back to the welcome screen in case of an invalid token [ROAD-642]

### DIFF
--- a/src/snyk/base/modules/baseSnykModule.ts
+++ b/src/snyk/base/modules/baseSnykModule.ts
@@ -65,9 +65,15 @@ export default abstract class BaseSnykModule implements IBaseSnykModule {
     this.openerService = new OpenerService();
     this.scanModeService = new ScanModeService(this.contextService, configuration);
     this.loadingBadge = new LoadingBadge();
-    this.snykApiClient = new SnykApiClient(configuration, vsCodeWorkspace);
-    this.falsePositiveApi = new FalsePositiveApi(configuration, vsCodeWorkspace);
-    this.snykCodeErrorHandler = new SnykCodeErrorHandler(this.contextService, this.loadingBadge, Logger, this, configuration);
+    this.snykApiClient = new SnykApiClient(configuration, vsCodeWorkspace, Logger);
+    this.falsePositiveApi = new FalsePositiveApi(configuration, vsCodeWorkspace, Logger);
+    this.snykCodeErrorHandler = new SnykCodeErrorHandler(
+      this.contextService,
+      this.loadingBadge,
+      Logger,
+      this,
+      configuration,
+    );
     this.codeSettings = new CodeSettings(this.snykApiClient, this.contextService, configuration, this.openerService);
   }
 

--- a/src/snyk/base/modules/snykLib.ts
+++ b/src/snyk/base/modules/snykLib.ts
@@ -49,7 +49,6 @@ export default class SnykLib extends BaseSnykModule implements ISnykLib {
         await this.startSnykCodeAnalysis(workspacePaths, manual, false); // mark void, handle errors inside of startSnykCodeAnalysis()
       }
     } catch (err) {
-      console.log(err);
       await ErrorHandler.handleGlobal(err, Logger, this.contextService, this.loadingBadge);
     }
   }

--- a/src/snyk/base/modules/snykLib.ts
+++ b/src/snyk/base/modules/snykLib.ts
@@ -28,6 +28,7 @@ export default class SnykLib extends BaseSnykModule implements ISnykLib {
       }
 
       await this.contextService.setContext(SNYK_CONTEXT.AUTHENTICATING, false);
+      await this.contextService.setContext(SNYK_CONTEXT.LOGGEDIN, true);
 
       if (!configuration.getFeaturesConfiguration()) {
         await this.contextService.setContext(SNYK_CONTEXT.FEATURES_SELECTED, false);
@@ -36,11 +37,10 @@ export default class SnykLib extends BaseSnykModule implements ISnykLib {
 
       await this.contextService.setContext(SNYK_CONTEXT.FEATURES_SELECTED, true);
 
-      await this.user.identify(this.snykApiClient, this.analytics);
-      await this.contextService.setContext(SNYK_CONTEXT.LOGGEDIN, true);
-
       const workspacePaths = vsCodeWorkspace.getWorkspaceFolders();
       await this.setWorkspaceContext(workspacePaths);
+
+      await this.user.identify(this.snykApiClient, this.analytics);
 
       if (workspacePaths.length) {
         this.logFullAnalysisIsTriggered(manual);

--- a/src/snyk/base/modules/snykLib.ts
+++ b/src/snyk/base/modules/snykLib.ts
@@ -13,9 +13,6 @@ import BaseSnykModule from './baseSnykModule';
 import { ISnykLib } from './interfaces';
 
 export default class SnykLib extends BaseSnykModule implements ISnykLib {
-  // default set blocking to true
-  private isBlockingError = true;
-
   private async runFullScan_(manual = false): Promise<void> {
     Logger.info('Starting full scan');
 
@@ -39,7 +36,8 @@ export default class SnykLib extends BaseSnykModule implements ISnykLib {
 
       await this.contextService.setContext(SNYK_CONTEXT.FEATURES_SELECTED, true);
 
-      await this.validateUserToken();
+      await this.user.identify(this.snykApiClient, this.analytics);
+      await this.contextService.setContext(SNYK_CONTEXT.LOGGEDIN, true);
 
       const workspacePaths = vsCodeWorkspace.getWorkspaceFolders();
       await this.setWorkspaceContext(workspacePaths);
@@ -51,18 +49,8 @@ export default class SnykLib extends BaseSnykModule implements ISnykLib {
         await this.startSnykCodeAnalysis(workspacePaths, manual, false); // mark void, handle errors inside of startSnykCodeAnalysis()
       }
     } catch (err) {
-      await ErrorHandler.handleGlobal(err, Logger, this.contextService, this.loadingBadge, this.isBlockingError);
-    }
-  }
-
-  private async validateUserToken(): Promise<void> {
-    try {
-      await this.user.identify(this.snykApiClient, this.analytics);
-      await this.contextService.setContext(SNYK_CONTEXT.LOGGEDIN, true);
-    } catch (err) {
-      this.isBlockingError = false;
-      await this.contextService.setContext(SNYK_CONTEXT.LOGGEDIN, false);
-      await this.contextService.setContext(SNYK_CONTEXT.WELCOME_VIEW_EXPERIMENT, 'control');
+      console.log(err);
+      await ErrorHandler.handleGlobal(err, Logger, this.contextService, this.loadingBadge);
     }
   }
 

--- a/src/snyk/common/api/apiСlient.ts
+++ b/src/snyk/common/api/apiСlient.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { IConfiguration } from '../configuration/configuration';
 import { configuration } from '../configuration/instance';
+import { ILog } from '../logger/interfaces';
 import { getAxiosProxyConfig } from '../proxy';
 import { IVSCodeWorkspace } from '../vscode/workspace';
 import { DEFAULT_API_HEADERS } from './headers';
@@ -12,7 +13,11 @@ export interface ISnykApiClient {
 export class SnykApiClient implements ISnykApiClient {
   private instance: AxiosInstance | null = null;
 
-  constructor(private readonly configuration: IConfiguration, private readonly workspace: IVSCodeWorkspace) {}
+  constructor(
+    private readonly configuration: IConfiguration,
+    private readonly workspace: IVSCodeWorkspace,
+    private readonly logger: ILog,
+  ) {}
 
   private get http(): AxiosInstance {
     return this.instance != null ? this.instance : this.initHttp();
@@ -30,10 +35,10 @@ export class SnykApiClient implements ISnykApiClient {
       async (error: AxiosError) => {
         if (error.response?.status === 401) {
           await configuration.setToken(undefined);
-          console.log('Call to Snyk API failed - Invalid token');
+          this.logger.warn('Call to Snyk API failed - Invalid token');
           return;
         }
-        console.error('Call to Snyk API failed: ', error);
+        this.logger.error(`Call to Snyk API failed: ${error}`);
         return Promise.reject(error);
       },
     );

--- a/src/snyk/common/error/errorHandler.ts
+++ b/src/snyk/common/error/errorHandler.ts
@@ -16,10 +16,13 @@ export class ErrorHandler {
     logger: ILog,
     contextService: IContextService,
     loadingBadge: ILoadingBadge,
+    isBlocking: boolean,
   ): Promise<void> {
-    await contextService.setContext(SNYK_CONTEXT.ERROR, SNYK_ERROR_CODES.BLOCKING);
-    loadingBadge.setLoadingBadge(true);
+    if (isBlocking) {
+      await contextService.setContext(SNYK_CONTEXT.ERROR, SNYK_ERROR_CODES.BLOCKING);
+    }
 
+    loadingBadge.setLoadingBadge(true);
     this.handle(error, logger);
   }
 

--- a/src/snyk/common/error/errorHandler.ts
+++ b/src/snyk/common/error/errorHandler.ts
@@ -16,12 +16,8 @@ export class ErrorHandler {
     logger: ILog,
     contextService: IContextService,
     loadingBadge: ILoadingBadge,
-    isBlocking: boolean,
   ): Promise<void> {
-    if (isBlocking) {
-      await contextService.setContext(SNYK_CONTEXT.ERROR, SNYK_ERROR_CODES.BLOCKING);
-    }
-
+    await contextService.setContext(SNYK_CONTEXT.ERROR, SNYK_ERROR_CODES.BLOCKING);
     loadingBadge.setLoadingBadge(true);
     this.handle(error, logger);
   }

--- a/src/snyk/common/services/cliConfigService.ts
+++ b/src/snyk/common/services/cliConfigService.ts
@@ -8,11 +8,14 @@ export type SastSettings = {
   };
 };
 
-export async function getSastSettings(api: ISnykApiClient): Promise<SastSettings> {
-  const { data } = await api.get<SastSettings>('cli-config/settings/sast', {
+export async function getSastSettings(api: ISnykApiClient): Promise<SastSettings | undefined> {
+  const response = await api.get<SastSettings>('cli-config/settings/sast', {
     headers: {
       'x-snyk-ide': `${Configuration.source}-${await Configuration.getVersion()}`,
     },
   });
-  return data;
+
+  if (!response) return;
+
+  return response.data;
 }

--- a/src/snyk/common/user.ts
+++ b/src/snyk/common/user.ts
@@ -44,8 +44,10 @@ export class User {
     }
   }
 
-  private async userMe(api: ISnykApiClient): Promise<UserDto> {
-    const { data } = await api.get<UserDto>('/user/me');
-    return data;
+  private async userMe(api: ISnykApiClient): Promise<UserDto | undefined> {
+    const response = await api.get<UserDto>('/user/me');
+    if (!response) return;
+
+    return response.data;
   }
 }

--- a/src/snyk/snykCode/codeSettings.ts
+++ b/src/snyk/snykCode/codeSettings.ts
@@ -20,6 +20,10 @@ export class CodeSettings implements ICodeSettings {
 
   async checkCodeEnabled(): Promise<boolean> {
     const settings = await this.getSastSettings();
+    if (!settings) {
+      return false;
+    }
+
     await this.contextService.setContext(SNYK_CONTEXT.CODE_ENABLED, settings.sastEnabled);
     await this.contextService.setContext(
       SNYK_CONTEXT.CODE_LOCAL_ENGINE_ENABLED,
@@ -31,7 +35,7 @@ export class CodeSettings implements ICodeSettings {
 
   async enable(): Promise<boolean> {
     let settings = await this.getSastSettings();
-    if (settings.sastEnabled) {
+    if (settings?.sastEnabled) {
       return true;
     }
 
@@ -46,7 +50,7 @@ export class CodeSettings implements ICodeSettings {
 
       // eslint-disable-next-line no-await-in-loop
       settings = await this.getSastSettings();
-      if (settings.sastEnabled) {
+      if (settings?.sastEnabled) {
         return true;
       }
     }
@@ -54,7 +58,7 @@ export class CodeSettings implements ICodeSettings {
     return false;
   }
 
-  getSastSettings(): Promise<SastSettings> {
+  getSastSettings(): Promise<SastSettings | undefined> {
     return getSastSettings(this.snykApiClient);
   }
 


### PR DESCRIPTION
When providing an invalid/revoked token the API responds with error code `401` which not being handled correctly navigates the user to error screen. This PR fixes that problem and navigates the user back to the welcome screen where user can generate a new token.