### PR TITLE
fix: Automated weekly release [ROAD-223]

### DIFF
--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -3,7 +3,7 @@ name: Build and Release
 on:
 workflow_dispatch:
 schedule:
-  - cron: '0 9 * * 2'  # every Tuesday at 9 am UTC
+  - cron: '0 9 * * 2' # every Tuesday at 9 am UTC
 
 jobs:
   build:
@@ -39,8 +39,8 @@ jobs:
         run: |
           sed -i \
               -e 's/${env.SNYK_VSCE_SEGMENT_WRITE_KEY}/${{ secrets.SNYK_VSCE_SEGMENT_WRITE_KEY }}/g' \
-              -e 's/${env.SNYK_VSCE_AMPLITUDE_EXPERIMENT_API_KEY}/${{ secrets.SNYK_VSCE_SEGMENT_WRITE_KEY }}/g' \
-              -e 's/${env.SNYK_VSCE_SENTRY_DSN_KEY}/${{ secrets.SNYK_VSCE_SEGMENT_WRITE_KEY }}/g' \
+              -e 's/${env.SNYK_VSCE_AMPLITUDE_EXPERIMENT_API_KEY}/${{ secrets.SNYK_VSCE_AMPLITUDE_EXPERIMENT_API_KEY }}/g' \
+              -e 's/${env.SNYK_VSCE_SENTRY_DSN_KEY}/${{ secrets.SNYK_VSCE_SENTRY_DSN_KEY }}/g' \
               snyk.config.json
 
       - name: Package VSIX
@@ -57,7 +57,7 @@ jobs:
         with:
           name: ${{ steps.patched-tag.outputs.tag }}
           tag_name: ${{ steps.patched-tag.outputs.tag }}
-          body: "${{ steps.extract-release-notes.outputs.release_notes }}"
+          body: '${{ steps.extract-release-notes.outputs.release_notes }}'
           draft: false
           prerelease: false
           fail_on_unmatched_files: true

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -1,0 +1,68 @@
+name: Build and Release
+
+on:
+workflow_dispatch:
+schedule:
+  - cron: '0 9 * * 2'  # every Tuesday at 9 am UTC
+
+jobs:
+  build:
+    uses: snyk/vscode-extension/.github/workflows/ci.yaml@main
+    secrets:
+      ITERATIVELY_KEY: ${{ secrets.ITERATIVELY_KEY }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    environment: Stable
+    name: Release
+    steps:
+      - name: Fetch sources
+        uses: actions/checkout@v2
+
+      - name: Setup VSCE
+        run: sudo npm install -g vsce@latest
+
+      - name: Bump patch version
+        id: patched-tag
+        uses: anothrnick/github-tag-action@1.35.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          RELEASE_BRANCHES: main
+          DEFAULT_BUMP: patch
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Add Credentials
+        run: |
+          sed -i \
+              -e 's/${env.SNYK_VSCE_SEGMENT_WRITE_KEY}/${{ secrets.SNYK_VSCE_SEGMENT_WRITE_KEY }}/g' \
+              -e 's/${env.SNYK_VSCE_AMPLITUDE_EXPERIMENT_API_KEY}/${{ secrets.SNYK_VSCE_SEGMENT_WRITE_KEY }}/g' \
+              -e 's/${env.SNYK_VSCE_SENTRY_DSN_KEY}/${{ secrets.SNYK_VSCE_SEGMENT_WRITE_KEY }}/g' \
+              snyk.config.json
+
+      - name: Package VSIX
+        run: echo y | vsce package
+
+      - name: Extract release notes
+        id: extract-release-notes
+        uses: ffurrer2/extract-release-notes@v1
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: ${{ steps.patched-tag.outputs.tag }}
+          tag_name: ${{ steps.patched-tag.outputs.tag }}
+          body: "${{ steps.extract-release-notes.outputs.release_notes }}"
+          draft: false
+          prerelease: false
+          fail_on_unmatched_files: true
+          files: |
+            **/*.vsix
+
+      - name: Publish to Marketplace
+        run: vsce publish -p ${{ secrets.MARKETPLACE_TOKEN }}


### PR DESCRIPTION
Introducing weekly automated stable release. That performs,

- Build the source code
- Bumps the patch version (based on the previous tag)
- Add required credentials 
- Create a release with the relevant files and release notes (notes should be same as changelog.md)
- Publish to marketplace

![](https://media.giphy.com/media/143vPc6b08locw/giphy.gif)