### PR TITLE
chore: indent on trigger correctly in release-stable yaml for GH actions

### DIFF
--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -1,9 +1,9 @@
 name: Build and Release
 
 on:
-workflow_dispatch:
-schedule:
-  - cron: '0 9 * * 2' # every Tuesday at 9 am UTC
+  workflow_dispatch:
+  schedule:
+    - cron: '0 9 * * 2'  # every Tuesday at 9 am UTC
 
 jobs:
   build:


### PR DESCRIPTION
Adding some indentation for on trigger because yaml 😫 