### PR TITLE
feat: support devDependencies on package.json parser

### DIFF
--- a/src/snyk/advisor/services/advisorService.ts
+++ b/src/snyk/advisor/services/advisorService.ts
@@ -113,7 +113,7 @@ export class AdvisorService implements Disposable {
   }
 
   private getModules(fileName: string, source: string, language: Language, logger: ILog): ImportedModule[] {
-    const parser = ModuleParserProvider.getInstance(language, logger);
+    const parser = ModuleParserProvider.getInstance(language, logger, this.configuration);
     if (!parser) {
       return [];
     }

--- a/src/snyk/common/services/moduleParserProvider.ts
+++ b/src/snyk/common/services/moduleParserProvider.ts
@@ -2,15 +2,17 @@ import { BabelParser } from '../../snykOss/services/vulnerabilityCount/parsers/b
 import { HtmlParser } from '../../snykOss/services/vulnerabilityCount/parsers/htmlParser';
 import { ModuleParser } from '../../snykOss/services/vulnerabilityCount/parsers/moduleParser';
 import { PackageJsonParser } from '../../snykOss/services/vulnerabilityCount/parsers/packageJsonParser';
+import { IConfiguration } from '../configuration/configuration';
 import { ILog } from '../logger/interfaces';
 import { Language } from '../types';
 
 export class ModuleParserProvider {
-  static getInstance(language: Language, logger: ILog): ModuleParser | undefined {
+  static getInstance(language: Language, logger: ILog, configuration: IConfiguration): ModuleParser | undefined {
     if ([Language.TypeScript, Language.JavaScript].includes(language)) {
       return new BabelParser();
     } else if (language === Language.PJSON) {
-      return new PackageJsonParser(logger);
+      const cliParameters = configuration.getAdditionalCliParameters();
+      return new PackageJsonParser(logger, cliParameters);
     } else if (language === Language.HTML) {
       return new HtmlParser();
     }

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -284,6 +284,7 @@ class SnykExtension extends SnykLib implements IExtension {
       new EditorDecorator(vsCodeWindow, vsCodeLanguages, new ThemeColorAdapter()),
       new CodeActionKindAdapter(),
       this.analytics,
+      configuration,
     );
     this.ossVulnerabilityCountService.activate();
 

--- a/src/snyk/snykOss/services/vulnerabilityCount/ossVulnerabilityCountService.ts
+++ b/src/snyk/snykOss/services/vulnerabilityCount/ossVulnerabilityCountService.ts
@@ -1,5 +1,6 @@
 import { Subscription } from 'rxjs';
 import { IAnalytics } from '../../../common/analytics/itly';
+import { IConfiguration } from '../../../common/configuration/configuration';
 import { HTML, JAVASCRIPT, PJSON, TYPESCRIPT } from '../../../common/constants/languageConsts';
 import { ILog } from '../../../common/logger/interfaces';
 import { getSupportedLanguage, isValidModuleName } from '../../../common/parsing';
@@ -44,6 +45,7 @@ export class OssVulnerabilityCountService implements Disposable {
     private readonly editorDecorator: EditorDecorator,
     private readonly codeActionKindProvider: ICodeActionKindAdapter,
     private readonly analytics: IAnalytics,
+    private readonly configuration: IConfiguration,
   ) {}
 
   activate(): boolean {
@@ -228,7 +230,7 @@ export class OssVulnerabilityCountService implements Disposable {
   }
 
   private getModules(fileName: string, source: string, language: Language): ImportedModule[] {
-    const parser = ModuleParserProvider.getInstance(language, this.logger);
+    const parser = ModuleParserProvider.getInstance(language, this.logger, this.configuration);
     if (!parser) {
       return [];
     }

--- a/src/snyk/snykOss/services/vulnerabilityCount/parsers/packageJsonParser.ts
+++ b/src/snyk/snykOss/services/vulnerabilityCount/parsers/packageJsonParser.ts
@@ -8,6 +8,7 @@ export type PackageJsonDependencies = {
 
 export interface PackageJson {
   dependencies: PackageJsonDependencies;
+  devDependencies: PackageJsonDependencies;
 }
 
 export interface DependencyLines {
@@ -16,13 +17,11 @@ export interface DependencyLines {
 }
 
 export class PackageJsonParser extends ModuleParser {
-  constructor(private readonly logger: ILog) {
+  constructor(private readonly logger: ILog, private readonly cliParameters?: string) {
     super();
   }
 
   getModules(fileName: string, source: string): ImportedModule[] {
-    const packages = [];
-
     const lines: string[] = [];
     source.split(/\r?\n/).forEach(function (line) {
       lines.push(line);
@@ -38,35 +37,57 @@ export class PackageJsonParser extends ModuleParser {
       }
     }
 
-    if (pjson) {
-      const depLines = this.findDependecyLines(pjson.dependencies, lines);
-      if (!depLines) {
-        return [];
-      }
+    if (!pjson) {
+      return [];
+    }
 
+    const depLines = this.findDependencyLines(pjson, 'dependencies', lines);
+    const parseDevDeps = pjson.devDependencies && this.cliParameters?.includes('--dev');
+    const devDepLines = parseDevDeps ? this.findDependencyLines(pjson, 'devDependencies', lines) : undefined;
+
+    if (!depLines && !devDepLines) {
+      return [];
+    }
+
+    const packages = [];
+
+    if (depLines) {
       for (const dependency in pjson.dependencies) {
-        const loc = this.findRange(dependency, depLines.lines, depLines.offset);
+        packages.push(this.parseDependency(dependency, depLines, fileName));
+      }
+    }
 
-        const module = {
-          fileName,
-          name: dependency,
-          loc,
-          line: loc?.start.line,
-        } as ImportedModule;
-
-        packages.push(module);
+    if (devDepLines) {
+      for (const devDependency in pjson.devDependencies) {
+        packages.push(this.parseDependency(devDependency, devDepLines, fileName));
       }
     }
 
     return packages;
   }
 
-  private findDependecyLines(dependencies: PackageJsonDependencies, lines: string[]): DependencyLines | undefined {
-    const depStartLine = lines.find(x => x.includes('"dependencies"'));
+  private parseDependency(dependency: string, depLines: DependencyLines, fileName: string) {
+    const loc = this.findRange(dependency, depLines.lines, depLines.offset);
+
+    return {
+      fileName,
+      name: dependency,
+      loc,
+      line: loc?.start.line,
+    } as ImportedModule;
+  }
+
+  private findDependencyLines(
+    pjson: PackageJson,
+    key: keyof PackageJson,
+    lines: string[],
+  ): DependencyLines | undefined {
+    const depStartLine = lines.find(x => x.includes(`"${key}"`));
     if (!depStartLine) {
       return;
     }
 
+    const dependencies = pjson[key];
     const depLineIndex = lines.indexOf(depStartLine) + 1;
     let dependenciesLength = Object.keys(dependencies).length;
     const emptyLineTabRegex = /(\t)$/;

--- a/src/test/unit/advisor/services/advisorService.test.ts
+++ b/src/test/unit/advisor/services/advisorService.test.ts
@@ -31,6 +31,7 @@ suite('Advisor AdvisorService', () => {
       {} as HoverAdapter,
       {} as IMarkdownStringAdapter,
       {
+        getAdditionalCliParameters: () => undefined,
         getPreviewFeatures: () => {
           return {
             advisor: true,

--- a/src/test/unit/snykOss/services/vulnerabilityCount/ossVulnerabilityCountService.test.ts
+++ b/src/test/unit/snykOss/services/vulnerabilityCount/ossVulnerabilityCountService.test.ts
@@ -2,6 +2,7 @@ import { strictEqual } from 'assert';
 import { EMPTY } from 'rxjs';
 import sinon from 'sinon';
 import { IAnalytics } from '../../../../../snyk/common/analytics/itly';
+import { IConfiguration } from '../../../../../snyk/common/configuration/configuration';
 import { ICodeActionKindAdapter } from '../../../../../snyk/common/vscode/codeAction';
 import { IVSCodeLanguages } from '../../../../../snyk/common/vscode/languages';
 import { IThemeColorAdapter } from '../../../../../snyk/common/vscode/theme';
@@ -46,6 +47,7 @@ suite('OSS VulnerabilityCountService', () => {
       getQuickFix: sinon.fake(),
     } as ICodeActionKindAdapter;
     const analytics = {} as IAnalytics;
+    const configuration = {} as IConfiguration;
 
     ossVulnerabilityCountService = new OssVulnerabilityCountService(
       workspace,
@@ -57,6 +59,7 @@ suite('OSS VulnerabilityCountService', () => {
       editorDecorator,
       codeActionProvider,
       analytics,
+      configuration,
     );
   });
 

--- a/src/test/unit/snykOss/services/vulnerabilityCount/parsers/moduleParserProvider.test.ts
+++ b/src/test/unit/snykOss/services/vulnerabilityCount/parsers/moduleParserProvider.test.ts
@@ -1,17 +1,22 @@
 import { strictEqual } from 'assert';
+import { IConfiguration } from '../../../../../../snyk/common/configuration/configuration';
 import { ModuleParserProvider } from '../../../../../../snyk/common/services/moduleParserProvider';
 import { Language } from '../../../../../../snyk/common/types';
 import { BabelParser } from '../../../../../../snyk/snykOss/services/vulnerabilityCount/parsers/babelParser';
 import { LoggerMock } from '../../../../mocks/logger.mock';
 
 suite('OSS ModuleParserProvider', () => {
+  const configuration = {
+    getAdditionalCliParameters: () => undefined,
+  } as IConfiguration;
+
   test('Babel parser is returned for TS and JS', () => {
-    const parser = ModuleParserProvider.getInstance(Language.JavaScript, new LoggerMock());
+    const parser = ModuleParserProvider.getInstance(Language.JavaScript, new LoggerMock(), configuration);
     strictEqual(parser instanceof BabelParser, true);
   });
 
   test('Undefined instance is returned for non-supported language', () => {
-    const parser = ModuleParserProvider.getInstance(-1, new LoggerMock());
+    const parser = ModuleParserProvider.getInstance(-1, new LoggerMock(), configuration);
     strictEqual(parser, undefined);
   });
 });

--- a/src/test/unit/snykOss/services/vulnerabilityCount/parsers/packageJsonParser.test.ts
+++ b/src/test/unit/snykOss/services/vulnerabilityCount/parsers/packageJsonParser.test.ts
@@ -90,4 +90,20 @@ suite("'package.json' Parser", () => {
     const modules = parser.getModules('package.json', source);
     strictEqual(modules.length, 0);
   });
+
+  test('devDependencies when --dev is in CLI parameters', () => {
+    const source = `
+    {
+      "devDependencies": {
+          "adm-zip": "^0.2.7"
+      }
+    }
+    `;
+    parser = new PackageJsonParser(new LoggerMock(), '--dev');
+    const modules = parser.getModules('package.json', source);
+
+    strictEqual(modules.length, 1);
+    strictEqual(modules[0].name, 'adm-zip');
+    strictEqual(modules[0].line, 4);
+  });
 });


### PR DESCRIPTION
Fixes #173.

<details>
<summary>Screenshot</summary>

![Screenshot 2022-03-15 at 15 33 46](https://user-images.githubusercontent.com/13774309/158401386-c4f4cfcb-4c16-493b-a283-b6049ce57cf6.png)

</details>

As `--dev` is the trigger for scanning `devDependencies`, I've approached the issue like this:

1. Pass the additional CLI parameters to the package.json parser;
2. Look for the `--dev` string inside the parameters (if provided)
3. Check if there are `devDependencies` in the package.json
4. If 2 and 3 are true, parse the `devDependencies` as the `dependencies`

Let me know if you have suggestions for changes or if I have approached the issue incorrectly.