### PR TITLE
fix: unit test mocks hanging up

### DIFF
--- a/src/snyk/cli/process.ts
+++ b/src/snyk/cli/process.ts
@@ -56,7 +56,6 @@ export class CliProcess {
   }
 
   async getProcessEnv(): Promise<NodeJS.ProcessEnv> {
-    console.log(this.config);
     let env = {
       SNYK_INTEGRATION_NAME: CLI_INTEGRATION_NAME,
       SNYK_INTEGRATION_VERSION: await Configuration.getVersion(),

--- a/src/test/unit/base/services/authenticationService.test.ts
+++ b/src/test/unit/base/services/authenticationService.test.ts
@@ -18,6 +18,17 @@ suite('AuthenticationService', () => {
   let baseModule: IBaseSnykModule;
   let config: IConfiguration;
 
+  const NEEDLE_DEFAULT_TIMEOUT = 1000;
+
+  const overrideNeedleTimeoutOptions = {
+    // eslint-disable-next-line camelcase
+    open_timeout: NEEDLE_DEFAULT_TIMEOUT,
+    // eslint-disable-next-line camelcase
+    response_timeout: NEEDLE_DEFAULT_TIMEOUT,
+    // eslint-disable-next-line camelcase
+    read_timeout: NEEDLE_DEFAULT_TIMEOUT,
+  };
+
   setup(() => {
     contextService = ({
       setContext: sinon.fake(),
@@ -74,7 +85,8 @@ suite('AuthenticationService', () => {
         ({} as unknown) as NeedleResponse,
         null,
       );
-      return needle.post(uri, data, opts);
+      // eslint-disable-next-line camelcase
+      return needle.post(uri, data, { ...opts, ...overrideNeedleTimeoutOptions });
     });
 
     const ipFamily = await getIpFamily('https://dev.snyk.io');
@@ -97,7 +109,7 @@ suite('AuthenticationService', () => {
         } as NeedleResponse,
         null,
       );
-      return needle.post(uri, data, opts);
+      return needle.post(uri, data, { ...opts, ...overrideNeedleTimeoutOptions });
     });
 
     const ipFamily = await getIpFamily('https://dev.snyk.io');


### PR DESCRIPTION
Mocks for Needle client that we use within our tests has a default timeout set to 10 minutes (within code-client package) which hangs the socket for that time and tests takes 10 minutes to complete. 

- Adding an override for that timeout.
- Removing an unnessary logging statement.