### PR TITLE
fix: Snyk Code diagnostics to respect settings [ROAD-638]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Reported Snyk Code diagnostics not respecting `snyk.features.codeSecurity`, `snyk.features.codeQuality` and `snyk.severity` settings.
 - Reported diagnostics not opening files from Problems view, when operating in workspace mode with whitespace in paths to workspace folders.
 
 ## [1.2.12]

--- a/src/snyk/common/views/analysisTreeNodeProvider.ts
+++ b/src/snyk/common/views/analysisTreeNodeProvider.ts
@@ -72,5 +72,5 @@ export abstract class AnalysisTreeNodeProvder extends TreeNodeProvider {
     });
   }
 
-  protected abstract getFilteredIssues(issues: readonly unknown[]): unknown[];
+  protected abstract getFilteredIssues(issues: readonly unknown[]): readonly unknown[];
 }

--- a/src/snyk/common/watchers/configurationWatcher.ts
+++ b/src/snyk/common/watchers/configurationWatcher.ts
@@ -29,9 +29,11 @@ class ConfigurationWatcher implements IWatcher {
     } else if (key === OSS_ENABLED_SETTING) {
       extension.viewManagerService.refreshOssView();
     } else if (key === CODE_SECURITY_ENABLED_SETTING || key === CODE_QUALITY_ENABLED_SETTING) {
+      extension.snykCode.analyzer.refreshDiagnostics();
       // If two settings are changed simultaneously, only one will be applied, thus refresh all views
-      extension.viewManagerService.refreshAllCodeAnalysisViews();
+      return extension.viewManagerService.refreshAllCodeAnalysisViews();
     } else if (key === SEVERITY_FILTER_SETTING) {
+      extension.snykCode.analyzer.refreshDiagnostics();
       return extension.viewManagerService.refreshAllViews();
     }
 

--- a/src/snyk/snykCode/interfaces.ts
+++ b/src/snyk/snykCode/interfaces.ts
@@ -2,6 +2,7 @@ import { AnalysisResultLegacy, FilePath, FileSuggestion, Suggestion } from '@sny
 import * as vscode from 'vscode';
 import { DiagnosticCollection, TextDocument } from 'vscode';
 import { IExtension } from '../base/modules/interfaces';
+import { IHoverAdapter } from '../common/vscode/hover';
 import { Disposable } from '../common/vscode/types';
 
 export type completeFileSuggestionType = ICodeSuggestion &
@@ -41,6 +42,13 @@ export interface ISnykCodeResult extends AnalysisResultLegacy {
 export interface ISnykCodeAnalyzer extends Disposable {
   codeSecurityReview: DiagnosticCollection | undefined;
   codeQualityReview: DiagnosticCollection | undefined;
+
+  registerHoverProviders(codeSecurityHoverAdapter: IHoverAdapter, codeQualityHoverAdapter: IHoverAdapter): void;
+  registerCodeActionProviders(
+    codeSecurityCodeActionsProvider: Disposable,
+    codeQualityCodeActionsProvider: Disposable,
+  ): void;
+
   setAnalysisResults(results: AnalysisResultLegacy): void;
   getAnalysisResults(): Readonly<ISnykCodeResult>;
   findSuggestion(diagnostic: vscode.Diagnostic): Readonly<ICodeSuggestion | undefined>;
@@ -52,4 +60,5 @@ export interface ISnykCodeAnalyzer extends Disposable {
   checkFullSuggestion(suggestion: completeFileSuggestionType): boolean;
   createReviewResults(): void;
   updateReviewResultsPositions(extension: IExtension, updatedFile: openedTextEditorType): Promise<void>;
+  refreshDiagnostics(): void;
 }

--- a/src/snyk/snykCode/utils/analysisUtils.ts
+++ b/src/snyk/snykCode/utils/analysisUtils.ts
@@ -22,16 +22,15 @@ import {
 import { completeFileSuggestionType, ICodeSuggestion, ISnykCodeResult, openedTextEditorType } from '../interfaces';
 import { IssuePlacementPosition, IssueUtils } from './issueUtils';
 
-export const createSnykSeveritiesMap = (): { [x: number]: { name: DiagnosticSeverity; show: boolean } } => {
+export const createSnykSeveritiesMap = (): { [x: number]: { name: DiagnosticSeverity } } => {
   const { information, error, warning } = SNYK_SEVERITIES;
 
   return {
     [information]: {
       name: DiagnosticSeverity.Information,
-      show: true,
     },
-    [warning]: { name: DiagnosticSeverity.Warning, show: true },
-    [error]: { name: DiagnosticSeverity.Error, show: true },
+    [warning]: { name: DiagnosticSeverity.Warning },
+    [error]: { name: DiagnosticSeverity.Error },
   };
 };
 

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
@@ -179,7 +179,7 @@ export class CodeSuggestionWebviewProvider
       ['arrow-left-light', 'svg'],
       ['arrow-right-light', 'svg'],
     ].reduce<Record<string, string>>((accumulator: Record<string, string>, [name, ext]) => {
-      const uri = this.getWebViewUri('media', 'images', `${name}.${ext}`); // todo move to media folder
+      const uri = this.getWebViewUri('media', 'images', `${name}.${ext}`);
       if (!uri) throw new Error('Image missing.');
       accumulator[name] = uri.toString();
       return accumulator;

--- a/src/test/unit/common/configuration.test.ts
+++ b/src/test/unit/common/configuration.test.ts
@@ -8,6 +8,7 @@ import { ADVANCED_CUSTOM_ENDPOINT, FEATURES_PREVIEW_SETTING } from '../../../sny
 import SecretStorageAdapter from '../../../snyk/common/vscode/secretStorage';
 import { ExtensionContext } from '../../../snyk/common/vscode/types';
 import { IVSCodeWorkspace } from '../../../snyk/common/vscode/workspace';
+import { stubWorkspaceConfiguration } from '../mocks/workspace.mock';
 
 suite('Configuration', () => {
   let workspaceStub: IVSCodeWorkspace;
@@ -161,13 +162,4 @@ suite('Configuration', () => {
 
     deepStrictEqual(configuration.getPreviewFeatures(), previewFeatures);
   });
-
-  function stubWorkspaceConfiguration<T>(configSetting: string, returnValue: T | undefined): IVSCodeWorkspace {
-    return {
-      getConfiguration: (identifier: string, key: string) => {
-        if (`${identifier}.${key}` === configSetting) return returnValue;
-        return undefined;
-      },
-    } as IVSCodeWorkspace;
-  }
 });

--- a/src/test/unit/mocks/workspace.mock.ts
+++ b/src/test/unit/mocks/workspace.mock.ts
@@ -1,0 +1,10 @@
+import { IVSCodeWorkspace } from '../../../snyk/common/vscode/workspace';
+
+export function stubWorkspaceConfiguration<T>(configSetting: string, returnValue: T | undefined): IVSCodeWorkspace {
+  return {
+    getConfiguration: (identifier: string, key: string) => {
+      if (`${identifier}.${key}` === configSetting) return returnValue;
+      return undefined;
+    },
+  } as IVSCodeWorkspace;
+}

--- a/src/test/unit/snykCode/analyzer/analyzer.test.ts
+++ b/src/test/unit/snykCode/analyzer/analyzer.test.ts
@@ -1,0 +1,89 @@
+import { AnalysisSeverity } from '@snyk/code-client';
+import { strictEqual } from 'assert';
+import sinon from 'sinon';
+import { Configuration } from '../../../../snyk/common/configuration/configuration';
+import {
+  CODE_QUALITY_ENABLED_SETTING,
+  CODE_SECURITY_ENABLED_SETTING,
+  SEVERITY_FILTER_SETTING,
+} from '../../../../snyk/common/constants/settings';
+import SnykCodeAnalyzer from '../../../../snyk/snykCode/analyzer/analyzer';
+import { stubWorkspaceConfiguration } from '../../mocks/workspace.mock';
+
+suite('Snyk Code Analyzer', () => {
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('Security Issue is visible if Code Security is enabled', () => {
+    const securityIssue = true;
+    const workspace = stubWorkspaceConfiguration(CODE_SECURITY_ENABLED_SETTING, true);
+    const config = new Configuration({}, workspace);
+
+    strictEqual(SnykCodeAnalyzer.isIssueVisible(config, securityIssue, AnalysisSeverity.critical), true);
+  });
+
+  test('Security Issue is not visible if Code Security is disabled', () => {
+    const securityIssue = true;
+    const workspace = stubWorkspaceConfiguration(CODE_SECURITY_ENABLED_SETTING, false);
+    const config = new Configuration({}, workspace);
+
+    strictEqual(SnykCodeAnalyzer.isIssueVisible(config, securityIssue, AnalysisSeverity.critical), false);
+  });
+
+  test('Quality Issue is visible if Code Quality is enabled', () => {
+    const securityIssue = false;
+    const workspace = stubWorkspaceConfiguration(CODE_QUALITY_ENABLED_SETTING, true);
+    const config = new Configuration({}, workspace);
+
+    strictEqual(SnykCodeAnalyzer.isIssueVisible(config, securityIssue, AnalysisSeverity.critical), true);
+  });
+
+  test('Quality Issue is not visible if Code Quality is disabled', () => {
+    const securityIssue = false;
+    const workspace = stubWorkspaceConfiguration(CODE_QUALITY_ENABLED_SETTING, false);
+    const config = new Configuration({}, workspace);
+
+    strictEqual(SnykCodeAnalyzer.isIssueVisible(config, securityIssue, AnalysisSeverity.critical), false);
+  });
+
+  test('Critical severity issue respects high severity filter', () => {
+    const filter = {
+      critical: false,
+      high: false,
+    };
+    const workspace = stubWorkspaceConfiguration(SEVERITY_FILTER_SETTING, filter);
+    const config = new Configuration({}, workspace);
+
+    strictEqual(SnykCodeAnalyzer.isIssueVisible(config, true, AnalysisSeverity.critical), false);
+
+    filter.high = true;
+    strictEqual(SnykCodeAnalyzer.isIssueVisible(config, true, AnalysisSeverity.critical), true);
+  });
+
+  test('Warning severity issue respects medium severity filter', () => {
+    const filter = {
+      medium: false,
+    };
+    const workspace = stubWorkspaceConfiguration(SEVERITY_FILTER_SETTING, filter);
+    const config = new Configuration({}, workspace);
+
+    strictEqual(SnykCodeAnalyzer.isIssueVisible(config, true, AnalysisSeverity.warning), false);
+
+    filter.medium = true;
+    strictEqual(SnykCodeAnalyzer.isIssueVisible(config, true, AnalysisSeverity.warning), true);
+  });
+
+  test('Info severity issue is not visible if low severity is disabled', () => {
+    const filter = {
+      low: false,
+    };
+    const workspace = stubWorkspaceConfiguration(SEVERITY_FILTER_SETTING, filter);
+    const config = new Configuration({}, workspace);
+
+    strictEqual(SnykCodeAnalyzer.isIssueVisible(config, true, AnalysisSeverity.info), false);
+
+    filter.low = true;
+    strictEqual(SnykCodeAnalyzer.isIssueVisible(config, true, AnalysisSeverity.info), true);
+  });
+});


### PR DESCRIPTION
- Remove diagnostics when Snyk Code is disabled
- Update diagnostics when filters are applied
- Refactor analyzer.ts to be unit-testable

As part of addressing this issue I've noticed that Open Source Security still reports diagnostics when OSS is disabled. I've added [another ticket](https://snyksec.atlassian.net/browse/ROAD-834) for this.