### PR TITLE
feat: add request id to reporting

### DIFF
--- a/src/snyk/common/error/errorHandler.ts
+++ b/src/snyk/common/error/errorHandler.ts
@@ -2,7 +2,7 @@ import { ILoadingBadge } from '../../base/views/loadingBadge';
 import { SNYK_CONTEXT, SNYK_ERROR_CODES } from '../constants/views';
 import { ILog } from '../logger/interfaces';
 import { IContextService } from '../services/contextService';
-import { ErrorReporter } from './errorReporter';
+import { ErrorReporter, Tags } from './errorReporter';
 
 /**
  * General error handler.
@@ -25,13 +25,13 @@ export class ErrorHandler {
   /**
    * Should be used to log locally and report error event remotely.
    */
-  static handle(error: Error | unknown, logger: ILog, message?: string): void {
+  static handle(error: Error | unknown, logger: ILog, message?: string, tags?: Tags): void {
     const errorStr = this.stringifyError(error);
     logger.error(message ? `${message}. ${errorStr}` : errorStr);
-    ErrorReporter.capture(error);
+    ErrorReporter.capture(error, tags);
   }
 
-  static stringifyError(error: Error | unknown) {
+  static stringifyError(error: Error | unknown): string {
     return JSON.stringify(error, Object.getOwnPropertyNames(error));
   }
 }

--- a/src/snyk/snykCode/codeService.ts
+++ b/src/snyk/snykCode/codeService.ts
@@ -198,18 +198,18 @@ export class SnykCodeService extends AnalysisStatusProvider implements ISnykCode
       }
     } catch (err) {
       this.temporaryFailed = true;
-      await this.errorHandler.processError(err, undefined, () => {
+      await this.errorHandler.processError(err, undefined, requestId, () => {
         this.errorEncountered(requestId);
       });
 
-      if (enabledFeatures?.codeSecurityEnabled) {
+      if (enabledFeatures?.codeSecurityEnabled && this.errorHandler.connectionRetryLimitExhausted) {
         this.analytics.logAnalysisIsReady({
           ide: IDE_NAME,
           analysisType: 'Snyk Code Security',
           result: 'Error',
         });
       }
-      if (enabledFeatures?.codeQualityEnabled) {
+      if (enabledFeatures?.codeQualityEnabled && this.errorHandler.connectionRetryLimitExhausted) {
         this.analytics.logAnalysisIsReady({
           ide: IDE_NAME,
           analysisType: 'Snyk Code Quality',

--- a/src/test/unit/base/services/authenticationService.test.ts
+++ b/src/test/unit/base/services/authenticationService.test.ts
@@ -67,6 +67,7 @@ suite('AuthenticationService', () => {
       {
         processError: sinon.fake(),
         resetTransientErrors: sinon.fake(),
+        connectionRetryLimitExhausted: false,
       } as ISnykCodeErrorHandler,
     );
 
@@ -133,6 +134,7 @@ suite('AuthenticationService', () => {
       {
         processError: sinon.fake(),
         resetTransientErrors: sinon.fake(),
+        connectionRetryLimitExhausted: false,
       } as ISnykCodeErrorHandler,
     );
     sinon.replace(windowMock, 'showInputBox', sinon.fake.returns(''));
@@ -154,6 +156,7 @@ suite('AuthenticationService', () => {
       {
         processError: sinon.fake(),
         resetTransientErrors: sinon.fake(),
+        connectionRetryLimitExhausted: false,
       } as ISnykCodeErrorHandler,
     );
     sinon.replace(windowMock, 'showInputBox', sinon.fake.returns('token-value'));

--- a/src/test/unit/common/error/errorReporter.test.ts
+++ b/src/test/unit/common/error/errorReporter.test.ts
@@ -2,7 +2,7 @@ import { strictEqual } from 'assert';
 import sentryTestkit from 'sentry-testkit';
 import { IConfiguration } from '../../../../snyk/common/configuration/configuration';
 import { SnykConfiguration } from '../../../../snyk/common/configuration/snykConfiguration';
-import { ErrorReporter } from '../../../../snyk/common/error/errorReporter';
+import { ErrorReporter, TagKeys } from '../../../../snyk/common/error/errorReporter';
 import { envMock } from '../../mocks/env.mock';
 import { LoggerMock } from '../../mocks/logger.mock';
 
@@ -31,6 +31,22 @@ suite('ErrorReporter', () => {
 
     setTimeout(() => {
       strictEqual(testkit.reports().length, 1);
+      strictEqual(testkit.reports()[0].tags.code_request_id, undefined);
+      strictEqual(testkit.isExist(error), true);
+      done();
+    }, 10);
+  });
+
+  test('Reports error with local scope', done => {
+    configuration.shouldReportErrors = true;
+    const error = new Error('test error');
+    const requestId = '123456789';
+
+    ErrorReporter.capture(error, { [TagKeys.CodeRequestId]: requestId });
+
+    setTimeout(() => {
+      strictEqual(testkit.reports().length, 1);
+      strictEqual(testkit.reports()[0].tags.code_request_id, requestId);
       strictEqual(testkit.isExist(error), true);
       done();
     }, 10);


### PR DESCRIPTION
- Adding `requestId` to error reporting. Follow pattern described here https://blog.sentry.io/2019/01/31/using-nginx-sentry-trace-errors-logs
- Moving analytics event reporting to once the retry mechanism is exhausted.

This should enable for us to correlate the events we see during error reporting and essentially thread it through the system.