### PR TITLE
fix: token retrieval error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Snyk Security - Code and Open Source Dependencies Changelog
 
+## [1.2.16]
+
+### Fixed
+
+- "Error: Cannot get password" appearing during retrieval of the token from secret
+  storage.
+
 ## [1.2.15]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snyk-vulnerability-scanner",
   "//": "Changing display name requires change in general.ts",
   "displayName": "Snyk Security - Code and Open Source Dependencies",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "description": "Easily find and fix vulnerabilities in both your code and open source dependencies with fast and accurate scans.",
   "icon": "media/images/readme/snyk_extension_icon.png",
   "publisher": "snyk-security",

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -167,7 +167,12 @@ export class Configuration implements IConfiguration {
   }
 
   async getToken(): Promise<string | undefined> {
-    return SecretStorageAdapter.instance.get(SNYK_TOKEN_KEY);
+    try {
+      return SecretStorageAdapter.instance.get(SNYK_TOKEN_KEY);
+    } catch (e) {
+      // if the token cannot be parsed then clear the token
+      await this.clearToken();
+    }
   }
 
   get snykCodeToken(): Promise<string | undefined> {

--- a/src/snyk/common/services/learnService.ts
+++ b/src/snyk/common/services/learnService.ts
@@ -104,8 +104,6 @@ export class LearnService {
         return null;
       }
 
-      console.log(params);
-
       if (!params) {
         return null;
       }


### PR DESCRIPTION
Signed-off-by: Aayush Attri <aayush.attri@snyk.io>

### Description

The token retrieval method within `SecretStorage` class throws an error when the token cannot be parsed which creates a generic error that we want to handle for.

Also removing a `console.log` within `src/snyk/common/services/learnService.ts`

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
