### PR TITLE
fix: inter-file code flow in diagnostics [ROAD-864]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - "Error: Cannot get password" appearing during retrieval of the token from secret
   storage.
 - Cached Snyk Learn links being opened when clicking on "Learn about this vulnerability".
+- Snyk Code inter-file issues linking only to the main file where issue occurs.
 
 ## [1.2.15]
 

--- a/src/snyk/snykCode/analyzer/analyzer.ts
+++ b/src/snyk/snykCode/analyzer/analyzer.ts
@@ -15,6 +15,7 @@ import {
   Uri,
 } from '../../common/vscode/types';
 import { IUriAdapter } from '../../common/vscode/uri';
+import { IVSCodeWorkspace } from '../../common/vscode/workspace';
 import {
   DIAGNOSTICS_CODE_QUALITY_COLLECTION_NAME,
   DIAGNOSTICS_CODE_SECURITY_COLLECTION_NAME,
@@ -52,9 +53,10 @@ class SnykCodeAnalyzer implements ISnykCodeAnalyzer {
   private readonly diagnosticSuggestion = new Map<Diagnostic, ICodeSuggestion>();
 
   public constructor(
-    readonly logger: ILog,
-    readonly languages: IVSCodeLanguages,
-    readonly analytics: IAnalytics,
+    private readonly logger: ILog,
+    private readonly languages: IVSCodeLanguages,
+    private readonly workspace: IVSCodeWorkspace,
+    private readonly analytics: IAnalytics,
     private readonly errorHandler: ISnykCodeErrorHandler,
     private readonly uriAdapter: IUriAdapter,
     private readonly configuration: IConfiguration,
@@ -141,7 +143,14 @@ class SnykCodeAnalyzer implements ISnykCodeAnalyzer {
         : DIAGNOSTICS_CODE_QUALITY_COLLECTION_NAME,
       // issues markers can be in issuesPositions as prop 'markers',
       ...(issuePositions.markers && {
-        relatedInformation: createIssueRelatedInformation(issuePositions.markers, fileUri, message, this.languages),
+        relatedInformation: createIssueRelatedInformation(
+          issuePositions.markers,
+          fileUri.path,
+          message,
+          this.languages,
+          this.workspace,
+          this.uriAdapter,
+        ),
       }),
     };
   }

--- a/src/snyk/snykCode/codeService.ts
+++ b/src/snyk/snykCode/codeService.ts
@@ -90,7 +90,15 @@ export class SnykCodeService extends AnalysisStatusProvider implements ISnykCode
     private readonly learnService: LearnService,
   ) {
     super();
-    this.analyzer = new SnykCodeAnalyzer(logger, languages, analytics, errorHandler, this.uriAdapter, this.config);
+    this.analyzer = new SnykCodeAnalyzer(
+      logger,
+      languages,
+      workspace,
+      analytics,
+      errorHandler,
+      this.uriAdapter,
+      this.config,
+    );
     this.registerAnalyzerProviders(this.analyzer);
 
     this.falsePositiveProvider = new FalsePositiveWebviewProvider(
@@ -108,6 +116,7 @@ export class SnykCodeService extends AnalysisStatusProvider implements ISnykCode
       extensionContext,
       this.logger,
       languages,
+      workspace,
       codeSettings,
       this.learnService,
     );

--- a/src/snyk/snykCode/falsePositive/falsePositive.ts
+++ b/src/snyk/snykCode/falsePositive/falsePositive.ts
@@ -1,7 +1,7 @@
 import { Marker } from '@snyk/code-client';
-import path from 'path';
 import { IVSCodeWorkspace } from '../../common/vscode/workspace';
 import { completeFileSuggestionType } from '../interfaces';
+import { getAbsoluteMarkerFilePath } from '../utils/analysisUtils';
 import { IssueUtils } from '../utils/issueUtils';
 
 export class FalsePositive {
@@ -35,29 +35,10 @@ export class FalsePositive {
   private getFiles(markers: Marker[], uri: string): Set<string> {
     const markerPositions = markers.flatMap(marker => marker.pos);
     const filesArray = markerPositions.map(markerPosition =>
-      FalsePositive.getAbsoluteMarkerFilePath(this.workspace, markerPosition.file, uri),
+      getAbsoluteMarkerFilePath(this.workspace, markerPosition.file, uri),
     );
 
     return new Set(filesArray);
-  }
-
-  static getAbsoluteMarkerFilePath(
-    workspace: IVSCodeWorkspace,
-    markerFilePath: string,
-    suggestionFilePath: string,
-  ): string {
-    if (!markerFilePath) {
-      // If no filePath reported, use suggestion file path as marker's path. Suggestion path is always absolute.
-      return suggestionFilePath;
-    }
-
-    const workspaceFolders = workspace.getWorkspaceFolders();
-    if (workspaceFolders.length > 1) {
-      return markerFilePath;
-    }
-
-    // The Snyk Code analysis reported marker path is relative when in workspace with a single folder, thus need to convert to an absolute
-    return path.resolve(workspaceFolders[0], markerFilePath);
   }
 
   /**

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
@@ -67,11 +67,12 @@
       },
     });
   }
-  function getSuggestionPosition(range?: { rows: any; cols: any }) {
+  function getSuggestionPosition(position?: { file: string; rows: any; cols: any }) {
     return {
-      uri: suggestion.uri,
-      rows: range ? range.rows : suggestion.rows,
-      cols: range ? range.cols : suggestion.cols,
+      uri: position?.file ?? suggestion.uri,
+      rows: position ? position.rows : suggestion.rows,
+      cols: position ? position.cols : suggestion.cols,
+      suggestionUri: suggestion.uri,
     };
   }
   function previousExample() {

--- a/src/test/unit/mocks/languages.mock.ts
+++ b/src/test/unit/mocks/languages.mock.ts
@@ -1,0 +1,54 @@
+import sinon from 'sinon';
+import { IVSCodeLanguages } from '../../../snyk/common/vscode/languages';
+import { DiagnosticRelatedInformation, Position, Range as vsRange, Uri } from '../../../snyk/common/vscode/types';
+
+export const languagesMock = {
+  createDiagnostic: sinon.fake(),
+  createDiagnosticCollection: sinon.fake(),
+  registerCodeActionsProvider: sinon.fake(),
+  registerHoverProvider: sinon.fake(),
+
+  createDiagnosticRelatedInformation(
+    uri: Uri,
+    rangeOrPosition: vsRange | Position,
+    message: string,
+  ): DiagnosticRelatedInformation {
+    const range = isRange(rangeOrPosition)
+      ? rangeOrPosition
+      : ({
+          start: {
+            line: rangeOrPosition.line,
+            character: rangeOrPosition.character,
+          },
+          end: {
+            line: rangeOrPosition.line,
+            character: rangeOrPosition.character,
+          },
+        } as unknown as vsRange);
+
+    return {
+      message,
+      location: {
+        uri,
+        range,
+      },
+    };
+  },
+
+  createRange(startLine: number, startCharacter: number, endLine: number, endCharacter: number): vsRange {
+    return {
+      start: {
+        line: startLine,
+        character: startCharacter,
+      } as unknown as Position,
+      end: {
+        line: endLine,
+        character: endCharacter,
+      } as unknown as Position,
+    } as unknown as vsRange;
+  },
+} as IVSCodeLanguages;
+
+function isRange(pet: vsRange | Position): pet is vsRange {
+  return (pet as vsRange).start !== undefined;
+}

--- a/src/test/unit/mocks/uri.mock.ts
+++ b/src/test/unit/mocks/uri.mock.ts
@@ -1,0 +1,18 @@
+import { Uri } from '../../../snyk/common/vscode/types';
+import { IUriAdapter } from '../../../snyk/common/vscode/uri';
+
+export class UriAdapterMock implements IUriAdapter {
+  file(path: string): Uri {
+    return {
+      path: path,
+    } as Uri;
+  }
+
+  parse(path: string): Uri {
+    return {
+      path: path,
+    } as Uri;
+  }
+}
+
+export const uriAdapterMock = new UriAdapterMock();

--- a/src/test/unit/mocks/workspace.mock.ts
+++ b/src/test/unit/mocks/workspace.mock.ts
@@ -1,3 +1,5 @@
+import * as os from 'os';
+import path from 'path';
 import { IVSCodeWorkspace } from '../../../snyk/common/vscode/workspace';
 
 export function stubWorkspaceConfiguration<T>(configSetting: string, returnValue: T | undefined): IVSCodeWorkspace {
@@ -15,4 +17,4 @@ export const workspaceMock = {
   },
 } as IVSCodeWorkspace;
 
-export const workspaceFolder = '/Users/snyk/project';
+export const workspaceFolder = path.join(os.homedir(), 'snyk/project');

--- a/src/test/unit/mocks/workspace.mock.ts
+++ b/src/test/unit/mocks/workspace.mock.ts
@@ -8,3 +8,11 @@ export function stubWorkspaceConfiguration<T>(configSetting: string, returnValue
     },
   } as IVSCodeWorkspace;
 }
+
+export const workspaceMock = {
+  getWorkspaceFolders() {
+    return [workspaceFolder];
+  },
+} as IVSCodeWorkspace;
+
+export const workspaceFolder = '/Users/snyk/project';

--- a/src/test/unit/snykCode/falsePositive/falsePositive.test.ts
+++ b/src/test/unit/snykCode/falsePositive/falsePositive.test.ts
@@ -23,53 +23,6 @@ suite('False Positive', () => {
     throws(() => new FalsePositive(workspace, {} as completeFileSuggestionType));
   });
 
-  test('Returns correct absolute path if no marker file path provided', () => {
-    // arrange
-    const suggestionFilePath = '/Users/snyk/goof/test.js';
-    const markerFilePath = '';
-
-    // act
-    const absoluteFilePath = FalsePositive.getAbsoluteMarkerFilePath(workspace, markerFilePath, suggestionFilePath);
-
-    // assert
-    strictEqual(absoluteFilePath, suggestionFilePath);
-  });
-
-  test('Returns correct absolute path if in multi-folder workspace', () => {
-    // arrange
-    const suggestionFilePath = '/Users/snyk/goof/test.js';
-    const markerFilePath = '/Users/snyk/goof/test2.js';
-    workspace = {
-      getWorkspaceFolders: () => ['/Users/snyk/goof1', '/Users/snyk/goof2'],
-    } as unknown as IVSCodeWorkspace;
-
-    // act
-    const absoluteFilePath = FalsePositive.getAbsoluteMarkerFilePath(workspace, markerFilePath, suggestionFilePath);
-
-    // assert
-    strictEqual(absoluteFilePath, markerFilePath);
-  });
-
-  test('Returns correct absolute path if in single-folder workspace', () => {
-    // arrange
-    const suggestionFilePath = '/Users/snyk/goof/test.js';
-    const relativeMarkerFilePath = 'test2.js';
-    const workspaceFolder = '/Users/snyk/goof1';
-    workspace = {
-      getWorkspaceFolders: () => [workspaceFolder],
-    } as unknown as IVSCodeWorkspace;
-
-    // act
-    const absoluteFilePath = FalsePositive.getAbsoluteMarkerFilePath(
-      workspace,
-      relativeMarkerFilePath,
-      suggestionFilePath,
-    );
-
-    // assert
-    strictEqual(absoluteFilePath, path.resolve(workspaceFolder, relativeMarkerFilePath));
-  });
-
   test('Returns correct generated content', async () => {
     // arrange
     const filePath = os.platform() === 'win32' ? 'C:\\Users\\snyk\\goof\\test.js' : '/Users/snyk/goof/test.js';

--- a/src/test/unit/snykCode/utils/analysisUtils.test.ts
+++ b/src/test/unit/snykCode/utils/analysisUtils.test.ts
@@ -1,16 +1,29 @@
+import { Marker } from '@snyk/code-client';
+import { deepStrictEqual, strictEqual } from 'assert';
+import path from 'path';
 import sinon from 'sinon';
 import { IVSCodeLanguages } from '../../../../snyk/common/vscode/languages';
-import { createIssueRange } from '../../../../snyk/snykCode/utils/analysisUtils';
+import { IVSCodeWorkspace } from '../../../../snyk/common/vscode/workspace';
+import {
+  createIssueRange,
+  createIssueRelatedInformation,
+  getAbsoluteMarkerFilePath,
+} from '../../../../snyk/snykCode/utils/analysisUtils';
 import { IssuePlacementPosition } from '../../../../snyk/snykCode/utils/issueUtils';
+import { languagesMock } from '../../mocks/languages.mock';
+import { uriAdapterMock } from '../../mocks/uri.mock';
+import { workspaceFolder, workspaceMock } from '../../mocks/workspace.mock';
 
 suite('Snyk Code Analysis Utils', () => {
   const createRangeMock = sinon.mock();
   let languages: IVSCodeLanguages;
+  let workspace: IVSCodeWorkspace;
 
   setup(() => {
     languages = {
       createRange: createRangeMock,
     } as unknown as IVSCodeLanguages;
+    workspace = {} as IVSCodeWorkspace;
   });
 
   teardown(() => createRangeMock.reset());
@@ -47,5 +60,100 @@ suite('Snyk Code Analysis Utils', () => {
     createIssueRange(position, languages);
 
     sinon.assert.calledOnceWithExactly(createRangeMock, 0, 0, 0, 0);
+  });
+
+  test('Returns correct absolute path if no marker file path provided', () => {
+    // arrange
+    const suggestionFilePath = '/Users/snyk/goof/test.js';
+    const markerFilePath = '';
+
+    // act
+    const absoluteFilePath = getAbsoluteMarkerFilePath(workspace, markerFilePath, suggestionFilePath);
+
+    // assert
+    strictEqual(absoluteFilePath, suggestionFilePath);
+  });
+
+  test('Returns correct absolute path if in multi-folder workspace', () => {
+    // arrange
+    const suggestionFilePath = '/Users/snyk/goof/test.js';
+    const markerFilePath = '/Users/snyk/goof/test2.js';
+    workspace = {
+      getWorkspaceFolders: () => ['/Users/snyk/goof1', '/Users/snyk/goof2'],
+    } as unknown as IVSCodeWorkspace;
+
+    // act
+    const absoluteFilePath = getAbsoluteMarkerFilePath(workspace, markerFilePath, suggestionFilePath);
+
+    // assert
+    strictEqual(absoluteFilePath, markerFilePath);
+  });
+
+  test('Returns correct absolute path if in single-folder workspace', () => {
+    // arrange
+    const suggestionFilePath = '/Users/snyk/goof/test.js';
+    const relativeMarkerFilePath = 'test2.js';
+    const workspaceFolder = '/Users/snyk/goof1';
+    workspace = {
+      getWorkspaceFolders: () => [workspaceFolder],
+    } as unknown as IVSCodeWorkspace;
+
+    // act
+    const absoluteFilePath = getAbsoluteMarkerFilePath(workspace, relativeMarkerFilePath, suggestionFilePath);
+
+    // assert
+    strictEqual(absoluteFilePath, path.resolve(workspaceFolder, relativeMarkerFilePath));
+  });
+
+  test('Creates correct related information for inter-file issues', () => {
+    const file1Uri = 'file1.js';
+    const file2Uri = 'file2.js';
+
+    const markers: Marker[] = [
+      {
+        msg: [0, 16],
+        pos: [
+          {
+            file: file1Uri,
+            rows: [1, 1],
+            cols: [1, 1],
+          },
+          {
+            file: file2Uri,
+            rows: [2, 2],
+            cols: [10, 10],
+          },
+        ],
+      },
+    ];
+
+    const message =
+      'Unsanitized input from data from a remote resource flows into bypassSecurityTrustHtml, where it is used to render an HTML page returned to the user. This may result in a Cross-Site Scripting attack (XSS).';
+
+    const information = createIssueRelatedInformation(
+      markers,
+      file2Uri,
+      message,
+      languagesMock,
+      workspaceMock,
+      uriAdapterMock,
+    );
+
+    deepStrictEqual(information, [
+      {
+        message: 'Unsanitized input',
+        location: {
+          uri: { path: path.join(workspaceFolder, file1Uri) },
+          range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+        },
+      },
+      {
+        message: 'Unsanitized input',
+        location: {
+          uri: { path: path.join(workspaceFolder, file2Uri) },
+          range: { start: { line: 1, character: 9 }, end: { line: 1, character: 10 } },
+        },
+      },
+    ]);
   });
 });


### PR DESCRIPTION
### Description

Fixes Snyk Code inter-file issue display that don't link to the markers' reported files currently. The fix is applied to related diagnostics and fixes navigation from the Code suggestion webview.

I believe we should introduce Dependency Injection quite soon, since constructor injections become quite verbose now. 

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

<img width="1524" alt="Screenshot 2022-04-25 at 10 20 34" src="https://user-images.githubusercontent.com/2239563/165049247-2c4527a8-e2f4-402e-8abd-429583e64736.png">

