### PR TITLE
fix: readme sync img urls and gitbook hints [ROAD-775]

### DIFF
--- a/.github/workflows/readme-sync.yaml
+++ b/.github/workflows/readme-sync.yaml
@@ -19,6 +19,12 @@ jobs:
           git -C ./vscode-extension checkout -b docs/automatic-gitbook-update
 
           cp ./docs/docs/ide-tools/visual-studio-code-extension-for-snyk-code.md ./vscode-extension/README.md
+          sed -i \
+              -e "s|../.gitbook/assets/|https://github.com/snyk/user-docs/raw/$(git -C ./docs rev-parse HEAD)/docs/.gitbook/assets/|g" \
+              ./vscode-extension/README.md
+          sed -i \
+              -E 's|(\{%.*%\})||g' \
+              ./vscode-extension/README.md
 
           if [[ $(git -C ./vscode-extension status --porcelain) ]]; then
             echo "Documentation changes detected"
@@ -29,7 +35,7 @@ jobs:
             git push --force --set-upstream origin docs/automatic-gitbook-update
             if [[ ! $(gh pr view docs/automatic-gitbook-update 2>&1 | grep -q "no open pull requests";) ]]; then
               echo "Creating PR"
-              gh pr create --title="Synchronizing README from user-docs" --body="Automatic PR controlled by GitHub Action" --head docs/automatic-gitbook-update
+              gh pr create --title="Synchronizing README from user-docs" --body="Automatic PR controlled by GitHub Action. Please sign the commit before merging." --head docs/automatic-gitbook-update
             fi
             echo "PR exists, pushed changes to it."
           else


### PR DESCRIPTION
### Description
- Readme sync to clean up Gitbook hints in markdown.
- Readme sync to provide correct urls

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

<img width="861" alt="Screenshot 2022-05-13 at 12 28 45" src="https://user-images.githubusercontent.com/2239563/168265438-07096193-b93b-463d-9f89-bf512bd1cf62.png">

