### PR TITLE
fix: broken images in readme sync

### DIFF
--- a/.github/workflows/readme-sync.yaml
+++ b/.github/workflows/readme-sync.yaml
@@ -23,6 +23,9 @@ jobs:
               -e "s|../.gitbook/assets/|https://github.com/snyk/user-docs/raw/HEAD/docs/.gitbook/assets/|g" \
               ./vscode-extension/README.md
           sed -i \
+              -E "s|^\!\\[([[:alnum:][:space:][:punct:]]+)\]\(<([[:alnum:][:punct:]\-\.\/:[:space:]\(\)]+)>\)|<img src=\"\2\" alt=\"\1\" />|g" \
+              ./vscode-extension/README.md
+          sed -i \
               -E 's|(\{%.*%\})||g' \
               ./vscode-extension/README.md
 


### PR DESCRIPTION
### Description

This fixes broken images when syncing readme from Gitbook.

Marketplace Markdown doesn't support special characters `<>` when adding a Markdown image. E.g. the following Markdown will not be printed correctly and instead interpreted as plaintext:

`![Visual Studio Code extension results](<https://github.com/snyk/user-docs/raw/HEAD/docs/.gitbook/assets/image (76) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1).png>)`.

The fix is to replace these with <img> HTML tag using `sed` as part of readme sync. 

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing
