### PR TITLE
chore: refactored the way we handle lean query params [OWL-1436]

### DIFF
--- a/src/snyk/common/services/learnService.ts
+++ b/src/snyk/common/services/learnService.ts
@@ -109,7 +109,14 @@ export class LearnService {
       }
 
       const lessons = await this.requestLessons(params);
-
+      if (!lessons.length) {
+        return null;
+      } else {
+        const lesson = lessons[0];
+        const lessonURL = new URL(lesson.url);
+        lessonURL.searchParams.set('loc', 'ide');
+        return { ...lesson, url: lessonURL.toString() };
+      }
       return lessons.length > 0 ? lessons[0] : null;
     } catch (err) {
       ErrorHandler.handle(err, this.logger, 'Error getting Snyk Learn Lesson');

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
@@ -79,7 +79,7 @@ export class CodeSuggestionWebviewProvider
         if (lesson) {
           void this.panel.webview.postMessage({
             type: 'setLesson',
-            args: { url: `${lesson.url}?loc=ide`, title: learnMessages.lessonButtonTitle },
+            args: { url: lesson.url, title: learnMessages.lessonButtonTitle },
           });
         } else {
           void this.panel.webview.postMessage({

--- a/src/snyk/snykOss/views/suggestion/ossSuggestionWebviewProvider.ts
+++ b/src/snyk/snykOss/views/suggestion/ossSuggestionWebviewProvider.ts
@@ -46,7 +46,7 @@ export class OssSuggestionWebviewProvider extends WebviewProvider<OssIssueComman
         if (lesson) {
           void this.panel.webview.postMessage({
             type: 'setLesson',
-            args: { url: `${lesson.url}?loc=ide`, title: learnMessages.lessonButtonTitle },
+            args: { url: lesson.url, title: learnMessages.lessonButtonTitle },
           });
         } else {
           void this.panel.webview.postMessage({

--- a/src/test/unit/common/services/learnService.test.ts
+++ b/src/test/unit/common/services/learnService.test.ts
@@ -47,7 +47,7 @@ suite('LearnService', () => {
     test('getLesson - resolves a lesson', async () => {
       const stub = sinon.stub(axios, 'get').resolves({ data: { lessons: [lessonFixture] } });
       const lesson = await learnService.getLesson(ossIssueCommandArgFixture, OpenCommandIssueType.OssVulnerability);
-      deepStrictEqual(lesson, lessonFixture);
+      deepStrictEqual(lesson?.lessonId, lessonFixture.lessonId);
       deepStrictEqual(stub.getCall(0).args, [
         '/lessons/lookup-for-cta',
         {
@@ -85,7 +85,7 @@ suite('LearnService', () => {
     test('getLesson - resolves a lesson', async () => {
       const stub = sinon.stub(axios, 'get').resolves({ data: { lessons: [lessonFixture] } });
       const lesson = await learnService.getLesson(codeIssueCommandArgFixture, OpenCommandIssueType.CodeIssue);
-      deepStrictEqual(lesson, lessonFixture);
+      deepStrictEqual(lesson?.lessonId, lessonFixture.lessonId);
       deepStrictEqual(stub.getCall(0).args, [
         '/lessons/lookup-for-cta',
         {
@@ -112,6 +112,16 @@ suite('LearnService', () => {
   });
 
   suite('getLesson', () => {
+    test('adds loc=ide query parameter to lesson url', async () => {
+      const lessonFixtureWithQueryParams = {
+        ...lessonFixture,
+        url: 'https://example.com/?test=true',
+      };
+      sinon.stub(axios, 'get').resolves({ data: { lessons: [lessonFixtureWithQueryParams] } });
+      const lesson = await learnService.getLesson(ossIssueCommandArgFixture, OpenCommandIssueType.OssVulnerability);
+      deepStrictEqual(lesson?.url, `${lessonFixtureWithQueryParams.url}&loc=ide`);
+    });
+
     test('returns null if issueType is not known', async () => {
       const lesson = await learnService.getLesson(
         ossIssueCommandArgFixture,


### PR DESCRIPTION
### Description

- Reason for PR: Learn wants to be able to provide lesson url's with query parameters already injected, existing code does not support this functionality
- Refactor no changes in functionality, made existing code more flexible to correctly parse a lesson URL query parameter

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated (no need since no change)
- [ ] README.md updated, if user-facing  (no need since no change)

### Screenshots / GIFs

No visual change
