### PR TITLE
fix: create new bundle on 404 when extending bundle [ZEN-262]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Snyk Security - Code and Open Source Dependencies Changelog
 
+## [1.2.22]
+
+### Fixed
+
+- Snyk Code: failing when analysis bundle gets expired after its validity period.
+
 ## [1.2.21]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snyk-vulnerability-scanner",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snyk-vulnerability-scanner",
-      "version": "1.2.21",
+      "version": "1.2.22",
       "dependencies": {
         "@amplitude/experiment-node-server": "^1.0.2",
         "@babel/parser": "^7.12.11",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snyk-vulnerability-scanner",
   "//": "Changing display name requires change in general.ts",
   "displayName": "Snyk Security - Code and Open Source Dependencies",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "description": "Easily find and fix vulnerabilities in both your code and open source dependencies with fast and accurate scans.",
   "icon": "media/images/readme/snyk_extension_icon.png",
   "publisher": "snyk-security",

--- a/src/snyk/snykCode/analyzer/analyzer.ts
+++ b/src/snyk/snykCode/analyzer/analyzer.ts
@@ -242,7 +242,7 @@ class SnykCodeAnalyzer implements ISnykCodeAnalyzer {
     } catch (err) {
       await this.errorHandler.processError(err, {
         message: errorsLogs.updateReviewPositions,
-        bundleId: extension.snykCode.remoteBundle.fileBundle.bundleHash,
+        bundleId: extension.snykCode.remoteBundle?.fileBundle.bundleHash,
         data: {
           [updatedFile.fullPath]: updatedFile.contentChanges,
         },

--- a/src/snyk/snykCode/codeService.ts
+++ b/src/snyk/snykCode/codeService.ts
@@ -41,13 +41,14 @@ export interface ISnykCodeService extends AnalysisStatusProvider, Disposable {
   analyzer: ISnykCodeAnalyzer;
   analysisStatus: string;
   analysisProgress: string;
-  remoteBundle: FileAnalysis;
+  readonly remoteBundle: FileAnalysis | null;
   readonly suggestionProvider: ICodeSuggestionWebviewProvider;
   readonly falsePositiveProvider: IWebViewProvider<FalsePositiveWebviewModel>;
   hasError: boolean;
   hasTransientError: boolean;
 
   startAnalysis(paths: string[], manual: boolean, reportTriggeredEvent: boolean): Promise<void>;
+  clearBundle(): void;
   updateStatus(status: string, progress: string): void;
   errorEncountered(requestId: string): void;
   addChangedFile(filePath: string): void;
@@ -60,7 +61,7 @@ export interface ISnykCodeService extends AnalysisStatusProvider, Disposable {
 }
 
 export class SnykCodeService extends AnalysisStatusProvider implements ISnykCodeService {
-  remoteBundle: FileAnalysis;
+  remoteBundle: FileAnalysis | null;
   analyzer: ISnykCodeAnalyzer;
   readonly suggestionProvider: ICodeSuggestionWebviewProvider;
   readonly falsePositiveProvider: IWebViewProvider<FalsePositiveWebviewModel>;
@@ -238,6 +239,10 @@ export class SnykCodeService extends AnalysisStatusProvider implements ISnykCode
       this.analysisFinished();
       this.viewManagerService.refreshCodeAnalysisViews(enabledFeatures);
     }
+  }
+
+  clearBundle() {
+    this.remoteBundle = null;
   }
 
   private reportAnalysisIsTriggered(


### PR DESCRIPTION
### Description

[We don't retry](https://snyk.slack.com/archives/C01DGQ3AT09/p1657719637337439?thread_ts=1657718577.507199&cid=C01DGQ3AT09) on 404 on extendBundle from code-client. This leads to plenty of Sentry errors due to this. This fix should address the problem. 

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing