### PR TITLE
fix: git tag in release cron

### DIFF
--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -64,20 +64,19 @@ jobs:
 
       - name: Bump patch version
         id: patched-tag
-        uses: anothrnick/github-tag-action@1.35.0
+        uses: mathieudutour/github-tag-action@v6.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WITH_V: true
-          RELEASE_BRANCHES: main
-          DEFAULT_BUMP: patch
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_branches: main
+          default_bump: patch
 
       - name: Create release
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: ${{ steps.patched-tag.outputs.tag }}
-          tag_name: ${{ steps.patched-tag.outputs.tag }}
+          name: ${{ steps.patched-tag.outputs.new_tag }}
+          tag_name: ${{ steps.patched-tag.outputs.new_tag }}
           body: '${{ steps.extract-release-notes.outputs.release_notes }}'
           draft: false
           prerelease: false


### PR DESCRIPTION
### Description

VS Code release action fails when GitHub action is run as cron. It gets published to Marketplace, but the github release and tag aren’t created. Here’s an example: https://github.com/snyk/vscode-extension/runs/7519138993?check_suite_focus=true 

Reason: https://github.com/anothrNick/github-tag-action/issues/22
