### PR TITLE
fix: pass args via params, not envs for release version bump

### DIFF
--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Bump patch version
         id: patched-tag
         uses: mathieudutour/github-tag-action@v6.0
-        env:
+        with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: main
           default_bump: patch


### PR DESCRIPTION
### Description
Fixes `Error: Parameter token or opts.auth is required` during version bump version.

https://github.com/snyk/vscode-extension/runs/7562384992?check_suite_focus=true