### PR TITLE
fix: @types/vscode to match engine version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snyk-vulnerability-scanner",
-  "version": "1.2.24",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snyk-vulnerability-scanner",
-      "version": "1.2.24",
+      "version": "0.0.0",
       "dependencies": {
         "@amplitude/experiment-node-server": "^1.0.2",
         "@babel/parser": "^7.12.11",
@@ -47,7 +47,7 @@
         "@types/sinon": "^10.0.2",
         "@types/uuid": "^8.3.0",
         "@types/validate-npm-package-name": "^3.0.3",
-        "@types/vscode": "^1.48.0",
+        "@types/vscode": "^1.58.0",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "concurrently": "^7.0.0",
@@ -1845,9 +1845,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.55.0.tgz",
-      "integrity": "sha512-49hysH7jneTQoSC8TWbAi7nKK9Lc5osQNjmDHVosrcU8o3jecD9GrK0Qyul8q4aGPSXRfNGqIp9CBdb13akETg==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.70.0.tgz",
+      "integrity": "sha512-3/9Fz0F2eBgwciazc94Ien+9u1elnjFg9YAhvAb3qDy/WeFWD9VrOPU7CIytryOVUdbxus8uzL4VZYONA0gDtA==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -9605,9 +9605,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.55.0.tgz",
-      "integrity": "sha512-49hysH7jneTQoSC8TWbAi7nKK9Lc5osQNjmDHVosrcU8o3jecD9GrK0Qyul8q4aGPSXRfNGqIp9CBdb13akETg==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.70.0.tgz",
+      "integrity": "sha512-3/9Fz0F2eBgwciazc94Ien+9u1elnjFg9YAhvAb3qDy/WeFWD9VrOPU7CIytryOVUdbxus8uzL4VZYONA0gDtA==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -403,7 +403,7 @@
     "@types/sinon": "^10.0.2",
     "@types/uuid": "^8.3.0",
     "@types/validate-npm-package-name": "^3.0.3",
-    "@types/vscode": "^1.48.0",
+    "@types/vscode": "^1.58.0",
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",
     "concurrently": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snyk-vulnerability-scanner",
   "//": "Changing display name requires change in general.ts",
   "displayName": "Snyk Security - Code and Open Source Dependencies",
-  "version": "1.2.24",
+  "version": "0.0.0",
   "description": "Easily find and fix vulnerabilities in both your code and open source dependencies with fast and accurate scans.",
   "icon": "media/images/readme/snyk_extension_icon.png",
   "publisher": "snyk-security",

--- a/src/snyk/base/modules/baseSnykModule.ts
+++ b/src/snyk/base/modules/baseSnykModule.ts
@@ -15,6 +15,7 @@ import { IOpenerService, OpenerService } from '../../common/services/openerServi
 import { IViewManagerService, ViewManagerService } from '../../common/services/viewManagerService';
 import { User } from '../../common/user';
 import { ExtensionContext } from '../../common/vscode/extensionContext';
+import { IMarkdownStringAdapter, MarkdownStringAdapter } from '../../common/vscode/markdownString';
 import { vsCodeWorkspace } from '../../common/vscode/workspace';
 import { IWatcher } from '../../common/watchers/interfaces';
 import { ISnykCodeService } from '../../snykCode/codeService';
@@ -65,6 +66,8 @@ export default abstract class BaseSnykModule implements IBaseSnykModule {
   protected experimentService: ExperimentService;
   protected snykCodeErrorHandler: ISnykCodeErrorHandler;
 
+  protected markdownStringAdapter: IMarkdownStringAdapter;
+
   constructor() {
     this.statusBarItem = new SnykStatusBarItem();
     this.editorsWatcher = new SnykEditorsWatcher();
@@ -84,6 +87,7 @@ export default abstract class BaseSnykModule implements IBaseSnykModule {
     );
     this.codeSettings = new CodeSettings(this.snykApiClient, this.contextService, configuration, this.openerService);
     this.advisorApiClient = new AdvisorApiClient(configuration, Logger);
+    this.markdownStringAdapter = new MarkdownStringAdapter();
   }
 
   abstract runScan(): Promise<void>;

--- a/src/snyk/common/vscode/hover.ts
+++ b/src/snyk/common/vscode/hover.ts
@@ -1,12 +1,12 @@
 import * as vscode from 'vscode';
-import { Hover, MarkedString, Range } from './types';
+import { Hover, MarkdownString, Range } from './types';
 
 export interface IHoverAdapter {
-  create(contents: MarkedString | MarkedString[], range?: Range): Hover;
+  create(contents: MarkdownString | MarkdownString[], range?: Range): Hover;
 }
 
 export class HoverAdapter implements IHoverAdapter {
-  create(contents: MarkedString | MarkedString[], range?: Range): Hover {
+  create(contents: vscode.MarkdownString | MarkdownString[], range?: Range): Hover {
     return new vscode.Hover(contents, range);
   }
 }

--- a/src/snyk/common/vscode/window.ts
+++ b/src/snyk/common/vscode/window.ts
@@ -10,7 +10,7 @@ import { InputBoxOptions, TextDocument, TextDocumentShowOptions, TextEditor, Uri
 
 export interface IVSCodeWindow {
   getActiveTextEditor(): vscode.TextEditor | undefined;
-  getVisibleTextEditors(): TextEditor[];
+  getVisibleTextEditors(): readonly TextEditor[];
   showTextDocument(document: TextDocument, column?: ViewColumn, preserveFocus?: boolean): Promise<TextEditor>;
   showTextDocumentViaUri(uri: Uri, options?: TextDocumentShowOptions): Thenable<TextEditor>;
   createTextEditorDecorationType(options: vscode.DecorationRenderOptions): TextEditorDecorationType;
@@ -41,7 +41,7 @@ export class VSCodeWindow implements IVSCodeWindow {
     return vscode.window.activeTextEditor;
   }
 
-  getVisibleTextEditors(): TextEditor[] {
+  getVisibleTextEditors(): readonly TextEditor[] {
     return vscode.window.visibleTextEditors;
   }
 

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -54,7 +54,6 @@ import { vsCodeEnv } from './common/vscode/env';
 import { extensionContext } from './common/vscode/extensionContext';
 import { HoverAdapter } from './common/vscode/hover';
 import { vsCodeLanguages, VSCodeLanguages } from './common/vscode/languages';
-import { MarkdownStringAdapter } from './common/vscode/markdownString';
 import SecretStorageAdapter from './common/vscode/secretStorage';
 import { ThemeColorAdapter } from './common/vscode/theme';
 import { Range, Uri } from './common/vscode/types';
@@ -157,6 +156,7 @@ class SnykExtension extends SnykLib implements IExtension {
       new UriAdapter(),
       this.codeSettings,
       this.learnService,
+      this.markdownStringAdapter,
     );
     this.scanModeService = new ScanModeService(this.contextService, configuration, this.analytics);
 
@@ -304,7 +304,7 @@ class SnykExtension extends SnykLib implements IExtension {
       this.advisorApiClient,
       new ThemeColorAdapter(),
       new HoverAdapter(),
-      new MarkdownStringAdapter(),
+      this.markdownStringAdapter,
       configuration,
     );
     void this.advisorScoreDisposable.activate();

--- a/src/snyk/snykCode/analyzer/analyzer.ts
+++ b/src/snyk/snykCode/analyzer/analyzer.ts
@@ -6,6 +6,7 @@ import { ILog } from '../../common/logger/interfaces';
 import { errorsLogs } from '../../common/messages/errors';
 import { IHoverAdapter } from '../../common/vscode/hover';
 import { IVSCodeLanguages } from '../../common/vscode/languages';
+import { IMarkdownStringAdapter } from '../../common/vscode/markdownString';
 import {
   Diagnostic,
   DiagnosticCollection,
@@ -75,13 +76,17 @@ class SnykCodeAnalyzer implements ISnykCodeAnalyzer {
     this.disposables.push(codeSecurityCodeActionsProvider, codeQualityCodeActionsProvider);
   }
 
-  public registerHoverProviders(codeSecurityHoverAdapter: IHoverAdapter, codeQualityHoverAdapter: IHoverAdapter): void {
+  public registerHoverProviders(
+    codeSecurityHoverAdapter: IHoverAdapter,
+    codeQualityHoverAdapter: IHoverAdapter,
+    markdownStringAdapter: IMarkdownStringAdapter,
+  ): void {
     this.disposables.push(
-      new DisposableHoverProvider(this, this.logger, this.languages, this.analytics).register(
+      new DisposableHoverProvider(this, this.logger, this.languages, this.analytics, markdownStringAdapter).register(
         this.codeSecurityReview,
         codeSecurityHoverAdapter,
       ),
-      new DisposableHoverProvider(this, this.logger, this.languages, this.analytics).register(
+      new DisposableHoverProvider(this, this.logger, this.languages, this.analytics, markdownStringAdapter).register(
         this.codeQualityReview,
         codeQualityHoverAdapter,
       ),

--- a/src/snyk/snykCode/codeService.ts
+++ b/src/snyk/snykCode/codeService.ts
@@ -15,6 +15,7 @@ import { IWebViewProvider } from '../common/views/webviewProvider';
 import { ExtensionContext } from '../common/vscode/extensionContext';
 import { HoverAdapter } from '../common/vscode/hover';
 import { IVSCodeLanguages } from '../common/vscode/languages';
+import { IMarkdownStringAdapter } from '../common/vscode/markdownString';
 import { Diagnostic, Disposable } from '../common/vscode/types';
 import { IUriAdapter } from '../common/vscode/uri';
 import { IVSCodeWindow } from '../common/vscode/window';
@@ -89,6 +90,7 @@ export class SnykCodeService extends AnalysisStatusProvider implements ISnykCode
     private readonly uriAdapter: IUriAdapter,
     codeSettings: ICodeSettings,
     private readonly learnService: LearnService,
+    private readonly markdownStringAdapter: IMarkdownStringAdapter,
   ) {
     super();
     this.analyzer = new SnykCodeAnalyzer(
@@ -323,7 +325,7 @@ export class SnykCodeService extends AnalysisStatusProvider implements ISnykCode
   }
 
   private registerAnalyzerProviders(analyzer: ISnykCodeAnalyzer) {
-    analyzer.registerHoverProviders(new HoverAdapter(), new HoverAdapter());
+    analyzer.registerHoverProviders(new HoverAdapter(), new HoverAdapter(), this.markdownStringAdapter);
     analyzer.registerCodeActionProviders(
       new DisposableCodeActionsProvider(
         analyzer.codeSecurityReview,

--- a/src/snyk/snykCode/hoverProvider/hoverProvider.ts
+++ b/src/snyk/snykCode/hoverProvider/hoverProvider.ts
@@ -3,6 +3,7 @@ import { IDE_NAME } from '../../common/constants/general';
 import { ILog } from '../../common/logger/interfaces';
 import { IHoverAdapter } from '../../common/vscode/hover';
 import { IVSCodeLanguages } from '../../common/vscode/languages';
+import { IMarkdownStringAdapter } from '../../common/vscode/markdownString';
 import { Diagnostic, DiagnosticCollection, Disposable, Hover, Position, TextDocument } from '../../common/vscode/types';
 import { IGNORE_TIP_FOR_USER } from '../constants/analysis';
 import { ISnykCodeAnalyzer } from '../interfaces';
@@ -16,6 +17,7 @@ export class DisposableHoverProvider implements Disposable {
     private readonly logger: ILog,
     private readonly vscodeLanguages: IVSCodeLanguages,
     private readonly analytics: IAnalytics,
+    private readonly markdownStringAdapter: IMarkdownStringAdapter,
   ) {}
 
   register(snykReview: DiagnosticCollection | undefined, hoverAdapter: IHoverAdapter): Disposable {
@@ -37,7 +39,8 @@ export class DisposableHoverProvider implements Disposable {
       const issue = IssueUtils.findIssueWithRange(position, currentFileReviewIssues);
       if (issue) {
         this.logIssueHoverIsDisplayed(issue);
-        return hoverAdapter.create(IGNORE_TIP_FOR_USER);
+        const ignoreMarkdown = this.markdownStringAdapter.get(IGNORE_TIP_FOR_USER);
+        return hoverAdapter.create(ignoreMarkdown);
       }
     };
   }

--- a/src/snyk/snykCode/interfaces.ts
+++ b/src/snyk/snykCode/interfaces.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { DiagnosticCollection, TextDocument } from 'vscode';
 import { IExtension } from '../base/modules/interfaces';
 import { IHoverAdapter } from '../common/vscode/hover';
+import { IMarkdownStringAdapter } from '../common/vscode/markdownString';
 import { Disposable } from '../common/vscode/types';
 
 export type completeFileSuggestionType = ICodeSuggestion &
@@ -43,7 +44,11 @@ export interface ISnykCodeAnalyzer extends Disposable {
   codeSecurityReview: DiagnosticCollection | undefined;
   codeQualityReview: DiagnosticCollection | undefined;
 
-  registerHoverProviders(codeSecurityHoverAdapter: IHoverAdapter, codeQualityHoverAdapter: IHoverAdapter): void;
+  registerHoverProviders(
+    codeSecurityHoverAdapter: IHoverAdapter,
+    codeQualityHoverAdapter: IHoverAdapter,
+    markdownStringAdapter: IMarkdownStringAdapter,
+  ): void;
   registerCodeActionProviders(
     codeSecurityCodeActionsProvider: Disposable,
     codeQualityCodeActionsProvider: Disposable,

--- a/src/test/unit/advisor/services/advisorService.test.ts
+++ b/src/test/unit/advisor/services/advisorService.test.ts
@@ -96,6 +96,7 @@ suite('Advisor AdvisorService', () => {
     const ev: TextDocumentChangeEvent = {
       document,
       contentChanges: [],
+      reason: undefined,
     };
 
     const processFileSpy = sinon.spy(advisorService, 'processScores');

--- a/src/test/unit/snykCode/hoverProvider/hoverProvider.test.ts
+++ b/src/test/unit/snykCode/hoverProvider/hoverProvider.test.ts
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { IAnalytics } from '../../../../snyk/common/analytics/itly';
 import { IHoverAdapter } from '../../../../snyk/common/vscode/hover';
 import { IVSCodeLanguages } from '../../../../snyk/common/vscode/languages';
+import { IMarkdownStringAdapter } from '../../../../snyk/common/vscode/markdownString';
 import { Diagnostic, DiagnosticCollection, Position, TextDocument, Uri } from '../../../../snyk/common/vscode/types';
 import { DisposableHoverProvider } from '../../../../snyk/snykCode/hoverProvider/hoverProvider';
 import { ISnykCodeAnalyzer } from '../../../../snyk/snykCode/interfaces';
@@ -23,7 +24,9 @@ suite('Snyk Code hover provider', () => {
       logIssueHoverIsDisplayed,
     } as unknown as IAnalytics;
 
-    provider = new DisposableHoverProvider(analyzer, new LoggerMock(), vscodeLanguagesMock, analytics);
+    provider = new DisposableHoverProvider(analyzer, new LoggerMock(), vscodeLanguagesMock, analytics, {
+      get: sinon.fake(),
+    } as IMarkdownStringAdapter);
   });
 
   teardown(() => {


### PR DESCRIPTION
### Description

We specify `vscode` engine as version `^1.58.0`, however types dependency `@types/vscode` is not consistent as it has `^1.48.0` version types. This PR updates this and fixes issues 

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing
