### PR TITLE
fix: Build and Release workflow not putting version in .vsix file correctly

### DIFF
--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -40,9 +40,6 @@ jobs:
           release_branches: main
           default_bump: patch
 
-      - name: Update package.json version
-        run: jq '.version = "${{ steps.patched-tag.outputs.new_version }}"' package.json > tmp.package.json && mv tmp.package.json package.json
-
       - name: Add Credentials
         run: |
           sed -i \
@@ -52,7 +49,7 @@ jobs:
               snyk.config.json
 
       - name: Publish to Marketplace
-        run: vsce publish -p ${{ secrets.MARKETPLACE_TOKEN }}
+        run: vsce publish -p ${{ secrets.MARKETPLACE_TOKEN }} --no-update-package-json ${{ steps.patched-tag.outputs.new_version }}
 
   release:
     runs-on: ubuntu-latest
@@ -70,7 +67,7 @@ jobs:
         run: npm ci
 
       - name: Package VSIX
-        run: echo y | vsce package
+        run: echo y | vsce package --no-git-tag-version --no-update-package-json ${{ needs.publish.outputs.new-version }}
 
       - name: Extract release notes
         id: extract-release-notes


### PR DESCRIPTION
### Description

_Currently the `vsce package` command in the workflow will read the version from `package.json`. This is no longer manually maintained, so it will always be wrong. This PR computes the correct version suffix for `vsce package`._

### Checklist

- [x] Tests added and all succeed
- [x] Linted

