### PR TITLE
feat: translate configuration keys to language server [ROAD-1086]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### Added
 
 - Snyk LS: Handling of hasAuthenticated notification from LS
+- Snyk LS: Setting keys translation for language server.
+
+## [1.3.0]
+
+### Added
+
 - Snyk LS: Integrated language server - it's deactivated by default
 - Snyk LS: Adds functionality for setting a path to a custom LS binary
 

--- a/src/snyk/common/languageServer/middleware.ts
+++ b/src/snyk/common/languageServer/middleware.ts
@@ -1,0 +1,67 @@
+import {
+  CancellationToken,
+  ConfigurationParams,
+  ConfigurationRequestHandlerSignature,
+  Middleware,
+  ResponseError,
+  WorkspaceMiddleware,
+} from '../vscode/types';
+import { ClientSettings, ServerSettings } from './settings';
+
+export type LanguageClientWorkspaceMiddleware = Partial<WorkspaceMiddleware> & {
+  configuration: (
+    params: ConfigurationParams,
+    token: CancellationToken,
+    next: ConfigurationRequestHandlerSignature,
+  ) => Promise<ResponseError<void> | ServerSettings[]>;
+};
+
+export class LanguageClientMiddleware implements Middleware {
+  workspace: LanguageClientWorkspaceMiddleware = {
+    configuration: async (
+      params: ConfigurationParams,
+      token: CancellationToken,
+      next: ConfigurationRequestHandlerSignature,
+    ) => {
+      let settings = next(params, token);
+      if (this.isThenable(settings)) {
+        settings = await settings;
+      }
+
+      if (settings instanceof Error) {
+        return settings;
+      }
+
+      if (!settings.length) {
+        return [];
+      }
+
+      const clientSettings = settings[0] as ClientSettings;
+      // We should ideally have no setting translation and deliver LS-relevant only.
+      const serverSettings = [
+        {
+          activateSnykCode: 'false', // TODO: split into security and quality
+          activateSnykOpenSource: 'false',
+          activateSnykIac: 'false',
+          endpoint: clientSettings.advanced.customEndpoint,
+          additionalParams: clientSettings.advanced.additionalParameters,
+          sendErrorReports: `${clientSettings.yesCrashReport}`,
+          organization: `${clientSettings.advanced.organization}`,
+          enableTelemetry: `${clientSettings.yesTelemetry}`,
+          manageBinariesAutomatically: `${clientSettings.advanced.automaticDependencyManagement}`,
+          cliPath: `${clientSettings.advanced.cliPath}`,
+          // TODO: path,
+          // TODO: autoScanOpenSourceSecurity
+        } as ServerSettings,
+      ];
+
+      return serverSettings;
+    },
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  isThenable<T>(v: any): v is Thenable<T> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    return typeof v?.then === 'function';
+  }
+}

--- a/src/snyk/common/languageServer/settings.ts
+++ b/src/snyk/common/languageServer/settings.ts
@@ -1,0 +1,59 @@
+export type InitializationOptions = ServerSettings & {
+  integrationName?: string;
+  integrationVersion?: string;
+};
+
+export type ServerSettings = {
+  activateSnykCode?: string;
+  activateSnykOpenSource?: string;
+  activateSnykIac?: string;
+  endpoint?: string;
+  additionalParams?: string;
+  path?: string;
+  sendErrorReports?: string;
+  organization?: string;
+  enableTelemetry?: string;
+  manageBinariesAutomatically?: string;
+  cliPath?: string;
+  token?: string;
+};
+
+export type ClientSettings = {
+  yesCrashReport: boolean;
+  yesTelemetry: boolean;
+  yesWelcomeNotification: boolean;
+  yesBackgroundOssNotification: boolean;
+  advanced: AdvancedSettings;
+  features: FeaturesSettings;
+  severity: SeveritySettings;
+};
+
+export type AdvancedSettings = {
+  advancedMode: boolean;
+  autoScanOpenSourceSecurity: boolean;
+  additionalParameters: string;
+  customEndpoint: string;
+  organization: string;
+  tokenStorage: string;
+  automaticDependencyManagement: boolean;
+  cliPath: string;
+};
+
+export type FeaturesSettings = {
+  openSourceSecurity: boolean;
+  codeSecurity: boolean;
+  codeQuality: boolean;
+  preview: Preview;
+};
+
+export type Preview = {
+  reportFalsePositives: boolean;
+  lsAuthenticate: boolean;
+};
+
+export type SeveritySettings = {
+  critical: boolean;
+  high: boolean;
+  medium: boolean;
+  low: boolean;
+};

--- a/src/snyk/common/vscode/types.ts
+++ b/src/snyk/common/vscode/types.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as lsc from 'vscode-languageclient/node';
 
+// VS Code core type mappings
 export type Disposable = vscode.Disposable;
 export type DiagnosticCollection = vscode.DiagnosticCollection;
 export type Diagnostic = vscode.Diagnostic;
@@ -44,6 +45,14 @@ export type ExtensionContext = vscode.ExtensionContext;
 export type WebviewOptions = vscode.WebviewOptions;
 export type TextDocumentChangeEvent = vscode.TextDocumentChangeEvent;
 export type InputBoxOptions = vscode.InputBoxOptions;
+
+// Language client type mappings
 export type LanguageClient = lsc.LanguageClient;
 export type LanguageClientOptions = lsc.LanguageClientOptions;
 export type ServerOptions = lsc.ServerOptions;
+export type Middleware = lsc.Middleware;
+export type WorkspaceMiddleware = lsc.WorkspaceMiddleware;
+export type ConfigurationParams = lsc.ConfigurationParams;
+export type CancellationToken = lsc.CancellationToken;
+export type ConfigurationRequestHandlerSignature = lsc.ConfigurationRequest.HandlerSignature;
+export type ResponseError<D = void> = lsc.ResponseError<D>;

--- a/src/test/unit/common/languageServer/languageServer.test.ts
+++ b/src/test/unit/common/languageServer/languageServer.test.ts
@@ -1,17 +1,18 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { LanguageClient, LanguageClientOptions, ServerOptions } from '../../../../snyk/common/vscode/types';
-import sinon from 'sinon';
-import { IConfiguration, PreviewFeatures } from '../../../../snyk/common/configuration/configuration';
 import assert, { deepStrictEqual } from 'assert';
-import { LanguageServer } from '../../../../snyk/common/languageServer/languageServer';
-import { ILanguageClientAdapter } from '../../../../snyk/common/vscode/languageClient';
-import { IVSCodeWorkspace } from '../../../../snyk/common/vscode/workspace';
-import { stubWorkspaceConfiguration } from '../../mocks/workspace.mock';
-import { extensionContextMock } from '../../mocks/extensionContext.mock';
+import sinon from 'sinon';
 import { IAuthenticationService } from '../../../../snyk/base/services/authenticationService';
+import { IConfiguration, PreviewFeatures } from '../../../../snyk/common/configuration/configuration';
+import { LanguageServer } from '../../../../snyk/common/languageServer/languageServer';
+import { InitializationOptions } from '../../../../snyk/common/languageServer/settings';
+import { ILanguageClientAdapter } from '../../../../snyk/common/vscode/languageClient';
+import { LanguageClient, LanguageClientOptions, ServerOptions } from '../../../../snyk/common/vscode/types';
+import { IVSCodeWorkspace } from '../../../../snyk/common/vscode/workspace';
+import { extensionContextMock } from '../../mocks/extensionContext.mock';
 import { LoggerMock } from '../../mocks/logger.mock';
+import { stubWorkspaceConfiguration } from '../../mocks/workspace.mock';
 
-suite('languageServer', () => {
+suite('Language Server', () => {
   const extensionContext = extensionContextMock;
   const authService = {} as IAuthenticationService;
 
@@ -53,7 +54,7 @@ suite('languageServer', () => {
       authService,
       new LoggerMock(),
     );
-    const expectedInitializationOptions = {
+    const expectedInitializationOptions: InitializationOptions = {
       activateSnykCode: 'false',
       activateSnykOpenSource: 'false',
       activateSnykIac: 'false',
@@ -63,6 +64,8 @@ suite('languageServer', () => {
       sendErrorReports: 'true',
       integrationName: 'VS_CODE',
       integrationVersion: '0.0.0',
+      endpoint: undefined,
+      organization: undefined,
     };
 
     deepStrictEqual(await languageServer.getInitializationOptions(), expectedInitializationOptions);

--- a/src/test/unit/common/languageServer/middleware.test.ts
+++ b/src/test/unit/common/languageServer/middleware.test.ts
@@ -1,0 +1,115 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import { LanguageClientMiddleware } from '../../../../snyk/common/languageServer/middleware';
+import { ClientSettings, ServerSettings } from '../../../../snyk/common/languageServer/settings';
+import {
+  CancellationToken,
+  ConfigurationParams,
+  ConfigurationRequestHandlerSignature,
+  ResponseError,
+} from '../../../../snyk/common/vscode/types';
+
+suite('Language Server: Middleware', () => {
+  let clientSettings: ClientSettings;
+  setup(() => {
+    clientSettings = {
+      yesCrashReport: true,
+      yesTelemetry: true,
+      yesWelcomeNotification: false,
+      yesBackgroundOssNotification: true,
+      advanced: {
+        advancedMode: false,
+        autoScanOpenSourceSecurity: true,
+        additionalParameters: '',
+        customEndpoint: '',
+        organization: '',
+        tokenStorage: "Always use VS Code's secret storage",
+        automaticDependencyManagement: false,
+        cliPath: '',
+      },
+      features: {
+        openSourceSecurity: false,
+        codeSecurity: true,
+        codeQuality: false,
+        preview: {
+          reportFalsePositives: true,
+          lsAuthenticate: true,
+        },
+      },
+      severity: {
+        critical: true,
+        high: true,
+        medium: true,
+        low: true,
+      },
+    };
+  });
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('Configuration request should translate settings', async () => {
+    const middleware = new LanguageClientMiddleware();
+    const params: ConfigurationParams = {
+      items: [
+        {
+          section: 'snyk',
+        },
+      ],
+    };
+    const handler: ConfigurationRequestHandlerSignature = (_params, _token) => {
+      return [clientSettings];
+    };
+
+    const token: CancellationToken = {
+      isCancellationRequested: false,
+      onCancellationRequested: sinon.fake(),
+    };
+
+    const res = await middleware.workspace.configuration(params, token, handler);
+    if (res instanceof Error) {
+      assert.fail('Handler returned an error');
+    }
+
+    const serverResult = res[0] as ServerSettings;
+    assert.strictEqual(serverResult.activateSnykCode, 'false');
+    assert.strictEqual(serverResult.activateSnykOpenSource, 'false');
+    assert.strictEqual(serverResult.activateSnykIac, 'false');
+    assert.strictEqual(serverResult.endpoint, clientSettings.advanced.customEndpoint);
+    assert.strictEqual(serverResult.additionalParams, clientSettings.advanced.additionalParameters);
+    assert.strictEqual(serverResult.sendErrorReports, `${clientSettings.yesCrashReport}`);
+    assert.strictEqual(serverResult.organization, `${clientSettings.advanced.organization}`);
+    assert.strictEqual(serverResult.enableTelemetry, `${clientSettings.yesTelemetry}`);
+    assert.strictEqual(
+      serverResult.manageBinariesAutomatically,
+      `${clientSettings.advanced.automaticDependencyManagement}`,
+    );
+    assert.strictEqual(serverResult.cliPath, `${clientSettings.advanced.cliPath}`);
+  });
+
+  test('Configuration request should return an error', async () => {
+    const middleware = new LanguageClientMiddleware();
+    const params: ConfigurationParams = {
+      items: [
+        {
+          section: 'snyk',
+        },
+      ],
+    };
+    const handler: ConfigurationRequestHandlerSignature = (_params, _token) => {
+      return new Error('test err') as ResponseError;
+    };
+
+    const token: CancellationToken = {
+      isCancellationRequested: false,
+      onCancellationRequested: sinon.fake(),
+    };
+
+    const res = await middleware.workspace.configuration(params, token, handler);
+    if (!(res instanceof Error)) {
+      console.log(res);
+      assert.fail("Handler didn't return an error");
+    }
+  });
+});


### PR DESCRIPTION
### Description

This PR adds a middleware that translates client responses to `workspace/configuration` request, mapping them to LS-expected values. Ideally, we shouldn't have it at all. A follow-up work will be created on how we can minimise/remove the translation.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing