### PR TITLE
feat: send token to language server when updating token manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Snyk LS: Handling of hasAuthenticated notification from LS
 - Snyk LS: Setting keys translation for language server.
+- Snyk-LS: Transmit Snyk Token to language server on manually entering it.
 
 ## [1.3.0]
 

--- a/src/snyk/base/services/authenticationService.ts
+++ b/src/snyk/base/services/authenticationService.ts
@@ -10,12 +10,17 @@ import { IVSCodeWindow } from '../../common/vscode/window';
 import { ISnykCodeErrorHandler } from '../../snykCode/error/snykCodeErrorHandler';
 import { messages } from '../messages/loginMessages';
 import { IBaseSnykModule } from '../modules/interfaces';
+import { DID_CHANGE_CONFIGURATION_METHOD, LanguageClient } from '../../common/vscode/types';
 
 export interface IAuthenticationService {
   initiateLogin(getIpFamily: typeof getNetworkFamily): Promise<void>;
+
   initiateLogout(): Promise<void>;
+
   checkSession(): Promise<string>;
+
   setToken(): Promise<void>;
+
   updateToken(token: string): Promise<void>;
 }
 
@@ -34,6 +39,7 @@ export class AuthenticationService implements IAuthenticationService {
     private readonly analytics: IAnalytics,
     private readonly logger: ILog,
     private readonly snykCodeErrorHandler: ISnykCodeErrorHandler,
+    private readonly client: LanguageClient,
   ) {}
 
   async initiateLogin(getIpFamily: typeof getNetworkFamily): Promise<void> {
@@ -106,6 +112,15 @@ export class AuthenticationService implements IAuthenticationService {
 
     if (!token) return;
     await this.configuration.setToken(token);
+    // TODO remove feature flag when ready
+    if (!this.configuration.getPreviewFeatures().lsAuthenticate) {
+      return Promise.resolve();
+    }
+    return await this.client.sendNotification(DID_CHANGE_CONFIGURATION_METHOD, {
+      settings: {
+        token: token,
+      },
+    });
   }
 
   async updateToken(token: string): Promise<void> {

--- a/src/snyk/base/services/authenticationService.ts
+++ b/src/snyk/base/services/authenticationService.ts
@@ -117,7 +117,7 @@ export class AuthenticationService implements IAuthenticationService {
     if (!this.configuration.getPreviewFeatures().lsAuthenticate) {
       return Promise.resolve();
     }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+
     return await this.client.sendNotification(DID_CHANGE_CONFIGURATION_METHOD, {
       settings: {
         token: token,

--- a/src/snyk/base/services/authenticationService.ts
+++ b/src/snyk/base/services/authenticationService.ts
@@ -10,7 +10,8 @@ import { IVSCodeWindow } from '../../common/vscode/window';
 import { ISnykCodeErrorHandler } from '../../snykCode/error/snykCodeErrorHandler';
 import { messages } from '../messages/loginMessages';
 import { IBaseSnykModule } from '../modules/interfaces';
-import { DID_CHANGE_CONFIGURATION_METHOD, LanguageClient } from '../../common/vscode/types';
+import { LanguageClient } from '../../common/vscode/types';
+import { DID_CHANGE_CONFIGURATION_METHOD } from '../../common/constants/general';
 
 export interface IAuthenticationService {
   initiateLogin(getIpFamily: typeof getNetworkFamily): Promise<void>;
@@ -116,6 +117,7 @@ export class AuthenticationService implements IAuthenticationService {
     if (!this.configuration.getPreviewFeatures().lsAuthenticate) {
       return Promise.resolve();
     }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     return await this.client.sendNotification(DID_CHANGE_CONFIGURATION_METHOD, {
       settings: {
         token: token,

--- a/src/snyk/base/services/authenticationService.ts
+++ b/src/snyk/base/services/authenticationService.ts
@@ -11,7 +11,7 @@ import { ISnykCodeErrorHandler } from '../../snykCode/error/snykCodeErrorHandler
 import { messages } from '../messages/loginMessages';
 import { IBaseSnykModule } from '../modules/interfaces';
 import { LanguageClient } from '../../common/vscode/types';
-import { DID_CHANGE_CONFIGURATION_METHOD } from '../../common/constants/general';
+import { DID_CHANGE_CONFIGURATION_METHOD } from '../../common/constants/languageServer';
 
 export interface IAuthenticationService {
   initiateLogin(getIpFamily: typeof getNetworkFamily): Promise<void>;

--- a/src/snyk/common/constants/general.ts
+++ b/src/snyk/common/constants/general.ts
@@ -18,3 +18,6 @@ export const REFRESH_VIEW_DEBOUNCE_INTERVAL = 200; // 200 milliseconds
 export const CONNECTION_ERROR_RETRY_INTERVAL = DEFAULT_SCAN_DEBOUNCE_INTERVAL * 2 + 1000 * 3;
 
 export const SNYK_LEARN_API_CACHE_DURATION_IN_MS = 1000 * 60 * 60 * 24; // 1 day
+
+// Language Server constants
+export const DID_CHANGE_CONFIGURATION_METHOD = 'workspace/didChangeConfiguration';

--- a/src/snyk/common/constants/general.ts
+++ b/src/snyk/common/constants/general.ts
@@ -1,6 +1,5 @@
 // Changing this requires changing display name in package.json.
 export const SNYK_NAME = 'Snyk Security - Code and Open Source Dependencies';
-export const SNYK_LANGUAGE_SERVER_NAME = 'Snyk Language Server';
 export const SNYK_TOKEN_KEY = 'snyk.token';
 export const SNYK_UNIQUE_EXTENSION_NAME = 'Snyk Vulnerability Scanner';
 export const SNYK_PUBLISHER = 'snyk-security';
@@ -18,6 +17,3 @@ export const REFRESH_VIEW_DEBOUNCE_INTERVAL = 200; // 200 milliseconds
 export const CONNECTION_ERROR_RETRY_INTERVAL = DEFAULT_SCAN_DEBOUNCE_INTERVAL * 2 + 1000 * 3;
 
 export const SNYK_LEARN_API_CACHE_DURATION_IN_MS = 1000 * 60 * 60 * 24; // 1 day
-
-// Language Server constants
-export const DID_CHANGE_CONFIGURATION_METHOD = 'workspace/didChangeConfiguration';

--- a/src/snyk/common/constants/languageServer.ts
+++ b/src/snyk/common/constants/languageServer.ts
@@ -1,0 +1,8 @@
+// Language Server constants
+export const SNYK_LANGUAGE_SERVER_NAME = 'Snyk Language Server';
+
+// protocol methods
+export const DID_CHANGE_CONFIGURATION_METHOD = 'workspace/didChangeConfiguration';
+
+// custom methods
+export const SNYK_HAS_AUTHENTICATED = '$/snyk.hasAuthenticated';

--- a/src/snyk/common/vscode/languageClient.ts
+++ b/src/snyk/common/vscode/languageClient.ts
@@ -3,10 +3,18 @@ import { LanguageClient, LanguageClientOptions, ServerOptions } from './types';
 
 export interface ILanguageClientAdapter {
   create(id: string, name: string, serverOptions: ServerOptions, clientOptions: LanguageClientOptions): LanguageClient;
+  getLanguageClient(): LanguageClient;
 }
 
 export class LanguageClientAdapter implements ILanguageClientAdapter {
+  private client: LanguageClient;
+
   create(id: string, name: string, serverOptions: ServerOptions, clientOptions: LanguageClientOptions): LanguageClient {
-    return new lsc.LanguageClient(id, name, serverOptions, clientOptions);
+    this.client = new lsc.LanguageClient(id, name, serverOptions, clientOptions);
+    return this.client;
+  }
+
+  getLanguageClient(): LanguageClient {
+    return this.client;
   }
 }

--- a/src/snyk/common/vscode/types.ts
+++ b/src/snyk/common/vscode/types.ts
@@ -6,6 +6,7 @@ export type Disposable = vscode.Disposable;
 export type DiagnosticCollection = vscode.DiagnosticCollection;
 export type Diagnostic = vscode.Diagnostic;
 export type DiagnosticRelatedInformation = vscode.DiagnosticRelatedInformation;
+
 export enum DiagnosticSeverity { // map of vscode.DiagnosticSeverity
   Hint = 3,
   Information = 2,
@@ -56,3 +57,5 @@ export type ConfigurationParams = lsc.ConfigurationParams;
 export type CancellationToken = lsc.CancellationToken;
 export type ConfigurationRequestHandlerSignature = lsc.ConfigurationRequest.HandlerSignature;
 export type ResponseError<D = void> = lsc.ResponseError<D>;
+export type DidChangeConfigurationParams = lsc.DidChangeConfigurationParams;
+export const DID_CHANGE_CONFIGURATION_METHOD = 'workspace/didChangeConfiguration'; //lsc.DidChangeConfigurationNotification.method;

--- a/src/snyk/common/vscode/types.ts
+++ b/src/snyk/common/vscode/types.ts
@@ -57,5 +57,3 @@ export type ConfigurationParams = lsc.ConfigurationParams;
 export type CancellationToken = lsc.CancellationToken;
 export type ConfigurationRequestHandlerSignature = lsc.ConfigurationRequest.HandlerSignature;
 export type ResponseError<D = void> = lsc.ResponseError<D>;
-export type DidChangeConfigurationParams = lsc.DidChangeConfigurationParams;
-export const DidChangeConfigurationType = lsc.DidChangeConfigurationNotification.type;

--- a/src/snyk/common/vscode/types.ts
+++ b/src/snyk/common/vscode/types.ts
@@ -58,4 +58,4 @@ export type CancellationToken = lsc.CancellationToken;
 export type ConfigurationRequestHandlerSignature = lsc.ConfigurationRequest.HandlerSignature;
 export type ResponseError<D = void> = lsc.ResponseError<D>;
 export type DidChangeConfigurationParams = lsc.DidChangeConfigurationParams;
-export const DID_CHANGE_CONFIGURATION_METHOD = 'workspace/didChangeConfiguration'; //lsc.DidChangeConfigurationNotification.method;
+export const DidChangeConfigurationType = lsc.DidChangeConfigurationNotification.type;

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -77,6 +77,7 @@ import { OssSuggestionWebviewProvider } from './snykOss/views/suggestion/ossSugg
 import { DailyScanJob } from './snykOss/watchers/dailyScanJob';
 import { LanguageServer } from './common/languageServer/languageServer';
 import { LanguageClientAdapter } from './common/vscode/languageClient';
+import { LanguageClient } from 'vscode-languageclient/node';
 
 class SnykExtension extends SnykLib implements IExtension {
   public async activate(vscodeContext: vscode.ExtensionContext): Promise<void> {
@@ -127,6 +128,7 @@ class SnykExtension extends SnykLib implements IExtension {
 
     this.statusBarItem.show();
 
+    const languageClientAdapter = new LanguageClientAdapter();
     this.authService = new AuthenticationService(
       this.contextService,
       this.openerService,
@@ -136,12 +138,13 @@ class SnykExtension extends SnykLib implements IExtension {
       this.analytics,
       Logger,
       this.snykCodeErrorHandler,
+      languageClientAdapter.getLanguageClient(),
     );
 
     this.languageServer = new LanguageServer(
       vscodeContext,
       configuration,
-      new LanguageClientAdapter(),
+      languageClientAdapter,
       vsCodeWorkspace,
       this.authService,
       Logger,

--- a/src/test/unit/base/services/authenticationService.test.ts
+++ b/src/test/unit/base/services/authenticationService.test.ts
@@ -15,7 +15,7 @@ import { ISnykCodeErrorHandler } from '../../../../snyk/snykCode/error/snykCodeE
 import { LoggerMock } from '../../mocks/logger.mock';
 import { windowMock } from '../../mocks/window.mock';
 import { LanguageClient } from '../../../../snyk/common/vscode/types';
-import { DID_CHANGE_CONFIGURATION_METHOD } from '../../../../snyk/common/constants/general';
+import { DID_CHANGE_CONFIGURATION_METHOD } from '../../../../snyk/common/constants/languageServer';
 
 suite('AuthenticationService', () => {
   let contextService: IContextService;

--- a/src/test/unit/base/services/authenticationService.test.ts
+++ b/src/test/unit/base/services/authenticationService.test.ts
@@ -14,11 +14,8 @@ import { IOpenerService } from '../../../../snyk/common/services/openerService';
 import { ISnykCodeErrorHandler } from '../../../../snyk/snykCode/error/snykCodeErrorHandler';
 import { LoggerMock } from '../../mocks/logger.mock';
 import { windowMock } from '../../mocks/window.mock';
-import {
-  DID_CHANGE_CONFIGURATION_METHOD,
-  DidChangeConfigurationParams,
-  LanguageClient,
-} from '../../../../snyk/common/vscode/types';
+import { LanguageClient } from '../../../../snyk/common/vscode/types';
+import { DID_CHANGE_CONFIGURATION_METHOD } from '../../../../snyk/common/constants/general';
 
 suite('AuthenticationService', () => {
   let contextService: IContextService;
@@ -94,7 +91,7 @@ suite('AuthenticationService', () => {
         resetTransientErrors: sinon.fake(),
         connectionRetryLimitExhausted: false,
       } as ISnykCodeErrorHandler,
-      languageClient as unknown as LanguageClient,
+      languageClient,
     );
 
     await service.initiateLogin(getIpFamilyStub);


### PR DESCRIPTION
Signed-off-by: Bastian Doetsch <bastian.doetsch@snyk.io>

### Description

When a user manually enters a token with the setToken command, we need to inform Language Server of the new token. This PR implements sending a token via `DidChangeConfiguration` whenever the setToken command is yielding a valid token.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs


