### PR TITLE
fix: settings synchronisation [ROAD-1086]

### DIFF
--- a/src/snyk/common/languageServer/settings.ts
+++ b/src/snyk/common/languageServer/settings.ts
@@ -1,3 +1,6 @@
+import { CliExecutable } from '../../cli/cliExecutable';
+import { IConfiguration } from '../configuration/configuration';
+
 export type InitializationOptions = ServerSettings & {
   integrationName?: string;
   integrationVersion?: string;
@@ -18,42 +21,20 @@ export type ServerSettings = {
   token?: string;
 };
 
-export type ClientSettings = {
-  yesCrashReport: boolean;
-  yesTelemetry: boolean;
-  yesWelcomeNotification: boolean;
-  yesBackgroundOssNotification: boolean;
-  advanced: AdvancedSettings;
-  features: FeaturesSettings;
-  severity: SeveritySettings;
-};
-
-export type AdvancedSettings = {
-  advancedMode: boolean;
-  autoScanOpenSourceSecurity: boolean;
-  additionalParameters: string;
-  customEndpoint: string;
-  organization: string;
-  tokenStorage: string;
-  automaticDependencyManagement: boolean;
-  cliPath: string;
-};
-
-export type FeaturesSettings = {
-  openSourceSecurity: boolean;
-  codeSecurity: boolean;
-  codeQuality: boolean;
-  preview: Preview;
-};
-
-export type Preview = {
-  reportFalsePositives: boolean;
-  lsAuthenticate: boolean;
-};
-
-export type SeveritySettings = {
-  critical: boolean;
-  high: boolean;
-  medium: boolean;
-  low: boolean;
-};
+export class LanguageServerSettings {
+  static async fromConfiguration(configuration: IConfiguration, extensionPath: string): Promise<ServerSettings> {
+    return {
+      activateSnykCode: 'false',
+      activateSnykOpenSource: 'false',
+      activateSnykIac: 'false',
+      enableTelemetry: `${configuration.shouldReportEvents}`,
+      sendErrorReports: `${configuration.shouldReportErrors}`,
+      cliPath: CliExecutable.getPath(extensionPath, configuration.getCustomCliPath()),
+      endpoint: configuration.snykOssApiEndpoint,
+      additionalParams: configuration.getAdditionalCliParameters(),
+      organization: configuration.organization,
+      token: await configuration.getToken(),
+      manageBinariesAutomatically: `${configuration.isAutomaticDependencyManagementEnabled()}`,
+    };
+  }
+}

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -26,9 +26,9 @@ import {
   SNYK_OPEN_ISSUE_COMMAND,
   SNYK_OPEN_LOCAL_COMMAND,
   SNYK_REPORT_FALSE_POSITIVE_COMMAND,
-  SNYK_SET_TOKEN_COMMAND,
   SNYK_SETMODE_COMMAND,
   SNYK_SETTINGS_COMMAND,
+  SNYK_SET_TOKEN_COMMAND,
   SNYK_SHOW_OUTPUT_COMMAND,
   SNYK_START_COMMAND,
 } from './common/constants/commands';
@@ -45,6 +45,7 @@ import {
 import { ErrorHandler } from './common/error/errorHandler';
 import { ErrorReporter } from './common/error/errorReporter';
 import { ExperimentService } from './common/experiment/services/experimentService';
+import { LanguageServer } from './common/languageServer/languageServer';
 import { Logger } from './common/logger/logger';
 import { NotificationService } from './common/services/notificationService';
 import { User } from './common/user';
@@ -53,6 +54,7 @@ import { vsCodeComands } from './common/vscode/commands';
 import { vsCodeEnv } from './common/vscode/env';
 import { extensionContext } from './common/vscode/extensionContext';
 import { HoverAdapter } from './common/vscode/hover';
+import { LanguageClientAdapter } from './common/vscode/languageClient';
 import { vsCodeLanguages, VSCodeLanguages } from './common/vscode/languages';
 import SecretStorageAdapter from './common/vscode/secretStorage';
 import { ThemeColorAdapter } from './common/vscode/theme';
@@ -75,9 +77,6 @@ import { ModuleVulnerabilityCountProvider } from './snykOss/services/vulnerabili
 import { OssVulnerabilityTreeProvider } from './snykOss/views/ossVulnerabilityTreeProvider';
 import { OssSuggestionWebviewProvider } from './snykOss/views/suggestion/ossSuggestionWebviewProvider';
 import { DailyScanJob } from './snykOss/watchers/dailyScanJob';
-import { LanguageServer } from './common/languageServer/languageServer';
-import { LanguageClientAdapter } from './common/vscode/languageClient';
-import { LanguageClient } from 'vscode-languageclient/node';
 
 class SnykExtension extends SnykLib implements IExtension {
   public async activate(vscodeContext: vscode.ExtensionContext): Promise<void> {

--- a/src/test/unit/common/languageServer/languageServer.test.ts
+++ b/src/test/unit/common/languageServer/languageServer.test.ts
@@ -38,7 +38,13 @@ suite('Language Server', () => {
       getSnykLanguageServerPath(): string {
         return 'testPath';
       },
-    } as unknown as IConfiguration;
+      getAdditionalCliParameters() {
+        return '--all-projects';
+      },
+      isAutomaticDependencyManagementEnabled() {
+        return true;
+      },
+    } as IConfiguration;
   });
 
   teardown(() => {
@@ -66,6 +72,8 @@ suite('Language Server', () => {
       integrationVersion: '0.0.0',
       endpoint: undefined,
       organization: undefined,
+      additionalParams: '--all-projects',
+      manageBinariesAutomatically: 'true',
     };
 
     deepStrictEqual(await languageServer.getInitializationOptions(), expectedInitializationOptions);


### PR DESCRIPTION
### Description

This aligns on settings that are passed in initialization request and upon LS querying them. This was originally [reported here](https://github.com/snyk/vscode-extension/pull/283#discussion_r955736288) by @bastiandoetsch 

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

