### PR TITLE
fix: fast-glob performance issues [ROAD-1087]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 ### Added
 
-- Snyk LS: Configure custom Language Server binary path in settings
+- Snyk LS: Configure custom Language Server binary path in settings.
+- Snyk LS: Deprecate snyk.logout command.
 
 ## [1.5.0]
 
 ### Added
 
 - Snyk LS: Deprecate copyAuthLink command.
-- Snyk LS: Deprecate snyk.logout command.
 
 ## [1.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Snyk LS: Configure custom Language Server binary path in settings.
 - Snyk LS: Deprecate snyk.logout command.
 
+### Fixed
+
+-- Performance issues on some machines due to outdated dependency.
+
 ## [1.5.0]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@itly/sdk": "^2.3.1",
         "@sentry/node": "^6.16.1",
         "@sentry/tracing": "^6.19.7",
-        "@snyk/code-client": "^4.12.3",
+        "@snyk/code-client": "^4.12.4",
         "analytics-node": "^4.0.1",
         "axios": "^0.27.2",
         "glob": "^7.2.0",
@@ -1584,18 +1584,18 @@
       "dev": true
     },
     "node_modules/@snyk/code-client": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.12.3.tgz",
-      "integrity": "sha512-bvwncCaN2KTQ/KigVmC4og8CC4Otu/8R3LwEumGVcHEVHN97PpbckCutkv+I1PP/JdqxbCJd++XG1xApVxtrYA==",
+      "version": "4.12.4",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.12.4.tgz",
+      "integrity": "sha512-K2k8J761iJfKxWI026ZAWw15Xaw3Vff4Wmy9SPx5QR3aU6qrHn1d872v+9B8nnrHfbgJbU45t/iLzCv/fiotNg==",
       "dependencies": {
         "@deepcode/dcignore": "^1.0.4",
-        "@snyk/fast-glob": "^3.2.6-patch",
         "@types/flat-cache": "^2.0.0",
         "@types/lodash.omit": "^4.5.6",
         "@types/lodash.pick": "^4.4.6",
         "@types/lodash.union": "^4.6.6",
         "@types/sarif": "^2.1.4",
         "@types/uuid": "^8.3.1",
+        "fast-glob": "^3.2.11",
         "ignore": "^5.1.8",
         "lodash.omit": "^4.5.0",
         "lodash.pick": "^4.4.0",
@@ -1605,33 +1605,6 @@
         "p-map": "^3.0.0",
         "uuid": "^8.3.2",
         "yaml": "^1.10.2"
-      }
-    },
-    "node_modules/@snyk/fast-glob": {
-      "version": "3.2.6-patch",
-      "resolved": "https://registry.npmjs.org/@snyk/fast-glob/-/fast-glob-3.2.6-patch.tgz",
-      "integrity": "sha512-E/Pfdze/WFfxwyuTFcfhQN1SwyUsc43yuCoW63RVBCaxTD6OzhVD2Pvc/Sy7BjiWUfmelzyKkIBpoow8zZX7Zg==",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "@snyk/glob-parent": "^5.1.2-patch.1",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@snyk/glob-parent": {
-      "version": "5.1.2-patch.1",
-      "resolved": "https://registry.npmjs.org/@snyk/glob-parent/-/glob-parent-5.1.2-patch.1.tgz",
-      "integrity": "sha512-OkUPdHgxIWKAAzceG1nraNA0kgI+eS0I9wph8tll9UL0slD2mIWSj4mAqroGovaEXm8nHedoUfuDRGEb6wnzCQ==",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -4110,7 +4083,6 @@
       "version": "3.2.11",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
       "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -4465,7 +4437,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -9386,18 +9357,18 @@
       "dev": true
     },
     "@snyk/code-client": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.12.3.tgz",
-      "integrity": "sha512-bvwncCaN2KTQ/KigVmC4og8CC4Otu/8R3LwEumGVcHEVHN97PpbckCutkv+I1PP/JdqxbCJd++XG1xApVxtrYA==",
+      "version": "4.12.4",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.12.4.tgz",
+      "integrity": "sha512-K2k8J761iJfKxWI026ZAWw15Xaw3Vff4Wmy9SPx5QR3aU6qrHn1d872v+9B8nnrHfbgJbU45t/iLzCv/fiotNg==",
       "requires": {
         "@deepcode/dcignore": "^1.0.4",
-        "@snyk/fast-glob": "^3.2.6-patch",
         "@types/flat-cache": "^2.0.0",
         "@types/lodash.omit": "^4.5.6",
         "@types/lodash.pick": "^4.4.6",
         "@types/lodash.union": "^4.6.6",
         "@types/sarif": "^2.1.4",
         "@types/uuid": "^8.3.1",
+        "fast-glob": "^3.2.11",
         "ignore": "^5.1.8",
         "lodash.omit": "^4.5.0",
         "lodash.pick": "^4.4.0",
@@ -9407,27 +9378,6 @@
         "p-map": "^3.0.0",
         "uuid": "^8.3.2",
         "yaml": "^1.10.2"
-      }
-    },
-    "@snyk/fast-glob": {
-      "version": "3.2.6-patch",
-      "resolved": "https://registry.npmjs.org/@snyk/fast-glob/-/fast-glob-3.2.6-patch.tgz",
-      "integrity": "sha512-E/Pfdze/WFfxwyuTFcfhQN1SwyUsc43yuCoW63RVBCaxTD6OzhVD2Pvc/Sy7BjiWUfmelzyKkIBpoow8zZX7Zg==",
-      "requires": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "@snyk/glob-parent": "^5.1.2-patch.1",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
-      }
-    },
-    "@snyk/glob-parent": {
-      "version": "5.1.2-patch.1",
-      "resolved": "https://registry.npmjs.org/@snyk/glob-parent/-/glob-parent-5.1.2-patch.1.tgz",
-      "integrity": "sha512-OkUPdHgxIWKAAzceG1nraNA0kgI+eS0I9wph8tll9UL0slD2mIWSj4mAqroGovaEXm8nHedoUfuDRGEb6wnzCQ==",
-      "requires": {
-        "is-glob": "^4.0.1"
       }
     },
     "@tootallnate/once": {
@@ -11331,7 +11281,6 @@
       "version": "3.2.11",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
       "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -11597,7 +11546,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -463,7 +463,7 @@
     "@itly/sdk": "^2.3.1",
     "@sentry/node": "^6.16.1",
     "@sentry/tracing": "^6.19.7",
-    "@snyk/code-client": "^4.12.3",
+    "@snyk/code-client": "^4.12.4",
     "analytics-node": "^4.0.1",
     "axios": "^0.27.2",
     "glob": "^7.2.0",


### PR DESCRIPTION
### Description

On some machines @snyk/fast-glob causes performance bottleneck. Our @snyk/fast-glob fork is quite outdated and not maintained. `code-client` dropped this dependency and replaced with the official fast-glob lib in https://github.com/snyk/code-client/pull/160 as it provides some performance improvements.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing
