### PR TITLE
feat: pass anonymousId to language server [ROAD-1185]

### DIFF
--- a/src/snyk/common/languageServer/languageServer.ts
+++ b/src/snyk/common/languageServer/languageServer.ts
@@ -7,10 +7,10 @@ import { CONFIGURATION_IDENTIFIER } from '../constants/settings';
 import { ErrorHandler } from '../error/errorHandler';
 import { ILog } from '../logger/interfaces';
 import { getProxyEnvVariable, getProxyOptions } from '../proxy';
-import { IContextService } from '../services/contextService';
 import { DownloadService } from '../services/downloadService';
+import { User } from '../user';
 import { ILanguageClientAdapter } from '../vscode/languageClient';
-import { ExtensionContext, LanguageClient, LanguageClientOptions, ServerOptions } from '../vscode/types';
+import { LanguageClient, LanguageClientOptions, ServerOptions } from '../vscode/types';
 import { IVSCodeWindow } from '../vscode/window';
 import { IVSCodeWorkspace } from '../vscode/workspace';
 import { LsExecutable } from './lsExecutable';
@@ -28,9 +28,8 @@ export class LanguageServer implements ILanguageServer {
   readonly cliReady$ = new ReplaySubject<string>(1);
 
   constructor(
-    private context: ExtensionContext,
+    private user: User,
     private configuration: IConfiguration,
-    private contextService: IContextService,
     private languageClientAdapter: ILanguageClientAdapter,
     private workspace: IVSCodeWorkspace,
     private window: IVSCodeWindow,
@@ -82,7 +81,7 @@ export class LanguageServer implements ILanguageServer {
       synchronize: {
         configurationSection: CONFIGURATION_IDENTIFIER,
       },
-      middleware: new LanguageClientMiddleware(this.context, this.configuration),
+      middleware: new LanguageClientMiddleware(this.configuration),
       outputChannel: this.window.createOutputChannel(SNYK_LANGUAGE_SERVER_NAME),
     };
 
@@ -126,6 +125,7 @@ export class LanguageServer implements ILanguageServer {
       ...settings,
       integrationName: CLI_INTEGRATION_NAME,
       integrationVersion: await Configuration.getVersion(),
+      deviceId: this.user.anonymousId,
       automaticAuthentication: 'false',
     };
   }

--- a/src/snyk/common/languageServer/languageServer.ts
+++ b/src/snyk/common/languageServer/languageServer.ts
@@ -119,6 +119,8 @@ export class LanguageServer implements ILanguageServer {
     this.logger.info('Snyk Language Server started');
   }
 
+  // Initialization options are not semantically equal to server settings, thus separated here
+  // https://github.com/microsoft/language-server-protocol/issues/567
   async getInitializationOptions(): Promise<InitializationOptions> {
     const settings = await LanguageServerSettings.fromConfiguration(this.configuration);
     return {

--- a/src/snyk/common/languageServer/middleware.ts
+++ b/src/snyk/common/languageServer/middleware.ts
@@ -3,7 +3,6 @@ import {
   CancellationToken,
   ConfigurationParams,
   ConfigurationRequestHandlerSignature,
-  ExtensionContext,
   Middleware,
   ResponseError,
   WorkspaceMiddleware,
@@ -19,7 +18,7 @@ export type LanguageClientWorkspaceMiddleware = Partial<WorkspaceMiddleware> & {
 };
 
 export class LanguageClientMiddleware implements Middleware {
-  constructor(private context: ExtensionContext, private configuration: IConfiguration) {}
+  constructor(private configuration: IConfiguration) {}
 
   workspace: LanguageClientWorkspaceMiddleware = {
     configuration: async (

--- a/src/snyk/common/languageServer/settings.ts
+++ b/src/snyk/common/languageServer/settings.ts
@@ -4,6 +4,7 @@ export type InitializationOptions = ServerSettings & {
   integrationName?: string;
   integrationVersion?: string;
   automaticAuthentication?: string;
+  deviceId?: string;
 };
 
 export type ServerSettings = {

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -165,9 +165,8 @@ class SnykExtension extends SnykLib implements IExtension {
     );
 
     this.languageServer = new LanguageServer(
-      vscodeContext,
+      this.user,
       configuration,
-      this.contextService,
       languageClientAdapter,
       vsCodeWorkspace,
       vsCodeWindow,

--- a/src/test/unit/common/languageServer/middleware.test.ts
+++ b/src/test/unit/common/languageServer/middleware.test.ts
@@ -32,7 +32,7 @@ suite('Language Server: Middleware', () => {
   });
 
   test('Configuration request should translate settings', async () => {
-    const middleware = new LanguageClientMiddleware(extensionContextMock, configuration);
+    const middleware = new LanguageClientMiddleware(configuration);
     const params: ConfigurationParams = {
       items: [
         {
@@ -74,7 +74,7 @@ suite('Language Server: Middleware', () => {
   });
 
   test('Configuration request should return an error', async () => {
-    const middleware = new LanguageClientMiddleware(extensionContextMock, configuration);
+    const middleware = new LanguageClientMiddleware(configuration);
     const params: ConfigurationParams = {
       items: [
         {


### PR DESCRIPTION
### Description

Ensures `anonymousId` synchronisation for analytics.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing
