### PR TITLE
fix: http:proxyStrictSSL setting is respected when setting proxy options [ROAD-1132]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - `http:proxyStrictSSL` option always respected.
+- Language client respects proxy protocol when proxy is used.
 
 ## [1.7.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Snyk Security - Code and Open Source Dependencies Changelog
 
+## [1.7.6]
+
+### Fixed
+
+- `http:proxyStrictSSL` option always respected.
+
 ## [1.7.4]
 
 ### Fixed

--- a/src/snyk/common/proxy.ts
+++ b/src/snyk/common/proxy.ts
@@ -47,6 +47,7 @@ export function getProxyOptions(
     port: port,
     auth: proxyUrl.auth,
     rejectUnauthorized: strictProxy,
+    protocol: proxyUrl.protocol,
   };
 }
 
@@ -68,9 +69,9 @@ export function getProxyEnvVariable(
   if (!proxyOptions) {
     return;
   }
-  const { host, port, auth } = proxyOptions;
+  const { host, port, auth, protocol } = proxyOptions;
   if (!host) return;
 
   // noinspection HttpUrlsUsage
-  return `http://${auth ? `${auth}@` : ''}${host}${port ? `:${port}` : ''}`;
+  return `${protocol}//${auth ? `${auth}@` : ''}${host}${port ? `:${port}` : ''}`;
 }

--- a/src/snyk/common/proxy.ts
+++ b/src/snyk/common/proxy.ts
@@ -6,37 +6,38 @@ import { IVSCodeWorkspace } from './vscode/workspace';
 export function getHttpsProxyAgent(
   workspace: IVSCodeWorkspace,
   processEnv: NodeJS.ProcessEnv = process.env,
-): HttpsProxyAgent | undefined {
-  const proxyOptions = getProxyOptions(workspace, processEnv);
-  if (proxyOptions == undefined) {
-    return undefined;
-  }
-  return new HttpsProxyAgent(proxyOptions);
+): HttpsProxyAgent {
+  return new HttpsProxyAgent(getProxyOptions(workspace, processEnv));
 }
 
 export function getProxyOptions(
   workspace: IVSCodeWorkspace,
   processEnv: NodeJS.ProcessEnv = process.env,
-): HttpsProxyAgentOptions | undefined {
+): HttpsProxyAgentOptions {
   let proxy: string | undefined = getVsCodeProxy(workspace);
+
+  const strictProxy = workspace.getConfiguration<boolean>('http', 'proxyStrictSSL') ?? true;
+  const defaultOptions: HttpsProxyAgentOptions = {
+    rejectUnauthorized: strictProxy,
+  };
+
   if (!proxy) {
     proxy = processEnv.HTTPS_PROXY || processEnv.https_proxy || processEnv.HTTP_PROXY || processEnv.http_proxy;
     if (!proxy) {
-      return undefined; // No proxy
+      return defaultOptions; // No proxy
     }
   }
 
   // Basic sanity checking on proxy url
   const proxyUrl = url.parse(proxy);
   if (proxyUrl.protocol !== 'https:' && proxyUrl.protocol !== 'http:') {
-    return undefined;
+    return defaultOptions;
   }
 
   if (proxyUrl.hostname == null || proxyUrl.hostname === '') {
-    return undefined;
+    return defaultOptions;
   }
 
-  const strictProxy = workspace.getConfiguration<boolean>('http', 'proxyStrictSSL') ?? true;
   let port;
   if (proxyUrl.port && proxyUrl.port !== '') {
     port = parseInt(proxyUrl.port, 10);

--- a/src/test/unit/common/proxy.test.ts
+++ b/src/test/unit/common/proxy.test.ts
@@ -33,6 +33,32 @@ suite('Proxy', () => {
     assert.deepStrictEqual(agent?.proxy.rejectUnauthorized, proxyStrictSSL);
   });
 
+  suite('.getProxyOptions()', () => {
+    suite('when proxyStrictSsl is set', () => {
+      const getConfiguration = sinon.stub();
+      const workspace = {
+        getConfiguration,
+      } as unknown as IVSCodeWorkspace;
+      getConfiguration.withArgs('http', 'proxyStrictSSL').returns(true);
+      test('should return rejectUnauthorized true', () => {
+        const options = getProxyOptions(workspace);
+        assert.deepStrictEqual(options.rejectUnauthorized, true);
+      });
+    });
+
+    suite('when proxyStrictSsl is not set', () => {
+      const getConfiguration = sinon.stub();
+      const workspace = {
+        getConfiguration,
+      } as unknown as IVSCodeWorkspace;
+      getConfiguration.withArgs('http', 'proxyStrictSSL').returns(false);
+      test('should return rejectUnauthorized false', () => {
+        const options = getProxyOptions(workspace);
+        assert.deepStrictEqual(options.rejectUnauthorized, false);
+      });
+    });
+  });
+
   test('Proxy is set in VS Code settings', () => {
     const getConfiguration = sinon.stub();
     getConfiguration.withArgs('http', 'proxy').returns(proxy);

--- a/src/test/unit/common/proxy.test.ts
+++ b/src/test/unit/common/proxy.test.ts
@@ -20,7 +20,7 @@ suite('Proxy', () => {
 
   test('No proxy set', () => {
     const getConfiguration = sinon.stub();
-    getConfiguration.withArgs('http', 'proxy').returns(undefined);
+    getConfiguration.withArgs('http', 'proxyStrictSSL').returns(proxyStrictSSL);
 
     const workspace = {
       getConfiguration,
@@ -28,7 +28,8 @@ suite('Proxy', () => {
 
     const agent = getHttpsProxyAgent(workspace);
 
-    assert.strictEqual(agent, undefined);
+    // @ts-ignore: cannot test options otherwise
+    assert.deepStrictEqual(agent?.proxy.rejectUnauthorized, proxyStrictSSL);
   });
 
   test('Proxy is set in VS Code settings', () => {

--- a/src/test/unit/common/proxy.test.ts
+++ b/src/test/unit/common/proxy.test.ts
@@ -11,7 +11,8 @@ suite('Proxy', () => {
   const host = 'my.proxy.com';
   const port = 8080;
   const auth = 'user:password';
-  const proxy = `https://${auth}@${host}:${port}`;
+  const protocol = 'https:';
+  const proxy = `${protocol}//${auth}@${host}:${port}`;
   const proxyStrictSSL = true;
 
   teardown(() => {
@@ -20,7 +21,7 @@ suite('Proxy', () => {
 
   test('No proxy set', () => {
     const getConfiguration = sinon.stub();
-    getConfiguration.withArgs('http', 'proxyStrictSSL').returns(proxyStrictSSL);
+    getConfiguration.withArgs('http', 'proxy').returns(undefined);
 
     const workspace = {
       getConfiguration,
@@ -77,7 +78,7 @@ suite('Proxy', () => {
     assert.deepStrictEqual(agent?.proxy.rejectUnauthorized, proxyStrictSSL);
   });
 
-  test('getProxyEnvVariable should return the proxy as env var', () => {
+  test('getProxyEnvVariable should return the https proxy as env var', () => {
     const getConfiguration = sinon.stub();
     getConfiguration.withArgs('http', 'proxy').returns(proxy);
     getConfiguration.withArgs('http', 'proxyStrictSSL').returns(proxyStrictSSL);
@@ -89,6 +90,6 @@ suite('Proxy', () => {
     const envVariable = getProxyEnvVariable(getProxyOptions(workspace));
 
     // noinspection HttpUrlsUsage
-    assert.deepStrictEqual(envVariable, `http://${auth}@${host}:${port}`);
+    assert.deepStrictEqual(envVariable, `${protocol}//${auth}@${host}:${port}`);
   });
 });


### PR DESCRIPTION
### Description

_This PR should update the `getProxyOptions` method to always respect the strictSSL VSCode config._

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
