### PR TITLE
fix: reuse current output channel instead of disposing and creating a new one [ROAD-1226]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Snyk Security - Code and Open Source Dependencies Changelog
 
+## [1.7.7]
+
+### Fixed
+
+- `Error: Channel has been closed` exception.
+
 ## [1.7.6]
 
 ### Fixed

--- a/src/snyk/common/languageServer/languageServer.ts
+++ b/src/snyk/common/languageServer/languageServer.ts
@@ -82,7 +82,7 @@ export class LanguageServer implements ILanguageServer {
         configurationSection: CONFIGURATION_IDENTIFIER,
       },
       middleware: new LanguageClientMiddleware(this.configuration),
-      outputChannel: this.window.createOutputChannel(SNYK_LANGUAGE_SERVER_NAME),
+      outputChannel: this.client?.outputChannel ?? this.window.createOutputChannel(SNYK_LANGUAGE_SERVER_NAME),
     };
 
     // Create the language client and start the client.
@@ -150,8 +150,7 @@ export class LanguageServer implements ILanguageServer {
     if (this.client?.needsStop()) {
       await this.client.stop();
     }
-    // cleanup output channel explicitly
-    this.client.outputChannel.dispose();
+
     this.logger.info('Snyk Language Server stopped');
   }
 }

--- a/src/snyk/common/languageServer/languageServer.ts
+++ b/src/snyk/common/languageServer/languageServer.ts
@@ -82,6 +82,10 @@ export class LanguageServer implements ILanguageServer {
         configurationSection: CONFIGURATION_IDENTIFIER,
       },
       middleware: new LanguageClientMiddleware(this.configuration),
+      /**
+       * We reuse the output channel here as it's not properly disposed of by the language client (vscode-languageclient@8.0.0-next.2)
+       * See: https://github.com/microsoft/vscode-languageserver-node/blob/cdf4d6fdaefe329ce417621cf0f8b14e0b9bb39d/client/src/common/client.ts#L2789
+       */
       outputChannel: this.client?.outputChannel ?? this.window.createOutputChannel(SNYK_LANGUAGE_SERVER_NAME),
     };
 


### PR DESCRIPTION
### Description

_This PR should fix a Sentry exception being thrown (`Error: Channel has been closed`) by reusing the current output channel instead of creating a new one_

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated