### PR TITLE
feat: allow configuring IaC via settings [ROAD-1149]

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,12 @@
             "description": "Find and fix code quality issues in your application code in real time.",
             "default": true
           },
+          "snyk.features.infrastructureAsCode": {
+            "type": "boolean",
+            "title": "Snyk Infrastructure as Code issues",
+            "description": "Find and fix your IaC misconfigurations.",
+            "default": true
+          },
           "snyk.severity": {
             "type": "object",
             "default": {

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -15,6 +15,7 @@ import {
   CODE_SECURITY_ENABLED_SETTING,
   CONFIGURATION_IDENTIFIER,
   FEATURES_PREVIEW_SETTING,
+  IAC_ENABLED_SETTING,
   OSS_ENABLED_SETTING,
   SEVERITY_FILTER_SETTING,
   TRUSTED_FOLDERS,
@@ -30,6 +31,7 @@ export type FeaturesConfiguration = {
   ossEnabled: boolean | undefined;
   codeSecurityEnabled: boolean | undefined;
   codeQualityEnabled: boolean | undefined;
+  iacEnabled: boolean | undefined;
 };
 
 export interface SeverityFilter {
@@ -275,16 +277,26 @@ export class Configuration implements IConfiguration {
       CONFIGURATION_IDENTIFIER,
       this.getConfigName(CODE_QUALITY_ENABLED_SETTING),
     );
+    const iacEnabled = this.workspace.getConfiguration<boolean>(
+      CONFIGURATION_IDENTIFIER,
+      this.getConfigName(IAC_ENABLED_SETTING),
+    );
 
-    if (_.isUndefined(ossEnabled) && _.isUndefined(codeSecurityEnabled) && _.isUndefined(codeQualityEnabled)) {
+    if (
+      _.isUndefined(ossEnabled) &&
+      _.isUndefined(codeSecurityEnabled) &&
+      _.isUndefined(codeQualityEnabled) &&
+      _.isUndefined(iacEnabled)
+    ) {
       // TODO: return 'undefined' to render feature selection screen once OSS integration is available
-      return { ossEnabled: true, codeSecurityEnabled: true, codeQualityEnabled: true };
+      return { ossEnabled: true, codeSecurityEnabled: true, codeQualityEnabled: true, iacEnabled: true };
     }
 
     return {
       ossEnabled,
       codeSecurityEnabled,
       codeQualityEnabled,
+      iacEnabled,
     };
   }
 

--- a/src/snyk/common/constants/settings.ts
+++ b/src/snyk/common/constants/settings.ts
@@ -5,6 +5,7 @@ export const CONFIGURATION_IDENTIFIER = 'snyk';
 export const OSS_ENABLED_SETTING = `${CONFIGURATION_IDENTIFIER}.features.openSourceSecurity`;
 export const CODE_SECURITY_ENABLED_SETTING = `${CONFIGURATION_IDENTIFIER}.features.codeSecurity`;
 export const CODE_QUALITY_ENABLED_SETTING = `${CONFIGURATION_IDENTIFIER}.features.codeQuality`;
+export const IAC_ENABLED_SETTING = `${CONFIGURATION_IDENTIFIER}.features.infrastructureAsCode`;
 export const FEATURES_PREVIEW_SETTING = `${CONFIGURATION_IDENTIFIER}.features.preview`;
 
 export const YES_CRASH_REPORT_SETTING = `${CONFIGURATION_IDENTIFIER}.yesCrashReport`;

--- a/src/snyk/common/languageServer/settings.ts
+++ b/src/snyk/common/languageServer/settings.ts
@@ -26,10 +26,12 @@ export type ServerSettings = {
 
 export class LanguageServerSettings {
   static async fromConfiguration(configuration: IConfiguration): Promise<ServerSettings> {
+    const iacEnabled =
+      configuration.getPreviewFeatures().lsIacScan && configuration.getFeaturesConfiguration()?.iacEnabled;
     return {
       activateSnykCode: 'false',
       activateSnykOpenSource: 'false',
-      activateSnykIac: `${configuration.getPreviewFeatures().lsIacScan}`,
+      activateSnykIac: `${iacEnabled ?? false}`,
       enableTelemetry: `${configuration.shouldReportEvents}`,
       sendErrorReports: `${configuration.shouldReportErrors}`,
       cliPath: configuration.getCliPath(),


### PR DESCRIPTION
### Description

⚠️ To be merged before IaC feature flag drop.

Enables configuring IaC enablement.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing
