### PR TITLE
feat: Enable IaC scan behind preview feature flag [ROAD-1142]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Snyk Security - Code and Open Source Dependencies Changelog
 
+## [1.7.8]
+
+### Added
+
+- Snyk LS: (Preview) Added IaC scans enabled by feature flag (`lsIacScan`).
+
 ## [1.7.7]
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
                 "description": "Discover the health (maintenance, community, popularity & security) status of your open source packages.",
                 "default": false
               },
-              "LsIacScan": {
+              "lsIacScan": {
                 "type": "boolean",
                 "title": "(Preview) Enable Snyk Infrastructure as Code scans",
                 "description": "(Preview) Run IaC scans through Language Server",

--- a/package.json
+++ b/package.json
@@ -193,6 +193,12 @@
                 "title": "Enable \"Snyk Advisor\"",
                 "description": "Discover the health (maintenance, community, popularity & security) status of your open source packages.",
                 "default": false
+              },
+              "LsIacScan": {
+                "type": "boolean",
+                "title": "(Preview) Enable Snyk Infrastructure as Code scans",
+                "description": "(Preview) Run IaC scans through Language Server",
+                "default": false
               }
             }
           }

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -43,6 +43,7 @@ export interface SeverityFilter {
 export type PreviewFeatures = {
   reportFalsePositives: boolean | undefined;
   advisor: boolean | undefined;
+  lsIacScan: boolean | undefined;
 };
 
 export interface IConfiguration {

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -391,6 +391,7 @@ export class Configuration implements IConfiguration {
     const defaultSetting: PreviewFeatures = {
       reportFalsePositives: false,
       advisor: false,
+      lsIacScan: false,
     };
 
     const userSetting =

--- a/src/snyk/common/languageServer/settings.ts
+++ b/src/snyk/common/languageServer/settings.ts
@@ -27,7 +27,7 @@ export class LanguageServerSettings {
     return {
       activateSnykCode: 'false',
       activateSnykOpenSource: 'false',
-      activateSnykIac: 'false',
+      activateSnykIac: `${configuration.getPreviewFeatures().lsIacScan}`,
       enableTelemetry: `${configuration.shouldReportEvents}`,
       sendErrorReports: `${configuration.shouldReportErrors}`,
       cliPath: configuration.getCliPath(),

--- a/src/test/unit/common/configuration.test.ts
+++ b/src/test/unit/common/configuration.test.ts
@@ -182,6 +182,7 @@ suite('Configuration', () => {
     deepStrictEqual(configuration.getPreviewFeatures(), {
       reportFalsePositives: false,
       advisor: false,
+      lsIacScan: false,
     } as PreviewFeatures);
   });
 
@@ -189,6 +190,7 @@ suite('Configuration', () => {
     const previewFeatures = {
       reportFalsePositives: true,
       advisor: false,
+      lsIacScan: false,
     } as PreviewFeatures;
     const workspace = stubWorkspaceConfiguration(FEATURES_PREVIEW_SETTING, previewFeatures);
 

--- a/src/test/unit/common/languageServer/languageServer.test.ts
+++ b/src/test/unit/common/languageServer/languageServer.test.ts
@@ -42,6 +42,13 @@ suite('Language Server', () => {
       isAutomaticDependencyManagementEnabled() {
         return true;
       },
+      getPreviewFeatures() {
+        return {
+          lsIacScan: false,
+          advisor: false,
+          reportFalsePositives: false,
+        };
+      },
     } as IConfiguration;
 
     downloadService = {

--- a/src/test/unit/common/languageServer/middleware.test.ts
+++ b/src/test/unit/common/languageServer/middleware.test.ts
@@ -24,6 +24,13 @@ suite('Language Server: Middleware', () => {
       getToken: () => Promise.resolve('token'),
       isAutomaticDependencyManagementEnabled: () => true,
       getCliPath: () => '/path/to/cli',
+      getPreviewFeatures: () => {
+        return {
+          lsIacScan: false,
+          advisor: false,
+          reportFalsePositives: false,
+        };
+      },
     } as IConfiguration;
   });
 


### PR DESCRIPTION
### Description

Allow enablement of IaC scans through LS via feature flag

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing
