### PR TITLE
fix: readme sync path

### DIFF
--- a/.github/workflows/readme-sync.yaml
+++ b/.github/workflows/readme-sync.yaml
@@ -52,7 +52,7 @@ jobs:
             echo "No documentation changes detected, exiting."
           fi
         env:
-          SOURCE_PATH: ./docs/docs/ide-tools/visual-studio-code-extension-for-snyk-code/README.md
+          SOURCE_PATH: ./docs/ide-tools/visual-studio-code-extension/README.md
           FILE_TO_COMMIT: README.md
           DESTINATION_REPOSITORY: vscode-extension
           DESTINATION_BRANCH: docs/automatic-gitbook-update

--- a/.github/workflows/readme-sync.yaml
+++ b/.github/workflows/readme-sync.yaml
@@ -52,7 +52,7 @@ jobs:
             echo "No documentation changes detected, exiting."
           fi
         env:
-          SOURCE_PATH: ./docs/ide-tools/visual-studio-code-extension/README.md
+          SOURCE_PATH: ./docs/docs/ide-tools/visual-studio-code-extension/README.md
           FILE_TO_COMMIT: README.md
           DESTINATION_REPOSITORY: vscode-extension
           DESTINATION_BRANCH: docs/automatic-gitbook-update


### PR DESCRIPTION
### Description
VS Code extension docs path has changed to https://github.com/snyk/user-docs/blob/main/docs/ide-tools/visual-studio-code-extension/README.md

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
