### PR TITLE
fix: proxyStrictSsl setting should only apply to proxied requests [ROAD-1245]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Snyk Security - Code and Open Source Dependencies Changelog
 
+## [1.12.0]
+
+### Fixed
+
+- Regression introduced in 1.7.6
+
 ## [1.11.0]
 
 ### Changed

--- a/src/test/unit/common/proxy.test.ts
+++ b/src/test/unit/common/proxy.test.ts
@@ -29,34 +29,7 @@ suite('Proxy', () => {
 
     const agent = getHttpsProxyAgent(workspace);
 
-    // @ts-ignore: cannot test options otherwise
-    assert.deepStrictEqual(agent?.proxy.rejectUnauthorized, proxyStrictSSL);
-  });
-
-  suite('.getProxyOptions()', () => {
-    suite('when proxyStrictSsl is set', () => {
-      const getConfiguration = sinon.stub();
-      const workspace = {
-        getConfiguration,
-      } as unknown as IVSCodeWorkspace;
-      getConfiguration.withArgs('http', 'proxyStrictSSL').returns(true);
-      test('should return rejectUnauthorized true', () => {
-        const options = getProxyOptions(workspace);
-        assert.deepStrictEqual(options.rejectUnauthorized, true);
-      });
-    });
-
-    suite('when proxyStrictSsl is not set', () => {
-      const getConfiguration = sinon.stub();
-      const workspace = {
-        getConfiguration,
-      } as unknown as IVSCodeWorkspace;
-      getConfiguration.withArgs('http', 'proxyStrictSSL').returns(false);
-      test('should return rejectUnauthorized false', () => {
-        const options = getProxyOptions(workspace);
-        assert.deepStrictEqual(options.rejectUnauthorized, false);
-      });
-    });
+    assert.deepStrictEqual(agent, undefined);
   });
 
   test('Proxy is set in VS Code settings', () => {


### PR DESCRIPTION
### Description

_The `Http: Strict Proxy SSL` setting is to apply it to proxied requests only; so when no proxy is set, it should not be used to set `rejectUnauthorized`_

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
