### PR TITLE
fix: trust workspace folder if parent dir is trusted [ROAD-1250]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Snyk Security - Code and Open Source Dependencies Changelog
+## [1.12.2]
+### Fixed
+- trust workspace folders if parent dir is trusted
 
 ## [1.12.0]
 

--- a/src/snyk/common/configuration/trustedFolders.ts
+++ b/src/snyk/common/configuration/trustedFolders.ts
@@ -2,6 +2,12 @@ import { IConfiguration } from './configuration';
 
 export function getTrustedFolders(config: IConfiguration, workspaceFolders: string[]): string[] {
   const trustedFolders = config.getTrustedFolders();
+  const path = require('path');
 
-  return workspaceFolders.filter(folder => trustedFolders.includes(folder));
+  return workspaceFolders.filter(folder => {
+    return trustedFolders.some(trustedFolder => {
+      const relative = path.relative(trustedFolder, folder);
+      return relative && !relative.startsWith('..' + path.separator) && !path.isAbsolute(relative);
+    });
+  });
 }

--- a/src/snyk/common/configuration/trustedFolders.ts
+++ b/src/snyk/common/configuration/trustedFolders.ts
@@ -7,7 +7,7 @@ export function getTrustedFolders(config: IConfiguration, workspaceFolders: stri
   return workspaceFolders.filter(folder => {
     return trustedFolders.some(trustedFolder => {
       const relative = path.relative(trustedFolder, folder);
-      return relative && !relative.startsWith('..' + path.sep) && !path.isAbsolute(relative);
+      return relative === '' || (relative && !relative.startsWith('..' + path.sep) && !path.isAbsolute(relative));
     });
   });
 }

--- a/src/snyk/common/configuration/trustedFolders.ts
+++ b/src/snyk/common/configuration/trustedFolders.ts
@@ -1,13 +1,13 @@
 import { IConfiguration } from './configuration';
 
+import path from 'path';
+
 export function getTrustedFolders(config: IConfiguration, workspaceFolders: string[]): string[] {
   const trustedFolders = config.getTrustedFolders();
-  const path = require('path');
-
   return workspaceFolders.filter(folder => {
     return trustedFolders.some(trustedFolder => {
       const relative = path.relative(trustedFolder, folder);
-      return relative && !relative.startsWith('..' + path.separator) && !path.isAbsolute(relative);
+      return relative && !relative.startsWith('..' + path.sep) && !path.isAbsolute(relative);
     });
   });
 }

--- a/src/test/unit/common/configuration/trustedFolders.test.ts
+++ b/src/test/unit/common/configuration/trustedFolders.test.ts
@@ -35,4 +35,26 @@ suite('Trusted Folders', () => {
 
     deepStrictEqual(trustedFolders, []);
   });
+
+  test('Parent folder trusted', () => {
+    const config = {
+      getTrustedFolders: () => ['/test'],
+    } as IConfiguration;
+    const workspaceFolders = ['/test/workspace', '/test/workspace2'];
+
+    const trustedFolders = getTrustedFolders(config, workspaceFolders);
+
+    deepStrictEqual(trustedFolders, ['/test/workspace', '/test/workspace2']);
+  });
+
+  test('Parent folder trusted (trailing slash)', () => {
+    const config = {
+      getTrustedFolders: () => ['/test/'],
+    } as IConfiguration;
+    const workspaceFolders = ['/test/workspace', '/test/workspace2'];
+
+    const trustedFolders = getTrustedFolders(config, workspaceFolders);
+
+    deepStrictEqual(trustedFolders, ['/test/workspace', '/test/workspace2']);
+  });
 });


### PR DESCRIPTION
### Description

Previously, if `/test` was trusted, `/test/folder` was not trusted in Open Source and Code scans. This is fixed with this PR.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
