### PR TITLE
feat: report progress to the tree view for Code scans using LS [ROAD-1266]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Snyk Security - Code and Open Source Dependencies Changelog
+
 ## [1.13.0]
-### Fixed
-- trust workspace folders if parent dir is trusted
 
-### Changed
-- removed background notification about found vulnerabilities in Snyk Open Source
+### Added
 
+- Enabling Snyk Code scans using Language Server under a feature flag.
 
 ## [1.12.3]
+
 ### Fixed
+
+- Trust workspace folders if parent dir is trusted.
 - Snyk LS: updated protocol version.
 - Contact and documentation url.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Snyk LS: updated protocol version.
 - Contact and documentation url.
 
+### Changed
+
+- Removed background notification about found vulnerabilities in Snyk Open Source.
+
 ## [1.12.2]
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -197,6 +197,12 @@
             "description": "Preview features that are currently in development. Setting keys will be removed when features become stable.",
             "propertyNames": true,
             "properties": {
+              "lsCode": {
+                "type": "boolean",
+                "title": "Enable \"Code\" using Snyk Language Server",
+                "description": "Enables Snyk Code results delivery using Snyk Language Server.",
+                "default": false
+              },
               "reportFalsePositives": {
                 "type": "boolean",
                 "title": "Enable \"report false positives\"",
@@ -242,14 +248,24 @@
           "when": "snyk:loggedIn && snyk:featuresSelected && snyk:workspaceFound && !snyk:error"
         },
         {
-          "id": "snyk.views.analysis.code.security",
+          "id": "snyk.views.analysis.code.security.old",
           "name": "Code Security",
           "when": "snyk:loggedIn && snyk:featuresSelected && snyk:codeEnabled && !snyk:codeLocalEngineEnabled && snyk:workspaceFound && !snyk:error"
         },
         {
-          "id": "snyk.views.analysis.code.quality",
+          "id": "snyk.views.analysis.code.quality.old",
           "name": "Code Quality",
           "when": "snyk:loggedIn && snyk:featuresSelected && snyk:codeEnabled && !snyk:codeLocalEngineEnabled && snyk:workspaceFound && !snyk:error"
+        },
+        {
+          "id": "snyk.views.analysis.code.security",
+          "name": "Code Security (LS)",
+          "when": "snyk:lsCodePreview && snyk:loggedIn && snyk:featuresSelected && snyk:codeEnabled && !snyk:codeLocalEngineEnabled && snyk:workspaceFound && !snyk:error"
+        },
+        {
+          "id": "snyk.views.analysis.code.quality",
+          "name": "Code Quality (LS)",
+          "when": "snyk:lsCodePreview && snyk:loggedIn && snyk:featuresSelected && snyk:codeEnabled && !snyk:codeLocalEngineEnabled && snyk:workspaceFound && !snyk:error"
         },
         {
           "id": "snyk.views.analysis.code.enablement",
@@ -326,12 +342,12 @@
       "view/title": [
         {
           "command": "snyk.start",
-          "when": "view == 'snyk.views.analysis.code.security' || view == 'snyk.views.analysis.code.quality' || view == 'snyk.views.analysis.oss'",
+          "when": "view == 'snyk.views.analysis.code.security.old' || view == 'snyk.views.analysis.code.security' || view == 'snyk.views.analysis.code.quality.old' || view == 'snyk.views.analysis.code.quality' || view == 'snyk.views.analysis.oss'",
           "group": "navigation"
         },
         {
           "command": "snyk.settings",
-          "when": "view == 'snyk.views.analysis.code.security' || view == 'snyk.views.analysis.code.quality' || view == 'snyk.views.analysis.oss' || view == 'snyk.views.welcome' || view == 'snyk.views.actions'",
+          "when": "view == 'snyk.views.analysis.code.security.old' || view == 'snyk.views.analysis.code.security' || view == 'snyk.views.analysis.code.quality.old' || view == 'snyk.views.analysis.code.quality' || view == 'snyk.views.analysis.oss' || view == 'snyk.views.welcome' || view == 'snyk.views.actions'",
           "group": "navigation"
         }
       ],
@@ -390,6 +406,11 @@
       {
         "command": "snyk.showOutputChannel",
         "title": "Show Output Channel",
+        "category": "Snyk"
+      },
+      {
+        "command": "snyk.showLsOutputChannel",
+        "title": "Show Language Server Output Channel",
         "category": "Snyk"
       }
     ]

--- a/src/snyk/base/modules/baseSnykModule.ts
+++ b/src/snyk/base/modules/baseSnykModule.ts
@@ -1,14 +1,16 @@
 import { AdvisorApiClient, IAdvisorApiClient } from '../../advisor/services/advisorApiClient';
 import AdvisorProvider from '../../advisor/services/advisorProvider';
 import { AdvisorService } from '../../advisor/services/advisorService';
-import { DownloadService } from '../../common/services/downloadService';
 import { IAnalytics } from '../../common/analytics/itly';
 import { ISnykApiClient, SnykApiClient } from '../../common/api/apiСlient';
 import { CommandController } from '../../common/commands/commandController';
 import { configuration } from '../../common/configuration/instance';
+import { IWorkspaceTrust, WorkspaceTrust } from '../../common/configuration/trustedFolders';
 import { ExperimentService } from '../../common/experiment/services/experimentService';
+import { ILanguageServer } from '../../common/languageServer/languageServer';
 import { Logger } from '../../common/logger/logger';
 import { ContextService, IContextService } from '../../common/services/contextService';
+import { DownloadService } from '../../common/services/downloadService';
 import { LearnService } from '../../common/services/learnService';
 import { INotificationService } from '../../common/services/notificationService';
 import { IOpenerService, OpenerService } from '../../common/services/openerService';
@@ -19,6 +21,7 @@ import { IMarkdownStringAdapter, MarkdownStringAdapter } from '../../common/vsco
 import { vsCodeWorkspace } from '../../common/vscode/workspace';
 import { IWatcher } from '../../common/watchers/interfaces';
 import { ISnykCodeService } from '../../snykCode/codeService';
+import { ISnykCodeServiceOld } from '../../snykCode/codeServiceOld';
 import { CodeSettings, ICodeSettings } from '../../snykCode/codeSettings';
 import { ISnykCodeErrorHandler, SnykCodeErrorHandler } from '../../snykCode/error/snykCodeErrorHandler';
 import { FalsePositiveApi, IFalsePositiveApi } from '../../snykCode/falsePositive/api/falsePositiveApi';
@@ -30,7 +33,6 @@ import { ScanModeService } from '../services/scanModeService';
 import SnykStatusBarItem, { IStatusBarItem } from '../statusBarItem/statusBarItem';
 import { ILoadingBadge, LoadingBadge } from '../views/loadingBadge';
 import { IBaseSnykModule } from './interfaces';
-import { ILanguageServer } from '../../common/languageServer/languageServer';
 
 export default abstract class BaseSnykModule implements IBaseSnykModule {
   context: ExtensionContext;
@@ -60,6 +62,7 @@ export default abstract class BaseSnykModule implements IBaseSnykModule {
   protected snykApiClient: ISnykApiClient;
   protected advisorApiClient: IAdvisorApiClient;
   protected falsePositiveApi: IFalsePositiveApi;
+  snykCodeOld: ISnykCodeServiceOld;
   snykCode: ISnykCodeService;
   protected codeSettings: ICodeSettings;
 
@@ -69,6 +72,7 @@ export default abstract class BaseSnykModule implements IBaseSnykModule {
   protected snykCodeErrorHandler: ISnykCodeErrorHandler;
 
   protected markdownStringAdapter: IMarkdownStringAdapter;
+  readonly workspaceTrust: IWorkspaceTrust;
 
   constructor() {
     this.statusBarItem = new SnykStatusBarItem();
@@ -90,6 +94,7 @@ export default abstract class BaseSnykModule implements IBaseSnykModule {
     this.codeSettings = new CodeSettings(this.snykApiClient, this.contextService, configuration, this.openerService);
     this.advisorApiClient = new AdvisorApiClient(configuration, Logger);
     this.markdownStringAdapter = new MarkdownStringAdapter();
+    this.workspaceTrust = new WorkspaceTrust();
   }
 
   abstract runScan(): Promise<void>;

--- a/src/snyk/base/modules/interfaces.ts
+++ b/src/snyk/base/modules/interfaces.ts
@@ -1,9 +1,10 @@
+import { IWorkspaceTrust } from '../../common/configuration/trustedFolders';
 import { IContextService } from '../../common/services/contextService';
 import { IOpenerService } from '../../common/services/openerService';
 import { IViewManagerService } from '../../common/services/viewManagerService';
 import { ExtensionContext } from '../../common/vscode/extensionContext';
 import { ExtensionContext as VSCodeExtensionContext } from '../../common/vscode/types';
-import { ISnykCodeService } from '../../snykCode/codeService';
+import { ISnykCodeServiceOld } from '../../snykCode/codeServiceOld';
 import { IStatusBarItem } from '../statusBarItem/statusBarItem';
 import { ILoadingBadge } from '../views/loadingBadge';
 
@@ -13,7 +14,8 @@ export interface IBaseSnykModule {
   contextService: IContextService;
   openerService: IOpenerService;
   viewManagerService: IViewManagerService;
-  snykCode: ISnykCodeService;
+  snykCodeOld: ISnykCodeServiceOld;
+  readonly workspaceTrust: IWorkspaceTrust;
 
   // Abstract methods
   runScan(): Promise<void>;

--- a/src/snyk/base/modules/snykLib.ts
+++ b/src/snyk/base/modules/snykLib.ts
@@ -97,7 +97,7 @@ export default class SnykLib extends BaseSnykModule implements ISnykLib {
       paths = vsCodeWorkspace.getWorkspaceFolders();
     }
 
-    await this.snykCode.startAnalysis(paths, manual, reportTriggeredEvent);
+    await this.snykCodeOld.startAnalysis(paths, manual, reportTriggeredEvent);
   }
 
   async onDidChangeWelcomeViewVisibility(visible: boolean): Promise<void> {

--- a/src/snyk/common/analysis/statusProvider.ts
+++ b/src/snyk/common/analysis/statusProvider.ts
@@ -5,6 +5,8 @@ export class AnalysisStatusProvider {
   private _lastAnalysisDuration = 0;
   private _lastAnalysisTimestamp = Date.now();
 
+  private _isLsDownloadSuccessful = true;
+
   get isAnalysisRunning(): boolean {
     return this.runningAnalysis;
   }
@@ -13,6 +15,14 @@ export class AnalysisStatusProvider {
   }
   get lastAnalysisTimestamp(): number {
     return this._lastAnalysisTimestamp;
+  }
+
+  get isLsDownloadSuccessful(): boolean {
+    return this._isLsDownloadSuccessful;
+  }
+
+  handleLsDownloadFailure(): void {
+    this._isLsDownloadSuccessful = false;
   }
 
   analysisStarted(): void {

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -44,6 +44,7 @@ export interface SeverityFilter {
 }
 
 export type PreviewFeatures = {
+  lsCode: boolean | undefined;
   reportFalsePositives: boolean | undefined;
   advisor: boolean | undefined;
 };
@@ -85,7 +86,7 @@ export interface IConfiguration {
 
   hideWelcomeNotification(): Promise<void>;
 
-  getFeaturesConfiguration(): FeaturesConfiguration | undefined;
+  getFeaturesConfiguration(): FeaturesConfiguration;
 
   setFeaturesConfiguration(config: FeaturesConfiguration | undefined): Promise<void>;
 
@@ -263,7 +264,7 @@ export class Configuration implements IConfiguration {
     return this.defaultBaseApiHost;
   }
 
-  getFeaturesConfiguration(): FeaturesConfiguration | undefined {
+  getFeaturesConfiguration(): FeaturesConfiguration {
     const ossEnabled = this.workspace.getConfiguration<boolean>(
       CONFIGURATION_IDENTIFIER,
       this.getConfigName(OSS_ENABLED_SETTING),
@@ -405,6 +406,7 @@ export class Configuration implements IConfiguration {
 
   getPreviewFeatures(): PreviewFeatures {
     const defaultSetting: PreviewFeatures = {
+      lsCode: false,
       reportFalsePositives: false,
       advisor: false,
     };

--- a/src/snyk/common/constants/commands.ts
+++ b/src/snyk/common/constants/commands.ts
@@ -16,8 +16,8 @@ export const SNYK_OPEN_BROWSER_COMMAND = 'snyk.open';
 export const SNYK_OPEN_LOCAL_COMMAND = 'snyk.show';
 export const SNYK_OPEN_ISSUE_COMMAND = 'snyk.showissue';
 export const SNYK_IGNORE_ISSUE_COMMAND = 'snyk.ignoreissue';
-export const SNYK_REPORT_FALSE_POSITIVE_COMMAND = 'snyk.reportFalsePositive';
 export const SNYK_SHOW_OUTPUT_COMMAND = 'snyk.showOutputChannel';
+export const SNYK_SHOW_LS_OUTPUT_COMMAND = 'snyk.showLsOutputChannel';
 
 // custom Snyk constants used in commands
 export const SNYK_CONTEXT_PREFIX = 'snyk:';

--- a/src/snyk/common/constants/languageServer.ts
+++ b/src/snyk/common/constants/languageServer.ts
@@ -11,6 +11,7 @@ export const DID_CHANGE_CONFIGURATION_METHOD = 'workspace/didChangeConfiguration
 export const SNYK_HAS_AUTHENTICATED = '$/snyk.hasAuthenticated';
 export const SNYK_CLI_PATH = '$/snyk.isAvailableCli';
 export const SNYK_ADD_TRUSTED_FOLDERS = '$/snyk.addTrustedFolders';
+export const SNYK_SCAN = '$/snyk.scan';
 
 // commands
 export const SNYK_LOGIN_COMMAND = 'snyk.login';

--- a/src/snyk/common/constants/views.ts
+++ b/src/snyk/common/constants/views.ts
@@ -1,6 +1,8 @@
 export const SNYK_VIEW_WELCOME = 'snyk.views.welcome';
 export const SNYK_VIEW_FEATURES = 'snyk.views.features';
 export const SNYK_VIEW_ANALYSIS_CODE_ENABLEMENT = 'snyk.views.analysis.code.enablement';
+export const SNYK_VIEW_ANALYSIS_CODE_SECURITY_OLD = 'snyk.views.analysis.code.security.old';
+export const SNYK_VIEW_ANALYSIS_CODE_QUALITY_OLD = 'snyk.views.analysis.code.quality.old';
 export const SNYK_VIEW_ANALYSIS_CODE_SECURITY = 'snyk.views.analysis.code.security';
 export const SNYK_VIEW_ANALYSIS_CODE_QUALITY = 'snyk.views.analysis.code.quality';
 export const SNYK_VIEW_ANALYSIS_OSS = 'snyk.views.analysis.oss';
@@ -18,6 +20,7 @@ export const SNYK_CONTEXT = {
   FEATURES_SELECTED: 'featuresSelected',
   CODE_ENABLED: 'codeEnabled',
   CODE_LOCAL_ENGINE_ENABLED: 'codeLocalEngineEnabled',
+  LS_CODE_PREVIEW: 'lsCodePreview',
   WORKSPACE_FOUND: 'workspaceFound',
   ERROR: 'error',
   MODE: 'mode',

--- a/src/snyk/common/languageServer/settings.ts
+++ b/src/snyk/common/languageServer/settings.ts
@@ -29,14 +29,15 @@ export type ServerSettings = {
 
 export class LanguageServerSettings {
   static async fromConfiguration(configuration: IConfiguration): Promise<ServerSettings> {
-    let iacEnabled = configuration.getFeaturesConfiguration()?.iacEnabled;
-    if (_.isUndefined(iacEnabled)) {
-      iacEnabled = true;
-    }
+    const featuresConfiguration = configuration.getFeaturesConfiguration();
+
+    const iacEnabled = _.isUndefined(featuresConfiguration.iacEnabled) ? true : featuresConfiguration.iacEnabled;
+    const codeSecurityEnabled = configuration.getPreviewFeatures().lsCode && featuresConfiguration?.codeSecurityEnabled;
+    const codeQualityEnabled = configuration.getPreviewFeatures().lsCode && featuresConfiguration?.codeQualityEnabled;
 
     return {
-      activateSnykCodeSecurity: 'false', // TODO: fill this with preference settings, once LS serves Snyk Code Security issues
-      activateSnykCodeQuality: 'false', // TODO: fill this with preference settings, once LS serves Snyk Code Quality issues
+      activateSnykCodeSecurity: `${codeSecurityEnabled ?? false}`,
+      activateSnykCodeQuality: `${codeQualityEnabled ?? false}`,
       activateSnykOpenSource: 'false',
       activateSnykIac: `${iacEnabled}`,
       enableTelemetry: `${configuration.shouldReportEvents}`,

--- a/src/snyk/common/languageServer/types.ts
+++ b/src/snyk/common/languageServer/types.ts
@@ -1,0 +1,100 @@
+export enum ScanProduct {
+  Code = 'code',
+  OpenSource = 'oss',
+  InfrastructureAsCode = 'iac',
+}
+
+export type InProgress = 'inProgress';
+export enum ScanStatus {
+  InProgress = 'inProgress',
+  Success = 'success',
+  Error = 'error',
+}
+
+export type Scan<T> = {
+  folderPath: string;
+  product: ScanProduct;
+  status: ScanStatus;
+  issues: Issue<T>[];
+};
+
+export type Issue<T> = {
+  id: string;
+  title: string;
+  severity: IssueSeverity;
+  additionalData: T;
+};
+
+enum IssueSeverity {
+  Critical = 'critical',
+  High = 'high',
+  Medium = 'medium',
+  Low = 'low',
+}
+
+// Snyk Code
+export type CodeIssueData = {
+  message: string;
+  leadURL?: string;
+  rule: string;
+  repoDatasetSize: number;
+  exampleCommitFixes: ExampleCommitFix[];
+  cwe: string[];
+  text: string;
+
+  markers?: Marker[];
+  cols: Point;
+  rows: Point;
+  isSecurityType: boolean;
+};
+
+type ExampleCommitFix = {
+  commitURL: string;
+  lines: CommitChangeLine[];
+};
+type CommitChangeLine = {
+  line: string;
+  lineNumber: number;
+  lineChange: 'removed' | 'added' | 'none';
+};
+type Marker = {
+  msg: Point;
+  pos: MarkerPosition[];
+};
+type MarkerPosition = Position & {
+  file: string;
+};
+type Position = {
+  cols: Point;
+  rows: Point;
+};
+type Point = [number, number];
+
+// Snyk Open Source
+export type OssIssueData = {
+  license?: string;
+  identifiers?: Identifiers; // may be common?
+  description: string; // may be common?
+  language: string;
+  packageManager: string;
+  packageName: string;
+  name: string;
+  version: string;
+  exploit?: string;
+
+  CVSSv3?: string;
+  cvssScore?: string;
+
+  fixedIn?: Array<string>;
+  from: Array<string>;
+  upgradePath: Array<string>;
+  isPatchable: boolean;
+  isUpgradable: boolean;
+
+  projectName: string;
+  displayTargetFile: string;
+};
+export type Identifiers = {
+  CWE: string[];
+  CVE: string[];
+};

--- a/src/snyk/common/messages/analysisMessages.ts
+++ b/src/snyk/common/messages/analysisMessages.ts
@@ -2,6 +2,7 @@ export const messages = {
   scanFailed: 'Scan failed',
   noWorkspaceTrust: 'No workspace folder was granted trust',
   clickToProblem: 'Click here to see the problem.',
+  scanRunning: 'Scanning for vulnerabilities...',
   allSeverityFiltersDisabled: 'Please enable severity filters to see the results.',
   duration: (time: string, day: string): string => `Analysis finished at ${time}, ${day}`,
   noWorkspaceTrustDescription:

--- a/src/snyk/common/services/viewManagerService.ts
+++ b/src/snyk/common/services/viewManagerService.ts
@@ -23,12 +23,15 @@ export class ViewContainer {
 export interface IViewManagerService {
   viewContainer: ViewContainer;
 
+  readonly refreshOldCodeSecurityViewEmitter: EventEmitter<void>;
+  readonly refreshOldCodeQualityViewEmitter: EventEmitter<void>;
   readonly refreshCodeSecurityViewEmitter: EventEmitter<void>;
   readonly refreshCodeQualityViewEmitter: EventEmitter<void>;
   readonly refreshOssViewEmitter: EventEmitter<void>;
 
   refreshAllViews(): void;
   refreshAllCodeAnalysisViews(): void;
+  refreshAllOldCodeAnalysisViews(): void;
   refreshCodeAnalysisViews(enabledFeatures?: FeaturesConfiguration | null): void;
   refreshCodeSecurityView(): void;
   refreshCodeQualityView(): void;
@@ -38,20 +41,31 @@ export interface IViewManagerService {
 export class ViewManagerService implements IViewManagerService {
   readonly viewContainer: ViewContainer;
 
+  readonly refreshOldCodeSecurityViewEmitter: EventEmitter<void>;
+  readonly refreshOldCodeQualityViewEmitter: EventEmitter<void>;
   readonly refreshCodeSecurityViewEmitter: EventEmitter<void>;
   readonly refreshCodeQualityViewEmitter: EventEmitter<void>;
+
   readonly refreshOssViewEmitter: EventEmitter<void>;
 
   constructor() {
+    this.refreshOldCodeSecurityViewEmitter = new EventEmitter<void>();
+    this.refreshOldCodeQualityViewEmitter = new EventEmitter<void>();
     this.refreshCodeSecurityViewEmitter = new EventEmitter<void>();
     this.refreshCodeQualityViewEmitter = new EventEmitter<void>();
+
     this.refreshOssViewEmitter = new EventEmitter<void>();
     this.viewContainer = new ViewContainer();
   }
 
   refreshAllViews(): void {
     this.refreshOssView();
-    this.refreshAllCodeAnalysisViews();
+    this.refreshAllOldCodeAnalysisViews();
+  }
+
+  refreshAllOldCodeAnalysisViews(): void {
+    this.refreshOldCodeSecurityView();
+    this.refreshOldCodeQualityView();
   }
 
   refreshAllCodeAnalysisViews(): void {
@@ -67,15 +81,31 @@ export class ViewManagerService implements IViewManagerService {
     }
 
     if (enabledFeatures.codeSecurityEnabled) {
-      this.refreshCodeSecurityView();
+      this.refreshOldCodeSecurityView();
     }
     if (enabledFeatures.codeQualityEnabled) {
-      this.refreshCodeQualityView();
+      this.refreshOldCodeQualityView();
     }
   }
 
   // Avoid refreshing context/views too often:
   // https://github.com/Microsoft/vscode/issues/68424
+  refreshOldCodeSecurityView = _.throttle(
+    (): void => this.refreshOldCodeSecurityViewEmitter.fire(),
+    REFRESH_VIEW_DEBOUNCE_INTERVAL,
+    {
+      leading: true,
+    },
+  );
+
+  refreshOldCodeQualityView = _.throttle(
+    (): void => this.refreshOldCodeQualityViewEmitter.fire(),
+    REFRESH_VIEW_DEBOUNCE_INTERVAL,
+    {
+      leading: true,
+    },
+  );
+
   refreshCodeSecurityView = _.throttle(
     (): void => this.refreshCodeSecurityViewEmitter.fire(),
     REFRESH_VIEW_DEBOUNCE_INTERVAL,

--- a/src/snyk/common/views/analysisTreeNodeProvider.ts
+++ b/src/snyk/common/views/analysisTreeNodeProvider.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import * as path from 'path';
 import { AnalysisStatusProvider } from '../analysis/statusProvider';
 import { IConfiguration } from '../configuration/configuration';
-import { SNYK_SHOW_OUTPUT_COMMAND } from '../constants/commands';
+import { SNYK_SHOW_LS_OUTPUT_COMMAND, SNYK_SHOW_OUTPUT_COMMAND } from '../constants/commands';
 import { messages } from '../messages/analysisMessages';
 import { NODE_ICONS, TreeNode } from './treeNode';
 import { TreeNodeProvider } from './treeNodeProvider';
@@ -58,6 +58,8 @@ export abstract class AnalysisTreeNodeProvder extends TreeNodeProvider {
   }
 
   protected getErrorEncounteredTreeNode(scanPath?: string): TreeNode {
+    const lsCodeEnabled = this.configuration.getPreviewFeatures()?.lsCode;
+
     return new TreeNode({
       icon: NODE_ICONS.error,
       text: scanPath ? path.basename(scanPath) : messages.scanFailed,
@@ -66,17 +68,19 @@ export abstract class AnalysisTreeNodeProvder extends TreeNodeProvider {
         isError: true,
       },
       command: {
-        command: SNYK_SHOW_OUTPUT_COMMAND,
+        command: lsCodeEnabled ? SNYK_SHOW_LS_OUTPUT_COMMAND : SNYK_SHOW_OUTPUT_COMMAND,
         title: '',
       },
     });
   }
 
   protected getNoWorkspaceTrustTreeNode(): TreeNode {
+    const lsCodeEnabled = this.configuration.getPreviewFeatures()?.lsCode;
+
     return new TreeNode({
       text: messages.noWorkspaceTrust,
       command: {
-        command: SNYK_SHOW_OUTPUT_COMMAND,
+        command: lsCodeEnabled ? SNYK_SHOW_LS_OUTPUT_COMMAND : SNYK_SHOW_OUTPUT_COMMAND,
         title: '',
       },
     });

--- a/src/snyk/common/watchers/configurationWatcher.ts
+++ b/src/snyk/common/watchers/configurationWatcher.ts
@@ -33,17 +33,21 @@ class ConfigurationWatcher implements IWatcher {
     } else if (key === OSS_ENABLED_SETTING) {
       extension.viewManagerService.refreshOssView();
     } else if (key === CODE_SECURITY_ENABLED_SETTING || key === CODE_QUALITY_ENABLED_SETTING) {
-      extension.snykCode.analyzer.refreshDiagnostics();
+      extension.snykCodeOld.analyzer.refreshDiagnostics();
       // If two settings are changed simultaneously, only one will be applied, thus refresh all views
-      return extension.viewManagerService.refreshAllCodeAnalysisViews();
+      return extension.viewManagerService.refreshAllOldCodeAnalysisViews();
     } else if (key === SEVERITY_FILTER_SETTING) {
-      extension.snykCode.analyzer.refreshDiagnostics();
+      extension.snykCodeOld.analyzer.refreshDiagnostics();
       return extension.viewManagerService.refreshAllViews();
     } else if (key === ADVANCED_CUSTOM_ENDPOINT) {
       return configuration.clearToken();
     } else if (key === ADVANCED_CUSTOM_LS_PATH) {
       // Language Server client must sync config changes before we can restart
       return _.debounce(() => extension.restartLanguageServer(), DEFAULT_LS_DEBOUNCE_INTERVAL)();
+    } else if (key === TRUSTED_FOLDERS) {
+      extension.workspaceTrust.resetTrustedFoldersCache();
+      extension.viewManagerService.refreshAllCodeAnalysisViews();
+      // extension.viewManagerService.refreshAllViews(); // todo: when oss results delivered via LS
     }
 
     const extensionConfig = vscode.workspace.getConfiguration('snyk');

--- a/src/snyk/snykCode/analyzer/analyzer.ts
+++ b/src/snyk/snykCode/analyzer/analyzer.ts
@@ -251,7 +251,7 @@ class SnykCodeAnalyzer implements ISnykCodeAnalyzer {
     } catch (err) {
       await this.errorHandler.processError(err, {
         message: errorsLogs.updateReviewPositions,
-        bundleId: extension.snykCode.remoteBundle?.fileBundle.bundleHash,
+        bundleId: extension.snykCodeOld.remoteBundle?.fileBundle.bundleHash,
         data: {
           [updatedFile.fullPath]: updatedFile.contentChanges,
         },

--- a/src/snyk/snykCode/analyzer/progress.ts
+++ b/src/snyk/snykCode/analyzer/progress.ts
@@ -6,7 +6,7 @@ import { SNYK_ANALYSIS_STATUS } from '../../common/constants/views';
 import { Logger } from '../../common/logger/logger';
 import { IViewManagerService } from '../../common/services/viewManagerService';
 import { IVSCodeWorkspace } from '../../common/vscode/workspace';
-import { ISnykCodeService } from '../codeService';
+import { ISnykCodeServiceOld } from '../codeServiceOld';
 import createFileWatcher from '../watchers/filesWatcher';
 
 export class Progress {
@@ -14,7 +14,7 @@ export class Progress {
   private filesWatcher: vscode.FileSystemWatcher;
 
   constructor(
-    private readonly snykCode: ISnykCodeService,
+    private readonly snykCode: ISnykCodeServiceOld,
     private readonly viewManagerService: IViewManagerService,
     private readonly workspace: IVSCodeWorkspace,
   ) {}
@@ -39,7 +39,7 @@ export class Progress {
 
   updateStatus(status: string, progress: string): void {
     this.snykCode.updateStatus(status, progress);
-    this.viewManagerService.refreshAllCodeAnalysisViews();
+    this.viewManagerService.refreshAllOldCodeAnalysisViews();
   }
 
   onSupportedFilesLoaded(data: SupportedFiles | null): void {

--- a/src/snyk/snykCode/codeService.ts
+++ b/src/snyk/snykCode/codeService.ts
@@ -1,362 +1,131 @@
-import { AnalysisSeverity, analyzeFolders, extendAnalysis, FileAnalysis } from '@snyk/code-client';
-import { ConnectionOptions } from '@snyk/code-client/dist/http';
-import { v4 as uuidv4 } from 'uuid';
+import { Subscription } from 'rxjs';
 import { AnalysisStatusProvider } from '../common/analysis/statusProvider';
-import { IAnalytics, SupportedAnalysisProperties } from '../common/analytics/itly';
-import { FeaturesConfiguration, IConfiguration } from '../common/configuration/configuration';
-import { getTrustedFolders } from '../common/configuration/trustedFolders';
-import { IDE_NAME } from '../common/constants/general';
-import { ErrorHandler } from '../common/error/errorHandler';
-import { ILog } from '../common/logger/interfaces';
-import { Logger } from '../common/logger/logger';
-import { messages as generalAnalysisMessages } from '../common/messages/analysisMessages';
-import { LearnService } from '../common/services/learnService';
+import { IConfiguration } from '../common/configuration/configuration';
+import { IWorkspaceTrust } from '../common/configuration/trustedFolders';
+import { ILanguageServer } from '../common/languageServer/languageServer';
+import { CodeIssueData, Issue, Scan, ScanProduct, ScanStatus } from '../common/languageServer/types';
 import { IViewManagerService } from '../common/services/viewManagerService';
-import { User } from '../common/user';
-import { IWebViewProvider } from '../common/views/webviewProvider';
 import { ExtensionContext } from '../common/vscode/extensionContext';
-import { HoverAdapter } from '../common/vscode/hover';
-import { IVSCodeLanguages } from '../common/vscode/languages';
-import { IMarkdownStringAdapter } from '../common/vscode/markdownString';
-import { Diagnostic, Disposable } from '../common/vscode/types';
-import { IUriAdapter } from '../common/vscode/uri';
-import { IVSCodeWindow } from '../common/vscode/window';
+import { Disposable } from '../common/vscode/types';
 import { IVSCodeWorkspace } from '../common/vscode/workspace';
-import SnykCodeAnalyzer from './analyzer/analyzer';
-import { Progress } from './analyzer/progress';
-import { DisposableCodeActionsProvider } from './codeActions/disposableCodeActionsProvider';
-import { ICodeSettings } from './codeSettings';
-import { ISnykCodeErrorHandler } from './error/snykCodeErrorHandler';
-import { IFalsePositiveApi } from './falsePositive/api/falsePositiveApi';
-import { FalsePositive } from './falsePositive/falsePositive';
-import { ISnykCodeAnalyzer } from './interfaces';
-import { messages as analysisMessages } from './messages/analysis';
-import { messages } from './messages/error';
-import { IssueUtils } from './utils/issueUtils';
-import {
-  FalsePositiveWebviewModel,
-  FalsePositiveWebviewProvider,
-} from './views/falsePositive/falsePositiveWebviewProvider';
 import { ICodeSuggestionWebviewProvider } from './views/interfaces';
-import { CodeSuggestionWebviewProvider } from './views/suggestion/codeSuggestionWebviewProvider';
 
 export interface ISnykCodeService extends AnalysisStatusProvider, Disposable {
-  analyzer: ISnykCodeAnalyzer;
-  analysisStatus: string;
-  analysisProgress: string;
-  readonly remoteBundle: FileAnalysis | null;
   readonly suggestionProvider: ICodeSuggestionWebviewProvider;
-  readonly falsePositiveProvider: IWebViewProvider<FalsePositiveWebviewModel>;
-  hasError: boolean;
-  hasTransientError: boolean;
+  result: Readonly<CodeResult>;
   isAnyWorkspaceFolderTrusted: boolean;
 
-  startAnalysis(paths: string[], manual: boolean, reportTriggeredEvent: boolean): Promise<void>;
-  clearBundle(): void;
-  updateStatus(status: string, progress: string): void;
-  errorEncountered(requestId: string): void;
-  addChangedFile(filePath: string): void;
   activateWebviewProviders(): void;
-  reportFalsePositive(
-    falsePositive: FalsePositive,
-    isSecurityTypeIssue: boolean,
-    issueSeverity: AnalysisSeverity,
-  ): Promise<void>;
 }
 
+// Keep type declarations temporarily here, until we get rid of code-client types.
+// todo: tidy up during 'lsCode' feature flag drop
+export type CodeResult = Map<string, CodeWorkspaceFolderResult>; // map of a workspace folder to results array or an error occurred in this folder
+export type CodeWorkspaceFolderResult = Issue<CodeIssueData>[] | Error;
+
 export class SnykCodeService extends AnalysisStatusProvider implements ISnykCodeService {
-  remoteBundle: FileAnalysis | null;
-  analyzer: ISnykCodeAnalyzer;
+  private _result: CodeResult;
   readonly suggestionProvider: ICodeSuggestionWebviewProvider;
-  readonly falsePositiveProvider: IWebViewProvider<FalsePositiveWebviewModel>;
 
-  private changedFiles: Set<string> = new Set();
+  // Track running scan count. Assumption: server sends N success/error messages for N scans in progress.
+  private runningScanCount = 0;
 
-  private progress: Progress;
-  private _analysisStatus = '';
-  private _analysisProgress = '';
-  private temporaryFailed = false;
-  private failed = false;
-  private _isAnyWorkspaceFolderTrusted = true;
+  private lsSubscription: Subscription;
 
   constructor(
     readonly extensionContext: ExtensionContext,
     private readonly config: IConfiguration,
     private readonly viewManagerService: IViewManagerService,
-    private readonly workspace: IVSCodeWorkspace,
-    readonly window: IVSCodeWindow,
-    private readonly user: User,
-    private readonly falsePositiveApi: IFalsePositiveApi,
-    private readonly logger: ILog,
-    private readonly analytics: IAnalytics,
-    readonly languages: IVSCodeLanguages,
-    private readonly errorHandler: ISnykCodeErrorHandler,
-    private readonly uriAdapter: IUriAdapter,
-    codeSettings: ICodeSettings,
-    private readonly learnService: LearnService,
-    private readonly markdownStringAdapter: IMarkdownStringAdapter,
+    readonly workspace: IVSCodeWorkspace,
+    private readonly workspaceTrust: IWorkspaceTrust,
+    readonly languageServer: ILanguageServer,
   ) {
     super();
-    this.analyzer = new SnykCodeAnalyzer(
-      logger,
-      languages,
-      workspace,
-      analytics,
-      errorHandler,
-      this.uriAdapter,
-      this.config,
-    );
-    this.registerAnalyzerProviders(this.analyzer);
+    // this.analyzer = new SnykCodeAnalyzer(
+    //   logger,
+    //   languages,
+    //   workspace,
+    //   analytics,
+    //   errorHandler,
+    //   this.uriAdapter,
+    //   this.config,
+    // ); // todo: update in ROAD-1158
+    // this.registerAnalyzerProviders(this.analyzer); // todo: update in ROAD-1158
 
-    this.falsePositiveProvider = new FalsePositiveWebviewProvider(
-      this,
-      this.window,
-      extensionContext,
-      this.logger,
-      this.analytics,
-    );
-    this.suggestionProvider = new CodeSuggestionWebviewProvider(
-      config,
-      this.analyzer,
-      window,
-      this.falsePositiveProvider,
-      extensionContext,
-      this.logger,
-      languages,
-      workspace,
-      codeSettings,
-      this.learnService,
-    );
+    // this.suggestionProvider = new CodeSuggestionWebviewProvider(
+    //   config,
+    //   this.analyzer,
+    //   window,
+    //   extensionContext,
+    //   this.logger,
+    //   languages,
+    //   workspace,
+    //   codeSettings,
+    //   this.learnService,
+    // ); // todo: update in ROAD-1158
 
-    this.progress = new Progress(this, viewManagerService, this.workspace);
-    this.progress.bindListeners();
+    this.lsSubscription = languageServer.scan$.subscribe((scan: Scan<CodeIssueData>) => this.handleLsScanMessage(scan));
+    this._result = new Map<string, CodeWorkspaceFolderResult>();
   }
 
-  get hasError(): boolean {
-    return this.failed;
+  get result(): Readonly<CodeResult> {
+    return this._result;
   }
-  get hasTransientError(): boolean {
-    return this.temporaryFailed;
-  }
+
   get isAnyWorkspaceFolderTrusted(): boolean {
-    return this._isAnyWorkspaceFolderTrusted;
-  }
-
-  get analysisStatus(): string {
-    return this._analysisStatus;
-  }
-  get analysisProgress(): string {
-    return this._analysisProgress;
-  }
-
-  public async startAnalysis(paths: string[], manualTrigger: boolean, reportTriggeredEvent: boolean): Promise<void> {
-    if (this.isAnalysisRunning || !paths.length) {
-      return;
-    }
-
-    const enabledFeatures = this.config.getFeaturesConfiguration();
-    const requestId = uuidv4();
-
-    paths = getTrustedFolders(this.config, paths);
-    if (!paths.length) {
-      this._isAnyWorkspaceFolderTrusted = false;
-      this.viewManagerService.refreshCodeAnalysisViews(enabledFeatures);
-      this.logger.info(`Skipping Code scan. ${generalAnalysisMessages.noWorkspaceTrustDescription}`);
-      return;
-    }
-    this._isAnyWorkspaceFolderTrusted = true;
-
-    try {
-      Logger.info(analysisMessages.started);
-
-      // reset error state
-      this.temporaryFailed = false;
-      this.failed = false;
-
-      this.reportAnalysisIsTriggered(reportTriggeredEvent, enabledFeatures, manualTrigger);
-      this.analysisStarted();
-
-      const snykCodeToken = await this.config.snykCodeToken;
-
-      let result: FileAnalysis | null = null;
-      if (this.changedFiles.size && this.remoteBundle) {
-        const changedFiles = [...this.changedFiles];
-        result = await extendAnalysis({
-          ...this.remoteBundle,
-          files: changedFiles,
-          connection: this.getConnectionOptions(requestId, snykCodeToken),
-        });
-      } else {
-        result = await analyzeFolders({
-          connection: this.getConnectionOptions(requestId, snykCodeToken),
-          analysisOptions: {
-            legacy: true,
-          },
-          fileOptions: {
-            paths,
-          },
-          analysisContext: {
-            flow: this.config.source,
-            initiator: 'IDE',
-            orgDisplayName: this.config.organization,
-          },
-        });
-      }
-
-      if (result) {
-        this.remoteBundle = result;
-
-        if (result.analysisResults.type == 'legacy') {
-          this.analyzer.setAnalysisResults(result.analysisResults);
-        }
-        this.analyzer.createReviewResults();
-
-        Logger.info(analysisMessages.finished);
-
-        if (enabledFeatures?.codeSecurityEnabled) {
-          this.analytics.logAnalysisIsReady({
-            ide: IDE_NAME,
-            analysisType: 'Snyk Code Security',
-            result: 'Success',
-          });
-        }
-        if (enabledFeatures?.codeQualityEnabled) {
-          this.analytics.logAnalysisIsReady({
-            ide: IDE_NAME,
-            analysisType: 'Snyk Code Quality',
-            result: 'Success',
-          });
-        }
-
-        this.suggestionProvider.checkCurrentSuggestion();
-
-        // cleanup analysis state
-        this.changedFiles.clear();
-      }
-    } catch (err) {
-      this.temporaryFailed = true;
-      await this.errorHandler.processError(err, undefined, requestId, () => {
-        this.errorEncountered(requestId);
-      });
-
-      if (enabledFeatures?.codeSecurityEnabled && this.errorHandler.connectionRetryLimitExhausted) {
-        this.analytics.logAnalysisIsReady({
-          ide: IDE_NAME,
-          analysisType: 'Snyk Code Security',
-          result: 'Error',
-        });
-      }
-      if (enabledFeatures?.codeQualityEnabled && this.errorHandler.connectionRetryLimitExhausted) {
-        this.analytics.logAnalysisIsReady({
-          ide: IDE_NAME,
-          analysisType: 'Snyk Code Quality',
-          result: 'Error',
-        });
-      }
-    } finally {
-      this.analysisFinished();
-      this.viewManagerService.refreshCodeAnalysisViews(enabledFeatures);
-    }
-  }
-
-  clearBundle() {
-    this.remoteBundle = null;
-  }
-
-  private reportAnalysisIsTriggered(
-    reportTriggeredEvent: boolean,
-    enabledFeatures: FeaturesConfiguration | undefined,
-    manualTrigger: boolean,
-  ) {
-    if (reportTriggeredEvent) {
-      const analysisType: SupportedAnalysisProperties[] = [];
-      if (enabledFeatures?.codeSecurityEnabled) analysisType.push('Snyk Code Security');
-      if (enabledFeatures?.codeQualityEnabled) analysisType.push('Snyk Code Quality');
-
-      if (analysisType) {
-        this.analytics.logAnalysisIsTriggered({
-          analysisType: analysisType as [SupportedAnalysisProperties, ...SupportedAnalysisProperties[]],
-          ide: IDE_NAME,
-          triggeredByUser: manualTrigger,
-        });
-      }
-    }
-  }
-
-  updateStatus(status: string, progress: string): void {
-    this._analysisStatus = status;
-    this._analysisProgress = progress;
-  }
-
-  errorEncountered(requestId: string): void {
-    this.temporaryFailed = false;
-    this.failed = true;
-    this.logger.error(analysisMessages.failed(requestId));
-  }
-
-  addChangedFile(filePath: string): void {
-    this.changedFiles.add(filePath);
+    const workspacePaths = this.workspace.getWorkspaceFolders();
+    return this.workspaceTrust.getTrustedFolders(this.config, workspacePaths).length > 0;
   }
 
   activateWebviewProviders(): void {
     this.suggestionProvider.activate();
-    this.falsePositiveProvider.activate();
   }
 
-  async reportFalsePositive(
-    falsePositive: FalsePositive,
-    isSecurityTypeIssue: boolean,
-    issueSeverity: AnalysisSeverity,
-  ): Promise<void> {
-    try {
-      await this.falsePositiveApi.report(falsePositive, this.user);
-
-      this.analytics.logFalsePositiveIsSubmitted({
-        issueId: falsePositive.id,
-        issueType: IssueUtils.getIssueType(isSecurityTypeIssue),
-        severity: IssueUtils.severityAsText(issueSeverity),
-      });
-    } catch (e) {
-      ErrorHandler.handle(e, this.logger, messages.reportFalsePositiveFailed);
-    }
+  override handleLsDownloadFailure(): void {
+    super.handleLsDownloadFailure();
+    this.viewManagerService.refreshAllCodeAnalysisViews();
   }
 
   dispose(): void {
-    this.progress.removeAllListeners();
-    this.analyzer.dispose();
+    this.lsSubscription.unsubscribe();
   }
 
-  private getConnectionOptions(requestId: string, snykCodeToken: string | undefined): ConnectionOptions {
-    if (!snykCodeToken) {
-      throw new Error('Snyk token must be filled to obtain connection options');
+  private handleLsScanMessage(scanMsg: Scan<CodeIssueData>) {
+    if (scanMsg.product !== ScanProduct.Code) {
+      return;
     }
 
-    return {
-      baseURL: this.config.snykCodeBaseURL,
-      sessionToken: snykCodeToken,
-      source: this.config.source,
-      requestId,
-      base64Encoding: true,
-    };
+    if (scanMsg.status == ScanStatus.InProgress) {
+      if (!this.isAnalysisRunning) {
+        this.analysisStarted();
+        this._result.set(scanMsg.folderPath, []);
+        this.viewManagerService.refreshAllCodeAnalysisViews();
+      }
+
+      this.runningScanCount++;
+      return;
+    }
+
+    if (scanMsg.status == ScanStatus.Success || scanMsg.status == ScanStatus.Error) {
+      this.handleSuccessOrError(scanMsg);
+    }
   }
 
-  private registerAnalyzerProviders(analyzer: ISnykCodeAnalyzer) {
-    analyzer.registerHoverProviders(new HoverAdapter(), new HoverAdapter(), this.markdownStringAdapter);
-    analyzer.registerCodeActionProviders(
-      new DisposableCodeActionsProvider(
-        analyzer.codeSecurityReview,
-        {
-          findSuggestion: (diagnostic: Diagnostic) => analyzer.findSuggestion(diagnostic),
-        },
-        this.analytics,
-      ),
-      new DisposableCodeActionsProvider(
-        analyzer.codeQualityReview,
-        {
-          findSuggestion: (diagnostic: Diagnostic) => analyzer.findSuggestion(diagnostic),
-        },
-        this.analytics,
-      ),
-    );
+  private handleSuccessOrError(scanMsg: Scan<CodeIssueData>) {
+    this.runningScanCount--;
+
+    // prepare results for the view
+    if (this.runningScanCount <= 0) {
+      this.analysisFinished();
+      this.runningScanCount = 0;
+
+      if (scanMsg.status == ScanStatus.Success) {
+        this._result.set(scanMsg.folderPath, scanMsg.issues);
+      } else {
+        this._result.set(scanMsg.folderPath, new Error('Failed to analyze.'));
+      }
+
+      this.viewManagerService.refreshAllCodeAnalysisViews();
+    }
   }
 }

--- a/src/snyk/snykCode/codeServiceOld.ts
+++ b/src/snyk/snykCode/codeServiceOld.ts
@@ -1,0 +1,361 @@
+import { AnalysisSeverity, analyzeFolders, extendAnalysis, FileAnalysis } from '@snyk/code-client';
+import { ConnectionOptions } from '@snyk/code-client/dist/http';
+import { v4 as uuidv4 } from 'uuid';
+import { AnalysisStatusProvider } from '../common/analysis/statusProvider';
+import { IAnalytics, SupportedAnalysisProperties } from '../common/analytics/itly';
+import { FeaturesConfiguration, IConfiguration } from '../common/configuration/configuration';
+import { IWorkspaceTrust } from '../common/configuration/trustedFolders';
+import { IDE_NAME } from '../common/constants/general';
+import { ErrorHandler } from '../common/error/errorHandler';
+import { ILog } from '../common/logger/interfaces';
+import { Logger } from '../common/logger/logger';
+import { messages as generalAnalysisMessages } from '../common/messages/analysisMessages';
+import { LearnService } from '../common/services/learnService';
+import { IViewManagerService } from '../common/services/viewManagerService';
+import { User } from '../common/user';
+import { IWebViewProvider } from '../common/views/webviewProvider';
+import { ExtensionContext } from '../common/vscode/extensionContext';
+import { HoverAdapter } from '../common/vscode/hover';
+import { IVSCodeLanguages } from '../common/vscode/languages';
+import { IMarkdownStringAdapter } from '../common/vscode/markdownString';
+import { Diagnostic, Disposable } from '../common/vscode/types';
+import { IUriAdapter } from '../common/vscode/uri';
+import { IVSCodeWindow } from '../common/vscode/window';
+import { IVSCodeWorkspace } from '../common/vscode/workspace';
+import SnykCodeAnalyzer from './analyzer/analyzer';
+import { Progress } from './analyzer/progress';
+import { DisposableCodeActionsProvider } from './codeActions/disposableCodeActionsProvider';
+import { ICodeSettings } from './codeSettings';
+import { ISnykCodeErrorHandler } from './error/snykCodeErrorHandler';
+import { IFalsePositiveApi } from './falsePositive/api/falsePositiveApi';
+import { FalsePositive } from './falsePositive/falsePositive';
+import { ISnykCodeAnalyzer } from './interfaces';
+import { messages as analysisMessages } from './messages/analysis';
+import { messages } from './messages/error';
+import { IssueUtils } from './utils/issueUtils';
+import {
+  FalsePositiveWebviewModel,
+  FalsePositiveWebviewProvider,
+} from './views/falsePositive/falsePositiveWebviewProvider';
+import { ICodeSuggestionWebviewProvider } from './views/interfaces';
+import { CodeSuggestionWebviewProvider } from './views/suggestion/codeSuggestionWebviewProvider';
+
+export interface ISnykCodeServiceOld extends AnalysisStatusProvider, Disposable {
+  analyzer: ISnykCodeAnalyzer;
+  analysisStatus: string;
+  analysisProgress: string;
+  readonly remoteBundle: FileAnalysis | null;
+  readonly suggestionProvider: ICodeSuggestionWebviewProvider;
+  hasError: boolean;
+  hasTransientError: boolean;
+  isAnyWorkspaceFolderTrusted: boolean;
+
+  startAnalysis(paths: string[], manual: boolean, reportTriggeredEvent: boolean): Promise<void>;
+  clearBundle(): void;
+  updateStatus(status: string, progress: string): void;
+  errorEncountered(requestId: string): void;
+  addChangedFile(filePath: string): void;
+  activateWebviewProviders(): void;
+  reportFalsePositive(
+    falsePositive: FalsePositive,
+    isSecurityTypeIssue: boolean,
+    issueSeverity: AnalysisSeverity,
+  ): Promise<void>;
+}
+
+export class SnykCodeServiceOld extends AnalysisStatusProvider implements ISnykCodeServiceOld {
+  remoteBundle: FileAnalysis | null;
+  analyzer: ISnykCodeAnalyzer;
+  readonly suggestionProvider: ICodeSuggestionWebviewProvider;
+  readonly falsePositiveProvider: IWebViewProvider<FalsePositiveWebviewModel>;
+
+  private changedFiles: Set<string> = new Set();
+
+  private progress: Progress;
+  private _analysisStatus = '';
+  private _analysisProgress = '';
+  private temporaryFailed = false;
+  private failed = false;
+  private _isAnyWorkspaceFolderTrusted = true;
+
+  constructor(
+    readonly extensionContext: ExtensionContext,
+    private readonly config: IConfiguration,
+    private readonly viewManagerService: IViewManagerService,
+    private readonly workspace: IVSCodeWorkspace,
+    readonly window: IVSCodeWindow,
+    private readonly user: User,
+    private readonly falsePositiveApi: IFalsePositiveApi,
+    private readonly logger: ILog,
+    private readonly analytics: IAnalytics,
+    readonly languages: IVSCodeLanguages,
+    private readonly errorHandler: ISnykCodeErrorHandler,
+    private readonly uriAdapter: IUriAdapter,
+    codeSettings: ICodeSettings,
+    private readonly learnService: LearnService,
+    private readonly markdownStringAdapter: IMarkdownStringAdapter,
+    private readonly workspaceTrust: IWorkspaceTrust,
+  ) {
+    super();
+    this.analyzer = new SnykCodeAnalyzer(
+      logger,
+      languages,
+      workspace,
+      analytics,
+      errorHandler,
+      this.uriAdapter,
+      this.config,
+    );
+    this.registerAnalyzerProviders(this.analyzer);
+
+    this.falsePositiveProvider = new FalsePositiveWebviewProvider(
+      this,
+      this.window,
+      extensionContext,
+      this.logger,
+      this.analytics,
+    );
+    this.suggestionProvider = new CodeSuggestionWebviewProvider(
+      config,
+      this.analyzer,
+      window,
+      extensionContext,
+      this.logger,
+      languages,
+      workspace,
+      codeSettings,
+      this.learnService,
+    );
+
+    this.progress = new Progress(this, viewManagerService, this.workspace);
+    this.progress.bindListeners();
+  }
+
+  get hasError(): boolean {
+    return this.failed;
+  }
+  get hasTransientError(): boolean {
+    return this.temporaryFailed;
+  }
+  get isAnyWorkspaceFolderTrusted(): boolean {
+    return this._isAnyWorkspaceFolderTrusted;
+  }
+
+  get analysisStatus(): string {
+    return this._analysisStatus;
+  }
+  get analysisProgress(): string {
+    return this._analysisProgress;
+  }
+
+  public async startAnalysis(paths: string[], manualTrigger: boolean, reportTriggeredEvent: boolean): Promise<void> {
+    if (this.isAnalysisRunning || !paths.length) {
+      return;
+    }
+
+    const enabledFeatures = this.config.getFeaturesConfiguration();
+    const requestId = uuidv4();
+
+    const pathsToTest = this.workspaceTrust.getTrustedFolders(this.config, paths);
+    if (!pathsToTest.length) {
+      this._isAnyWorkspaceFolderTrusted = false;
+      this.viewManagerService.refreshCodeAnalysisViews(enabledFeatures);
+      this.logger.info(`Skipping Code scan. ${generalAnalysisMessages.noWorkspaceTrustDescription}`);
+      return;
+    }
+    this._isAnyWorkspaceFolderTrusted = true;
+
+    try {
+      Logger.info(analysisMessages.started);
+
+      // reset error state
+      this.temporaryFailed = false;
+      this.failed = false;
+
+      this.reportAnalysisIsTriggered(reportTriggeredEvent, enabledFeatures, manualTrigger);
+      this.analysisStarted();
+
+      const snykCodeToken = await this.config.snykCodeToken;
+
+      let result: FileAnalysis | null = null;
+      if (this.changedFiles.size && this.remoteBundle) {
+        const changedFiles = [...this.changedFiles];
+        result = await extendAnalysis({
+          ...this.remoteBundle,
+          files: changedFiles,
+          connection: this.getConnectionOptions(requestId, snykCodeToken),
+        });
+      } else {
+        result = await analyzeFolders({
+          connection: this.getConnectionOptions(requestId, snykCodeToken),
+          analysisOptions: {
+            legacy: true,
+          },
+          fileOptions: {
+            paths: pathsToTest.concat([]),
+          },
+          analysisContext: {
+            flow: this.config.source,
+            initiator: 'IDE',
+            orgDisplayName: this.config.organization,
+          },
+        });
+      }
+
+      if (result) {
+        this.remoteBundle = result;
+
+        if (result.analysisResults.type == 'legacy') {
+          this.analyzer.setAnalysisResults(result.analysisResults);
+        }
+        this.analyzer.createReviewResults();
+
+        Logger.info(analysisMessages.finished);
+
+        if (enabledFeatures?.codeSecurityEnabled) {
+          this.analytics.logAnalysisIsReady({
+            ide: IDE_NAME,
+            analysisType: 'Snyk Code Security',
+            result: 'Success',
+          });
+        }
+        if (enabledFeatures?.codeQualityEnabled) {
+          this.analytics.logAnalysisIsReady({
+            ide: IDE_NAME,
+            analysisType: 'Snyk Code Quality',
+            result: 'Success',
+          });
+        }
+
+        this.suggestionProvider.checkCurrentSuggestion();
+
+        // cleanup analysis state
+        this.changedFiles.clear();
+      }
+    } catch (err) {
+      this.temporaryFailed = true;
+      await this.errorHandler.processError(err, undefined, requestId, () => {
+        this.errorEncountered(requestId);
+      });
+
+      if (enabledFeatures?.codeSecurityEnabled && this.errorHandler.connectionRetryLimitExhausted) {
+        this.analytics.logAnalysisIsReady({
+          ide: IDE_NAME,
+          analysisType: 'Snyk Code Security',
+          result: 'Error',
+        });
+      }
+      if (enabledFeatures?.codeQualityEnabled && this.errorHandler.connectionRetryLimitExhausted) {
+        this.analytics.logAnalysisIsReady({
+          ide: IDE_NAME,
+          analysisType: 'Snyk Code Quality',
+          result: 'Error',
+        });
+      }
+    } finally {
+      this.analysisFinished();
+      this.viewManagerService.refreshCodeAnalysisViews(enabledFeatures);
+    }
+  }
+
+  clearBundle() {
+    this.remoteBundle = null;
+  }
+
+  private reportAnalysisIsTriggered(
+    reportTriggeredEvent: boolean,
+    enabledFeatures: FeaturesConfiguration | undefined,
+    manualTrigger: boolean,
+  ) {
+    if (reportTriggeredEvent) {
+      const analysisType: SupportedAnalysisProperties[] = [];
+      if (enabledFeatures?.codeSecurityEnabled) analysisType.push('Snyk Code Security');
+      if (enabledFeatures?.codeQualityEnabled) analysisType.push('Snyk Code Quality');
+
+      if (analysisType) {
+        this.analytics.logAnalysisIsTriggered({
+          analysisType: analysisType as [SupportedAnalysisProperties, ...SupportedAnalysisProperties[]],
+          ide: IDE_NAME,
+          triggeredByUser: manualTrigger,
+        });
+      }
+    }
+  }
+
+  updateStatus(status: string, progress: string): void {
+    this._analysisStatus = status;
+    this._analysisProgress = progress;
+  }
+
+  errorEncountered(requestId: string): void {
+    this.temporaryFailed = false;
+    this.failed = true;
+    this.logger.error(analysisMessages.failed(requestId));
+  }
+
+  addChangedFile(filePath: string): void {
+    this.changedFiles.add(filePath);
+  }
+
+  activateWebviewProviders(): void {
+    this.suggestionProvider.activate();
+    this.falsePositiveProvider.activate();
+  }
+
+  async reportFalsePositive(
+    falsePositive: FalsePositive,
+    isSecurityTypeIssue: boolean,
+    issueSeverity: AnalysisSeverity,
+  ): Promise<void> {
+    try {
+      await this.falsePositiveApi.report(falsePositive, this.user);
+
+      this.analytics.logFalsePositiveIsSubmitted({
+        issueId: falsePositive.id,
+        issueType: IssueUtils.getIssueType(isSecurityTypeIssue),
+        severity: IssueUtils.severityAsText(issueSeverity),
+      });
+    } catch (e) {
+      ErrorHandler.handle(e, this.logger, messages.reportFalsePositiveFailed);
+    }
+  }
+
+  dispose(): void {
+    this.progress.removeAllListeners();
+    this.analyzer.dispose();
+  }
+
+  private getConnectionOptions(requestId: string, snykCodeToken: string | undefined): ConnectionOptions {
+    if (!snykCodeToken) {
+      throw new Error('Snyk token must be filled to obtain connection options');
+    }
+
+    return {
+      baseURL: this.config.snykCodeBaseURL,
+      sessionToken: snykCodeToken,
+      source: this.config.source,
+      requestId,
+      base64Encoding: true,
+    };
+  }
+
+  private registerAnalyzerProviders(analyzer: ISnykCodeAnalyzer) {
+    analyzer.registerHoverProviders(new HoverAdapter(), new HoverAdapter(), this.markdownStringAdapter);
+    analyzer.registerCodeActionProviders(
+      new DisposableCodeActionsProvider(
+        analyzer.codeSecurityReview,
+        {
+          findSuggestion: (diagnostic: Diagnostic) => analyzer.findSuggestion(diagnostic),
+        },
+        this.analytics,
+      ),
+      new DisposableCodeActionsProvider(
+        analyzer.codeQualityReview,
+        {
+          findSuggestion: (diagnostic: Diagnostic) => analyzer.findSuggestion(diagnostic),
+        },
+        this.analytics,
+      ),
+    );
+  }
+}

--- a/src/snyk/snykCode/error/snykCodeErrorHandler.ts
+++ b/src/snyk/snykCode/error/snykCodeErrorHandler.ts
@@ -174,7 +174,7 @@ export class SnykCodeErrorHandler extends ErrorHandler implements ISnykCodeError
     this.transientErrors += 1;
 
     if (errorStatusCode === constants.ErrorCodes.notFound) {
-      this.baseSnykModule.snykCode.clearBundle(); // bundle has expired, trigger complete new analysis
+      this.baseSnykModule.snykCodeOld.clearBundle(); // bundle has expired, trigger complete new analysis
     }
 
     setTimeout(() => {

--- a/src/snyk/snykCode/messages/analysis.ts
+++ b/src/snyk/snykCode/messages/analysis.ts
@@ -1,4 +1,5 @@
 export const messages = {
+  runTest: 'Run scan for Code vulnerabilites and issues.',
   started: 'Code analysis started.',
   finished: 'Code analysis finished.',
   temporaryFailed: 'Snyk Code is temporarily unavailable.',

--- a/src/snyk/snykCode/views/falsePositive/falsePositiveWebviewProvider.ts
+++ b/src/snyk/snykCode/views/falsePositive/falsePositiveWebviewProvider.ts
@@ -10,7 +10,7 @@ import { WebviewPanelSerializer } from '../../../common/views/webviewPanelSerial
 import { WebviewProvider } from '../../../common/views/webviewProvider';
 import { ExtensionContext } from '../../../common/vscode/extensionContext';
 import { IVSCodeWindow } from '../../../common/vscode/window';
-import { ISnykCodeService } from '../../codeService';
+import { ISnykCodeServiceOld } from '../../codeServiceOld';
 import { FalsePositive } from '../../falsePositive/falsePositive';
 import { messages as errorMessages } from '../../messages/error';
 
@@ -37,7 +37,7 @@ export type FalsePositiveWebviewModel = {
 
 export class FalsePositiveWebviewProvider extends WebviewProvider<FalsePositiveWebviewModel> {
   constructor(
-    private readonly codeService: ISnykCodeService,
+    private readonly codeService: ISnykCodeServiceOld,
     private readonly window: IVSCodeWindow,
     protected readonly context: ExtensionContext,
     protected readonly logger: ILog,

--- a/src/snyk/snykCode/views/issueTreeProviderOld.ts
+++ b/src/snyk/snykCode/views/issueTreeProviderOld.ts
@@ -1,0 +1,187 @@
+import { Command, Diagnostic, DiagnosticCollection, Range, Uri } from 'vscode';
+import { OpenCommandIssueType, OpenIssueCommandArg } from '../../common/commands/types';
+import { IConfiguration } from '../../common/configuration/configuration';
+import { SNYK_OPEN_ISSUE_COMMAND } from '../../common/constants/commands';
+import { IContextService } from '../../common/services/contextService';
+import { AnalysisTreeNodeProvder } from '../../common/views/analysisTreeNodeProvider';
+import { INodeIcon, NODE_ICONS, TreeNode } from '../../common/views/treeNode';
+import { ISnykCodeServiceOld } from '../codeServiceOld';
+import { SNYK_SEVERITIES } from '../constants/analysis';
+import { messages } from '../messages/analysis';
+import { getSnykSeverity } from '../utils/analysisUtils';
+import { CodeIssueCommandArg } from './interfaces';
+
+interface ISeverityCounts {
+  [severity: number]: number;
+}
+
+export class IssueTreeProviderOld extends AnalysisTreeNodeProvder {
+  constructor(
+    protected contextService: IContextService,
+    protected snykCode: ISnykCodeServiceOld,
+    protected diagnosticCollection: DiagnosticCollection | undefined,
+    protected configuration: IConfiguration,
+  ) {
+    super(configuration, snykCode);
+  }
+
+  static getSeverityIcon(severity: number): INodeIcon {
+    return (
+      {
+        [SNYK_SEVERITIES.error]: NODE_ICONS.high,
+        [SNYK_SEVERITIES.warning]: NODE_ICONS.medium,
+        [SNYK_SEVERITIES.information]: NODE_ICONS.low,
+      }[severity] || NODE_ICONS.low
+    );
+  }
+
+  static getFileSeverity(counts: ISeverityCounts): number {
+    for (const s of [SNYK_SEVERITIES.error, SNYK_SEVERITIES.warning, SNYK_SEVERITIES.information]) {
+      if (counts[s]) return s;
+    }
+    return SNYK_SEVERITIES.information;
+  }
+
+  getRootChildren(): TreeNode[] {
+    const review: TreeNode[] = [];
+    let nIssues = 0;
+    if (!this.contextService.shouldShowCodeAnalysis) return review;
+
+    if (this.snykCode.hasTransientError) {
+      return this.getTransientErrorTreeNodes();
+    } else if (this.snykCode.hasError) {
+      return [this.getErrorEncounteredTreeNode()];
+    } else if (!this.snykCode.isAnyWorkspaceFolderTrusted) {
+      return [this.getNoWorkspaceTrustTreeNode()];
+    }
+
+    if (this.diagnosticCollection) {
+      this.diagnosticCollection.forEach((uri: Uri, diagnostics: readonly Diagnostic[]): void => {
+        const filePath = uri.path.split('/');
+        const filename = filePath.pop() || uri.path;
+        const dir = filePath.pop();
+
+        nIssues += diagnostics.length;
+
+        if (diagnostics.length == 0) return;
+
+        const [issues, severityCounts] = this.getVulnerabilityTreeNodes(diagnostics, uri);
+        issues.sort(this.compareNodes);
+        const fileSeverity = IssueTreeProviderOld.getFileSeverity(severityCounts);
+        const file = new TreeNode({
+          text: filename,
+          description: this.getIssueDescriptionText(dir, diagnostics),
+          icon: IssueTreeProviderOld.getSeverityIcon(fileSeverity),
+          children: issues,
+          internal: {
+            nIssues: diagnostics.length,
+            severity: fileSeverity,
+          },
+        });
+        review.push(file);
+      });
+    }
+    review.sort(this.compareNodes);
+    if (this.snykCode.isAnalysisRunning) {
+      review.unshift(
+        new TreeNode({
+          text: this.snykCode.analysisStatus,
+          description: this.snykCode.analysisProgress,
+        }),
+      );
+    } else {
+      const topNodes = [
+        new TreeNode({
+          text: this.getIssueFoundText(nIssues),
+        }),
+        this.getDurationTreeNode(),
+        this.getNoSeverityFiltersSelectedTreeNode(),
+      ];
+      review.unshift(...topNodes.filter((n): n is TreeNode => n !== null));
+    }
+    return review;
+  }
+
+  protected getIssueFoundText(nIssues: number): string {
+    return `Snyk found ${!nIssues ? 'no issues! ✅' : `${nIssues} issue${nIssues === 1 ? '' : 's'}`}`;
+  }
+
+  protected getIssueDescriptionText(dir: string | undefined, diagnostics: readonly Diagnostic[]): string | undefined {
+    return `${dir} - ${diagnostics.length} issue${diagnostics.length === 1 ? '' : 's'}`;
+  }
+
+  protected getFilteredIssues(diagnostics: readonly Diagnostic[]): readonly Diagnostic[] {
+    // Diagnostics are already filtered by the analyzer
+    return diagnostics;
+  }
+
+  private getVulnerabilityTreeNodes(
+    fileVulnerabilities: readonly Diagnostic[],
+    uri: Uri,
+  ): [TreeNode[], ISeverityCounts] {
+    const severityCounts: ISeverityCounts = {
+      [SNYK_SEVERITIES.information]: 0,
+      [SNYK_SEVERITIES.warning]: 0,
+      [SNYK_SEVERITIES.error]: 0,
+    };
+
+    const nodes = fileVulnerabilities.map(d => {
+      const severity = getSnykSeverity(d.severity);
+      severityCounts[severity] += 1;
+      const params: {
+        text: string;
+        icon: INodeIcon;
+        issue: { uri: Uri; range?: Range };
+        internal: { severity: number };
+        command: Command;
+        children?: TreeNode[];
+      } = {
+        text: d.message,
+        icon: IssueTreeProviderOld.getSeverityIcon(severity),
+        issue: {
+          uri,
+          range: d.range,
+        },
+        internal: {
+          severity,
+        },
+        command: {
+          command: SNYK_OPEN_ISSUE_COMMAND,
+          title: '',
+          arguments: [
+            {
+              issueType: OpenCommandIssueType.CodeIssue,
+              issue: {
+                message: d.message,
+                uri: uri,
+                range: d.range,
+                diagnostic: d,
+              } as CodeIssueCommandArg,
+            } as OpenIssueCommandArg,
+          ],
+        },
+      };
+
+      return new TreeNode(params);
+    });
+
+    return [nodes, severityCounts];
+  }
+
+  private getTransientErrorTreeNodes(): TreeNode[] {
+    return [
+      new TreeNode({
+        text: messages.temporaryFailed,
+        internal: {
+          isError: true,
+        },
+      }),
+      new TreeNode({
+        text: messages.retry,
+        internal: {
+          isError: true,
+        },
+      }),
+    ];
+  }
+}

--- a/src/snyk/snykCode/views/qualityIssueTreeProviderOld.ts
+++ b/src/snyk/snykCode/views/qualityIssueTreeProviderOld.ts
@@ -4,17 +4,17 @@ import { SNYK_ANALYSIS_STATUS } from '../../common/constants/views';
 import { IContextService } from '../../common/services/contextService';
 import { IViewManagerService } from '../../common/services/viewManagerService';
 import { TreeNode } from '../../common/views/treeNode';
-import { ISnykCodeService } from '../codeService';
-import { IssueTreeProvider } from './issueTreeProvider';
+import { ISnykCodeServiceOld } from '../codeServiceOld';
+import { IssueTreeProviderOld } from './issueTreeProviderOld';
 
-export class CodeQualityIssueTreeProvider extends IssueTreeProvider {
+export class CodeQualityIssueTreeProviderOld extends IssueTreeProviderOld {
   constructor(
     protected viewManagerService: IViewManagerService,
     protected contextService: IContextService,
-    protected codeService: ISnykCodeService,
+    protected snykCode: ISnykCodeServiceOld,
     protected configuration: IConfiguration,
   ) {
-    super(contextService, codeService, configuration);
+    super(contextService, snykCode, snykCode.analyzer.codeQualityReview, configuration);
   }
 
   getRootChildren(): TreeNode[] {
@@ -29,5 +29,5 @@ export class CodeQualityIssueTreeProvider extends IssueTreeProvider {
     return super.getRootChildren();
   }
 
-  onDidChangeTreeData = this.viewManagerService.refreshCodeQualityViewEmitter.event;
+  onDidChangeTreeData = this.viewManagerService.refreshOldCodeQualityViewEmitter.event;
 }

--- a/src/snyk/snykCode/views/securityIssueTreeProviderOld.ts
+++ b/src/snyk/snykCode/views/securityIssueTreeProviderOld.ts
@@ -5,17 +5,17 @@ import { SNYK_ANALYSIS_STATUS } from '../../common/constants/views';
 import { IContextService } from '../../common/services/contextService';
 import { IViewManagerService } from '../../common/services/viewManagerService';
 import { TreeNode } from '../../common/views/treeNode';
-import { ISnykCodeService } from '../codeService';
-import { IssueTreeProvider } from './issueTreeProvider';
+import { ISnykCodeServiceOld } from '../codeServiceOld';
+import { IssueTreeProviderOld } from './issueTreeProviderOld';
 
-export default class CodeSecurityIssueTreeProvider extends IssueTreeProvider {
+export class CodeSecurityIssueTreeProviderOld extends IssueTreeProviderOld {
   constructor(
     protected viewManagerService: IViewManagerService,
     protected contextService: IContextService,
-    protected codeService: ISnykCodeService,
+    protected snykCode: ISnykCodeServiceOld,
     protected configuration: IConfiguration,
   ) {
-    super(contextService, codeService, configuration);
+    super(contextService, snykCode, snykCode.analyzer.codeSecurityReview, configuration);
   }
 
   getRootChildren(): TreeNode[] {
@@ -30,7 +30,7 @@ export default class CodeSecurityIssueTreeProvider extends IssueTreeProvider {
     return super.getRootChildren();
   }
 
-  onDidChangeTreeData = this.viewManagerService.refreshCodeSecurityViewEmitter.event;
+  onDidChangeTreeData = this.viewManagerService.refreshOldCodeSecurityViewEmitter.event;
 
   protected getIssueDescriptionText(dir: string | undefined, diagnostics: readonly Diagnostic[]): string | undefined {
     return `${dir} - ${diagnostics.length} ${diagnostics.length === 1 ? 'vulnerability' : 'vulnerabilities'}`;

--- a/src/snyk/snykCode/watchers/editorsWatcher.ts
+++ b/src/snyk/snykCode/watchers/editorsWatcher.ts
@@ -55,7 +55,7 @@ class SnykEditorsWatcher implements IWatcher {
           contentChanges: [...event.contentChanges],
           document: event.document,
         };
-        void extension.snykCode.analyzer.updateReviewResultsPositions(
+        void extension.snykCodeOld.analyzer.updateReviewResultsPositions(
           extension,
           this.currentTextEditors[currentEditorFileName],
         );

--- a/src/snyk/snykCode/watchers/filesWatcher.ts
+++ b/src/snyk/snykCode/watchers/filesWatcher.ts
@@ -12,7 +12,7 @@ export default function createFileWatcher(
   const watcher = workspace.createFileSystemWatcher(globPattern);
 
   const updateFiles = (filePath: string): void => {
-    extension.snykCode.addChangedFile(filePath);
+    extension.snykCodeOld.addChangedFile(filePath);
     void extension.runCodeScan(); // It's debounced, so not worries about concurrent calls
   };
 

--- a/src/snyk/snykOss/messages/treeView.ts
+++ b/src/snyk/snykOss/messages/treeView.ts
@@ -2,7 +2,6 @@ export const messages = {
   cookingDependencies: 'Getting ready Snyk dependencies...',
 
   runTest: 'Run scan for Open Source security vulnerabilities.',
-  testRunning: 'Scanning project for vulnerabilities...',
   noVulnerabilitiesFound: 'Snyk found no vulnerabilities ✅',
   singleVulnerabilityFound: 'Snyk found 1 vulnerability',
   vulnerability: 'vulnerability',

--- a/src/snyk/snykOss/services/ossService.ts
+++ b/src/snyk/snykOss/services/ossService.ts
@@ -4,6 +4,7 @@ import { IExtension } from '../../base/modules/interfaces';
 import { CliError, CliService } from '../../cli/services/cliService';
 import { IAnalytics } from '../../common/analytics/itly';
 import { IConfiguration } from '../../common/configuration/configuration';
+import { IWorkspaceTrust } from '../../common/configuration/trustedFolders';
 import { IDE_NAME } from '../../common/constants/general';
 import { ILanguageServer } from '../../common/languageServer/languageServer';
 import { ILog } from '../../common/logger/interfaces';
@@ -38,8 +39,9 @@ export class OssService extends CliService<OssResult> {
     private readonly notificationService: INotificationService,
     private readonly analytics: IAnalytics,
     protected readonly languageServer: ILanguageServer,
+    protected readonly workspaceTrust: IWorkspaceTrust,
   ) {
-    super(extensionContext, logger, config, workspace, downloadService, languageServer);
+    super(extensionContext, logger, config, workspace, downloadService, languageServer, workspaceTrust);
   }
 
   public getResultArray = (): ReadonlyArray<OssFileResult> | undefined => {
@@ -99,9 +101,9 @@ export class OssService extends CliService<OssResult> {
     this.viewManagerService.refreshOssView();
   }
 
-  override handleLsDownloadFailure(error: Error | unknown): void {
+  override handleLsDownloadFailure(): void {
+    super.handleLsDownloadFailure();
     this.viewManagerService.refreshOssView();
-    super.handleLsDownloadFailure(error);
   }
 
   override handleNoTrustedFolders(): void {

--- a/src/snyk/snykOss/views/ossVulnerabilityTreeProvider.ts
+++ b/src/snyk/snykOss/views/ossVulnerabilityTreeProvider.ts
@@ -2,6 +2,7 @@ import { OpenCommandIssueType, OpenIssueCommandArg } from '../../common/commands
 import { IConfiguration } from '../../common/configuration/configuration';
 import { SNYK_OPEN_ISSUE_COMMAND } from '../../common/constants/commands';
 import { SNYK_ANALYSIS_STATUS } from '../../common/constants/views';
+import { messages as commonMessages } from '../../common/messages/analysisMessages';
 import { IContextService } from '../../common/services/contextService';
 import { IViewManagerService } from '../../common/services/viewManagerService';
 import { AnalysisTreeNodeProvder } from '../../common/views/analysisTreeNodeProvider';
@@ -57,7 +58,7 @@ export class OssVulnerabilityTreeProvider extends AnalysisTreeNodeProvder {
     if (this.ossService.isAnalysisRunning) {
       return [
         new TreeNode({
-          text: messages.testRunning,
+          text: commonMessages.scanRunning,
         }),
       ];
     }

--- a/src/test/unit/cli/services/cliService.test.ts
+++ b/src/test/unit/cli/services/cliService.test.ts
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import { CliProcess } from '../../../../snyk/cli/process';
 import { CliError, CliService } from '../../../../snyk/cli/services/cliService';
 import { IConfiguration } from '../../../../snyk/common/configuration/configuration';
+import { WorkspaceTrust } from '../../../../snyk/common/configuration/trustedFolders';
 import { ILanguageServer } from '../../../../snyk/common/languageServer/languageServer';
 import { ILog } from '../../../../snyk/common/logger/interfaces';
 import { DownloadService } from '../../../../snyk/common/services/downloadService';
@@ -77,6 +78,7 @@ suite('CliService', () => {
       } as IVSCodeWorkspace,
       downloadService,
       ls,
+      new WorkspaceTrust(),
     );
   });
 

--- a/src/test/unit/common/commands/commandController.test.ts
+++ b/src/test/unit/common/commands/commandController.test.ts
@@ -8,7 +8,7 @@ import { COMMAND_DEBOUNCE_INTERVAL } from '../../../../snyk/common/constants/gen
 import { IOpenerService } from '../../../../snyk/common/services/openerService';
 import { IVSCodeCommands } from '../../../../snyk/common/vscode/commands';
 import { IVSCodeWorkspace } from '../../../../snyk/common/vscode/workspace';
-import { ISnykCodeService } from '../../../../snyk/snykCode/codeService';
+import { ISnykCodeServiceOld } from '../../../../snyk/snykCode/codeServiceOld';
 import { OssService } from '../../../../snyk/snykOss/services/ossService';
 import { LoggerMock } from '../../mocks/logger.mock';
 import { windowMock } from '../../mocks/window.mock';
@@ -22,7 +22,7 @@ suite('CommandController', () => {
     controller = new CommandController(
       {} as IOpenerService,
       {} as IAuthenticationService,
-      {} as ISnykCodeService,
+      {} as ISnykCodeServiceOld,
       {} as OssService,
       {} as ScanModeService,
       {} as IVSCodeWorkspace,

--- a/src/test/unit/common/configuration.test.ts
+++ b/src/test/unit/common/configuration.test.ts
@@ -180,6 +180,7 @@ suite('Configuration', () => {
     const configuration = new Configuration({}, workspace);
 
     deepStrictEqual(configuration.getPreviewFeatures(), {
+      lsCode: false,
       reportFalsePositives: false,
       advisor: false,
     } as PreviewFeatures);
@@ -188,6 +189,7 @@ suite('Configuration', () => {
   test('Preview features: some features enabled', () => {
     const previewFeatures = {
       reportFalsePositives: true,
+      lsCode: false,
       advisor: false,
     } as PreviewFeatures;
     const workspace = stubWorkspaceConfiguration(FEATURES_PREVIEW_SETTING, previewFeatures);

--- a/src/test/unit/common/configuration/trustedFolders.test.ts
+++ b/src/test/unit/common/configuration/trustedFolders.test.ts
@@ -1,15 +1,20 @@
 import { deepStrictEqual } from 'assert';
 import { IConfiguration } from '../../../../snyk/common/configuration/configuration';
-import { getTrustedFolders } from '../../../../snyk/common/configuration/trustedFolders';
+import { IWorkspaceTrust, WorkspaceTrust } from '../../../../snyk/common/configuration/trustedFolders';
 
 suite('Trusted Folders', () => {
+  let workspaceTrust: IWorkspaceTrust;
+  setup(() => {
+    workspaceTrust = new WorkspaceTrust();
+  });
+
   test('Single folder trusted', () => {
     const config = {
       getTrustedFolders: () => ['/test/workspace', '/test/workspace2'],
     } as IConfiguration;
     const workspaceFolders = ['/test/workspace'];
 
-    const trustedFolders = getTrustedFolders(config, workspaceFolders);
+    const trustedFolders = workspaceTrust.getTrustedFolders(config, workspaceFolders);
 
     deepStrictEqual(trustedFolders, ['/test/workspace']);
   });
@@ -20,7 +25,7 @@ suite('Trusted Folders', () => {
     } as IConfiguration;
     const workspaceFolders = ['/test/workspace', '/test/workspace2'];
 
-    const trustedFolders = getTrustedFolders(config, workspaceFolders);
+    const trustedFolders = workspaceTrust.getTrustedFolders(config, workspaceFolders);
 
     deepStrictEqual(trustedFolders, ['/test/workspace', '/test/workspace2']);
   });
@@ -31,7 +36,7 @@ suite('Trusted Folders', () => {
     } as IConfiguration;
     const workspaceFolders = ['/test/workspace', '/test/workspace2'];
 
-    const trustedFolders = getTrustedFolders(config, workspaceFolders);
+    const trustedFolders = workspaceTrust.getTrustedFolders(config, workspaceFolders);
 
     deepStrictEqual(trustedFolders, []);
   });
@@ -42,7 +47,7 @@ suite('Trusted Folders', () => {
     } as IConfiguration;
     const workspaceFolders = ['/test/workspace', '/test/workspace2'];
 
-    const trustedFolders = getTrustedFolders(config, workspaceFolders);
+    const trustedFolders = workspaceTrust.getTrustedFolders(config, workspaceFolders);
 
     deepStrictEqual(trustedFolders, ['/test/workspace', '/test/workspace2']);
   });
@@ -53,7 +58,7 @@ suite('Trusted Folders', () => {
     } as IConfiguration;
     const workspaceFolders = ['/test/workspace', '/test/workspace2'];
 
-    const trustedFolders = getTrustedFolders(config, workspaceFolders);
+    const trustedFolders = workspaceTrust.getTrustedFolders(config, workspaceFolders);
 
     deepStrictEqual(trustedFolders, ['/test/workspace', '/test/workspace2']);
   });

--- a/src/test/unit/mocks/languageServer.mock.ts
+++ b/src/test/unit/mocks/languageServer.mock.ts
@@ -1,0 +1,12 @@
+import { ReplaySubject, Subject } from 'rxjs';
+import sinon from 'sinon';
+import { ILanguageServer } from '../../../snyk/common/languageServer/languageServer';
+import { CodeIssueData, OssIssueData, Scan } from '../../../snyk/common/languageServer/types';
+
+export class LanguageServerMock implements ILanguageServer {
+  start = sinon.fake();
+  stop = sinon.fake();
+
+  cliReady$ = new ReplaySubject<string>(1);
+  scan$ = new Subject<Scan<CodeIssueData | OssIssueData>>();
+}

--- a/src/test/unit/snykCode/codeService.test.ts
+++ b/src/test/unit/snykCode/codeService.test.ts
@@ -1,0 +1,135 @@
+import { strictEqual } from 'assert';
+import sinon from 'sinon';
+import { IConfiguration } from '../../../snyk/common/configuration/configuration';
+import { WorkspaceTrust } from '../../../snyk/common/configuration/trustedFolders';
+import { ILanguageServer } from '../../../snyk/common/languageServer/languageServer';
+import { ScanProduct, ScanStatus } from '../../../snyk/common/languageServer/types';
+import { IViewManagerService } from '../../../snyk/common/services/viewManagerService';
+import { ExtensionContext } from '../../../snyk/common/vscode/extensionContext';
+import { IVSCodeWorkspace } from '../../../snyk/common/vscode/workspace';
+import { ISnykCodeService, SnykCodeService } from '../../../snyk/snykCode/codeService';
+import { LanguageServerMock } from '../mocks/languageServer.mock';
+
+suite('Snyk Code Service', () => {
+  let ls: ILanguageServer;
+  let service: ISnykCodeService;
+  let refreshViewFake: sinon.SinonSpy;
+
+  setup(() => {
+    ls = new LanguageServerMock();
+    refreshViewFake = sinon.fake();
+    service = new SnykCodeService(
+      {} as ExtensionContext,
+      {} as IConfiguration,
+      {
+        refreshAllCodeAnalysisViews: refreshViewFake,
+      } as unknown as IViewManagerService,
+      {
+        getWorkspaceFolders: () => [''],
+      } as IVSCodeWorkspace,
+      new WorkspaceTrust(),
+      ls,
+    );
+  });
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('Scan returned for different product', () => {
+    ls.scan$.next({
+      product: ScanProduct.OpenSource,
+      folderPath: 'test/path',
+      issues: [],
+      status: ScanStatus.InProgress,
+    });
+
+    strictEqual(service.isAnalysisRunning, false);
+    sinon.assert.notCalled(refreshViewFake);
+  });
+
+  test('Scan in progress', () => {
+    ls.scan$.next({
+      product: ScanProduct.Code,
+      folderPath: 'test/path',
+      issues: [],
+      status: ScanStatus.InProgress,
+    });
+
+    strictEqual(service.isAnalysisRunning, true);
+    sinon.assert.calledOnce(refreshViewFake);
+  });
+
+  test('Scan successfully finished', () => {
+    const folderPath = 'test/path';
+    ls.scan$.next({
+      product: ScanProduct.Code,
+      folderPath,
+      issues: [],
+      status: ScanStatus.InProgress,
+    });
+    ls.scan$.next({
+      product: ScanProduct.Code,
+      folderPath,
+      issues: [],
+      status: ScanStatus.Success,
+    });
+
+    strictEqual(service.isAnalysisRunning, false);
+    sinon.assert.calledTwice(refreshViewFake);
+  });
+
+  test('Scan failed', () => {
+    const folderPath = 'test/path';
+    ls.scan$.next({
+      product: ScanProduct.Code,
+      folderPath,
+      issues: [],
+      status: ScanStatus.InProgress,
+    });
+    ls.scan$.next({
+      product: ScanProduct.Code,
+      folderPath,
+      issues: [],
+      status: ScanStatus.Error,
+    });
+
+    strictEqual(service.isAnalysisRunning, false);
+    sinon.assert.calledTwice(refreshViewFake);
+  });
+
+  test('Scan finished when all scans in progress completed', () => {
+    const folder1Path = 'test/path';
+    const folder2Path = 'test/path2';
+    ls.scan$.next({
+      product: ScanProduct.Code,
+      folderPath: folder1Path,
+      issues: [],
+      status: ScanStatus.InProgress,
+    });
+    ls.scan$.next({
+      product: ScanProduct.Code,
+      folderPath: folder2Path,
+      issues: [],
+      status: ScanStatus.InProgress,
+    });
+    ls.scan$.next({
+      product: ScanProduct.Code,
+      folderPath: folder1Path,
+      issues: [],
+      status: ScanStatus.Success,
+    });
+
+    strictEqual(service.isAnalysisRunning, true);
+
+    ls.scan$.next({
+      product: ScanProduct.Code,
+      folderPath: folder2Path,
+      issues: [],
+      status: ScanStatus.Success,
+    });
+
+    strictEqual(service.isAnalysisRunning, false);
+    sinon.assert.calledTwice(refreshViewFake);
+  });
+});

--- a/src/test/unit/snykOss/services/ossService.test.ts
+++ b/src/test/unit/snykOss/services/ossService.test.ts
@@ -1,12 +1,11 @@
 import { deepStrictEqual, rejects, strictEqual } from 'assert';
 import * as fs from 'fs/promises';
 import _ from 'lodash';
-import { ReplaySubject } from 'rxjs';
 import sinon from 'sinon';
 import { CliProcess } from '../../../../snyk/cli/process';
 import { IAnalytics } from '../../../../snyk/common/analytics/itly';
 import { IConfiguration } from '../../../../snyk/common/configuration/configuration';
-import { ILanguageServer } from '../../../../snyk/common/languageServer/languageServer';
+import { WorkspaceTrust } from '../../../../snyk/common/configuration/trustedFolders';
 import { ILog } from '../../../../snyk/common/logger/interfaces';
 import { DownloadService } from '../../../../snyk/common/services/downloadService';
 import { INotificationService } from '../../../../snyk/common/services/notificationService';
@@ -18,6 +17,7 @@ import { OssFileResult, OssResult, OssSeverity } from '../../../../snyk/snykOss/
 import { OssService } from '../../../../snyk/snykOss/services/ossService';
 import { OssIssueCommandArg } from '../../../../snyk/snykOss/views/ossVulnerabilityTreeProvider';
 import { DailyScanJob } from '../../../../snyk/snykOss/watchers/dailyScanJob';
+import { LanguageServerMock } from '../../mocks/languageServer.mock';
 import { LoggerMock } from '../../mocks/logger.mock';
 
 suite('OssService', () => {
@@ -28,9 +28,7 @@ suite('OssService', () => {
   setup(() => {
     logger = new LoggerMock();
 
-    const ls = {
-      cliReady$: new ReplaySubject<void>(1),
-    } as unknown as ILanguageServer;
+    const ls = new LanguageServerMock();
     ls.cliReady$.next('');
 
     const testFolderPath = '';
@@ -61,6 +59,7 @@ suite('OssService', () => {
         logAnalysisIsReady: sinon.fake(),
       } as unknown as IAnalytics,
       ls,
+      new WorkspaceTrust(),
     );
   });
 


### PR DESCRIPTION
### Description

- Introduces feature flag for Code results delivered via LS.
- Enables Code results via LS under feature flag.
- Adds new service, tree views and providers for Code results via LS. Old services and views are separate and independent from the results via LS.
- Refactors workspace trust to hold state and prevent from trusted folders recalculation, when none changed. This is to speed up Code results tree generation.
- Listens on Code scan status messages from LS to report progress to the tree view. 

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs
Default state of the new views, when no scan progress reported so far:
<img width="439" alt="Screenshot 2023-01-06 at 12 43 28" src="https://user-images.githubusercontent.com/2239563/211006668-877bbd85-424a-4c4c-ad19-46d438f10d0a.png">


