### PR TITLE
fix: do not send Snyk api token to LS when runnnig extension remotely [HEAD-16]

### DIFF
--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -24,6 +24,8 @@ import {
   YES_TELEMETRY_SETTING,
   YES_WELCOME_NOTIFICATION_SETTING,
 } from '../constants/settings';
+import { Logger } from '../logger/logger';
+import { vsCodeEnv } from '../vscode/env';
 import SecretStorageAdapter from '../vscode/secretStorage';
 import { IVSCodeWorkspace } from '../vscode/workspace';
 
@@ -203,6 +205,15 @@ export class Configuration implements IConfiguration {
   }
 
   async getToken(): Promise<string | undefined> {
+    // We do not want to get token if the extension is running in a remote environment
+    // This is due to the fact that SecretStorage runs independent of the workspace i.e. it runs on the local machine
+    const remoteNames = ['ssh-remote'];
+    const remoteName = vsCodeEnv.getRemoteName();
+    if (remoteName && remoteNames.includes(remoteName)) {
+      Logger.debug(`Token not retrieved. Extension is running remotely via: ${remoteName}`);
+      return;
+    }
+
     return new Promise(resolve => {
       SecretStorageAdapter.instance
         .get(SNYK_TOKEN_KEY)


### PR DESCRIPTION
### Description

_This PR should check whether the extension is running in an `ssh-remote` environment and not retrieve the Snyk API token if it is._

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing
