### PR TITLE
fix: 🐛 allow unknown CAs, if strictProxy setting is deselected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [1.13.0]
 ### Fixed
 - trust workspace folders if parent dir is trusted
+- ignore untrusted CAs if strict proxy is disabled
 
 ### Changed
 - removed background notification about found vulnerabilities in Snyk Open Source

--- a/src/snyk/common/api/apiСlient.ts
+++ b/src/snyk/common/api/apiСlient.ts
@@ -27,11 +27,9 @@ export class SnykApiClient implements ISnykApiClient {
     const axiosRequestConfig: AxiosRequestConfig = {
       headers: DEFAULT_API_HEADERS,
       responseType: 'json',
-      ...getAxiosConfig(this.workspace),
+      ...getAxiosConfig(this.workspace, this.configuration, this.logger),
     };
 
-    // TODO: remove this log
-    this.logger.info(`Initialising HTTP client with config: ${JSON.stringify(axiosRequestConfig, null, 2)}`);
     const http = axios.create(axiosRequestConfig);
 
     http.interceptors.response.use(

--- a/src/snyk/common/api/apiСlient.ts
+++ b/src/snyk/common/api/apiСlient.ts
@@ -2,7 +2,7 @@ import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } f
 import { IConfiguration } from '../configuration/configuration';
 import { configuration } from '../configuration/instance';
 import { ILog } from '../logger/interfaces';
-import { getAxiosProxyConfig } from '../proxy';
+import { getAxiosConfig } from '../proxy';
 import { IVSCodeWorkspace } from '../vscode/workspace';
 import { DEFAULT_API_HEADERS } from './headers';
 
@@ -24,11 +24,15 @@ export class SnykApiClient implements ISnykApiClient {
   }
 
   initHttp(): AxiosInstance {
-    const http = axios.create({
+    const axiosRequestConfig: AxiosRequestConfig = {
       headers: DEFAULT_API_HEADERS,
       responseType: 'json',
-      ...getAxiosProxyConfig(this.workspace),
-    });
+      ...getAxiosConfig(this.workspace),
+    };
+
+    // TODO: remove this log
+    this.logger.info(`Initialising HTTP client with config: ${JSON.stringify(axiosRequestConfig, null, 2)}`);
+    const http = axios.create(axiosRequestConfig);
 
     http.interceptors.response.use(
       response => response,

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -94,7 +94,8 @@ export interface IConfiguration {
   isAutomaticDependencyManagementEnabled(): boolean;
 
   getCliPath(): string | undefined;
-  getInsecure(): string;
+
+  getInsecure(): boolean;
 
   severityFilter: SeverityFilter;
 
@@ -117,9 +118,9 @@ export class Configuration implements IConfiguration {
 
   constructor(private processEnv: NodeJS.ProcessEnv = process.env, private workspace: IVSCodeWorkspace) {}
 
-  getInsecure(): string {
+  getInsecure(): boolean {
     const strictSSL = this.workspace.getConfiguration<boolean>('http', 'proxyStrictSSL') ?? true;
-    return `${!strictSSL}`;
+    return !strictSSL;
   }
 
   static async getVersion(): Promise<string> {

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -94,6 +94,7 @@ export interface IConfiguration {
   isAutomaticDependencyManagementEnabled(): boolean;
 
   getCliPath(): string | undefined;
+  getInsecure(): string;
 
   severityFilter: SeverityFilter;
 
@@ -115,6 +116,11 @@ export class Configuration implements IConfiguration {
   private readonly devBaseApiHost = 'https://api.dev.snyk.io';
 
   constructor(private processEnv: NodeJS.ProcessEnv = process.env, private workspace: IVSCodeWorkspace) {}
+
+  getInsecure(): string {
+    const strictSSL = this.workspace.getConfiguration<boolean>('http', 'proxyStrictSSL') ?? true;
+    return `${!strictSSL}`;
+  }
 
   static async getVersion(): Promise<string> {
     // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/src/snyk/common/languageServer/languageServer.ts
+++ b/src/snyk/common/languageServer/languageServer.ts
@@ -51,7 +51,7 @@ export class LanguageServer implements ILanguageServer {
     this.logger.info('Starting Snyk Language Server');
 
     // proxy settings
-    const proxyOptions = getProxyOptions(this.workspace);
+    const proxyOptions = getProxyOptions(this.workspace, this.configuration, this.logger);
     const proxyEnvVariable = getProxyEnvVariable(proxyOptions);
 
     let processEnv = process.env;

--- a/src/snyk/common/languageServer/languageServer.ts
+++ b/src/snyk/common/languageServer/languageServer.ts
@@ -55,7 +55,7 @@ export class LanguageServer implements ILanguageServer {
     this.logger.info('Starting Snyk Language Server');
 
     // proxy settings
-    const proxyOptions = getProxyOptions(this.workspace, this.configuration, this.logger);
+    const proxyOptions = await getProxyOptions(this.workspace, this.configuration, this.logger);
     const proxyEnvVariable = getProxyEnvVariable(proxyOptions);
 
     let processEnv = process.env;

--- a/src/snyk/common/languageServer/settings.ts
+++ b/src/snyk/common/languageServer/settings.ts
@@ -51,7 +51,7 @@ export class LanguageServerSettings {
       filterSeverity: configuration.severityFilter,
       enableTrustedFoldersFeature: 'true',
       trustedFolders: configuration.getTrustedFolders(),
-      insecure: configuration.getInsecure(),
+      insecure: `${configuration.getInsecure()}`,
     };
   }
 }

--- a/src/snyk/common/languageServer/settings.ts
+++ b/src/snyk/common/languageServer/settings.ts
@@ -25,6 +25,7 @@ export type ServerSettings = {
   filterSeverity?: SeverityFilter;
   enableTrustedFoldersFeature?: string;
   trustedFolders?: string[];
+  insecure?: string;
 };
 
 export class LanguageServerSettings {
@@ -50,6 +51,7 @@ export class LanguageServerSettings {
       filterSeverity: configuration.severityFilter,
       enableTrustedFoldersFeature: 'true',
       trustedFolders: configuration.getTrustedFolders(),
+      insecure: configuration.getInsecure(),
     };
   }
 }

--- a/src/snyk/common/languageServer/staticLsApi.ts
+++ b/src/snyk/common/languageServer/staticLsApi.ts
@@ -66,7 +66,7 @@ export class StaticLsApi implements IStaticLsApi {
     const fileName = await this.getFileName(platform);
     const { data } = await axios.get<string>(
       `${this.baseUrl}/snyk-ls_${await this.getLatestVersion()}_SHA256SUMS`,
-      getAxiosConfig(this.workspace, this.configuration, this.logger),
+      await getAxiosConfig(this.workspace, this.configuration, this.logger),
     );
 
     let checksum = '';
@@ -83,7 +83,7 @@ export class StaticLsApi implements IStaticLsApi {
   async getMetadata(): Promise<LsMetadata> {
     const response = await axios.get<LsMetadata>(
       `${this.baseUrl}/metadata.json`,
-      getAxiosConfig(this.workspace, this.configuration, this.logger),
+      await getAxiosConfig(this.workspace, this.configuration, this.logger),
     );
     return response.data;
   }

--- a/src/snyk/common/languageServer/staticLsApi.ts
+++ b/src/snyk/common/languageServer/staticLsApi.ts
@@ -1,10 +1,12 @@
 import axios, { CancelTokenSource } from 'axios';
 import { PROTOCOL_VERSION } from '../constants/languageServer';
-import { DownloadAxiosResponse } from '../download/downloader';
-import { getAxiosConfig } from '../proxy';
-import { IVSCodeWorkspace } from '../vscode/workspace';
 import { LsExecutable } from './lsExecutable';
 import { LsSupportedPlatform } from './supportedPlatforms';
+import { getAxiosConfig } from '../proxy';
+import { IVSCodeWorkspace } from '../vscode/workspace';
+import { DownloadAxiosResponse } from '../download/downloader';
+import { IConfiguration } from '../configuration/configuration';
+import { ILog } from '../logger/interfaces';
 
 export type LsMetadata = {
   tag: string;
@@ -29,7 +31,11 @@ export interface IStaticLsApi {
 export class StaticLsApi implements IStaticLsApi {
   private readonly baseUrl = `https://static.snyk.io/snyk-ls/${PROTOCOL_VERSION}`;
 
-  constructor(private readonly workspace: IVSCodeWorkspace) {}
+  constructor(
+    private readonly workspace: IVSCodeWorkspace,
+    private readonly configuration: IConfiguration,
+    private readonly logger: ILog,
+  ) {}
 
   async getDownloadUrl(platform: LsSupportedPlatform): Promise<string> {
     return `${this.baseUrl}/${await this.getFileName(platform)}`;
@@ -46,7 +52,7 @@ export class StaticLsApi implements IStaticLsApi {
     const response = axios.get(downloadUrl, {
       responseType: 'stream',
       cancelToken: axiosCancelToken.token,
-      ...getAxiosConfig(this.workspace),
+      ...getAxiosConfig(this.workspace, this.configuration, this.logger),
     });
 
     return [response as Promise<DownloadAxiosResponse>, axiosCancelToken];
@@ -60,7 +66,7 @@ export class StaticLsApi implements IStaticLsApi {
     const fileName = await this.getFileName(platform);
     const { data } = await axios.get<string>(
       `${this.baseUrl}/snyk-ls_${await this.getLatestVersion()}_SHA256SUMS`,
-      getAxiosConfig(this.workspace),
+      getAxiosConfig(this.workspace, this.configuration, this.logger),
     );
 
     let checksum = '';
@@ -75,7 +81,10 @@ export class StaticLsApi implements IStaticLsApi {
   }
 
   async getMetadata(): Promise<LsMetadata> {
-    const response = await axios.get<LsMetadata>(`${this.baseUrl}/metadata.json`, getAxiosConfig(this.workspace));
+    const response = await axios.get<LsMetadata>(
+      `${this.baseUrl}/metadata.json`,
+      getAxiosConfig(this.workspace, this.configuration, this.logger),
+    );
     return response.data;
   }
 }

--- a/src/snyk/common/languageServer/staticLsApi.ts
+++ b/src/snyk/common/languageServer/staticLsApi.ts
@@ -52,7 +52,7 @@ export class StaticLsApi implements IStaticLsApi {
     const response = axios.get(downloadUrl, {
       responseType: 'stream',
       cancelToken: axiosCancelToken.token,
-      ...getAxiosConfig(this.workspace, this.configuration, this.logger),
+      ...(await getAxiosConfig(this.workspace, this.configuration, this.logger)),
     });
 
     return [response as Promise<DownloadAxiosResponse>, axiosCancelToken];

--- a/src/snyk/common/languageServer/staticLsApi.ts
+++ b/src/snyk/common/languageServer/staticLsApi.ts
@@ -1,10 +1,10 @@
 import axios, { CancelTokenSource } from 'axios';
 import { PROTOCOL_VERSION } from '../constants/languageServer';
+import { DownloadAxiosResponse } from '../download/downloader';
+import { getAxiosConfig } from '../proxy';
+import { IVSCodeWorkspace } from '../vscode/workspace';
 import { LsExecutable } from './lsExecutable';
 import { LsSupportedPlatform } from './supportedPlatforms';
-import { getAxiosProxyConfig } from '../proxy';
-import { IVSCodeWorkspace } from '../vscode/workspace';
-import { DownloadAxiosResponse } from '../download/downloader';
 
 export type LsMetadata = {
   tag: string;
@@ -46,7 +46,7 @@ export class StaticLsApi implements IStaticLsApi {
     const response = axios.get(downloadUrl, {
       responseType: 'stream',
       cancelToken: axiosCancelToken.token,
-      ...getAxiosProxyConfig(this.workspace),
+      ...getAxiosConfig(this.workspace),
     });
 
     return [response as Promise<DownloadAxiosResponse>, axiosCancelToken];
@@ -60,7 +60,7 @@ export class StaticLsApi implements IStaticLsApi {
     const fileName = await this.getFileName(platform);
     const { data } = await axios.get<string>(
       `${this.baseUrl}/snyk-ls_${await this.getLatestVersion()}_SHA256SUMS`,
-      getAxiosProxyConfig(this.workspace),
+      getAxiosConfig(this.workspace),
     );
 
     let checksum = '';
@@ -75,7 +75,7 @@ export class StaticLsApi implements IStaticLsApi {
   }
 
   async getMetadata(): Promise<LsMetadata> {
-    const response = await axios.get<LsMetadata>(`${this.baseUrl}/metadata.json`, getAxiosProxyConfig(this.workspace));
+    const response = await axios.get<LsMetadata>(`${this.baseUrl}/metadata.json`, getAxiosConfig(this.workspace));
     return response.data;
   }
 }

--- a/src/snyk/common/proxy.ts
+++ b/src/snyk/common/proxy.ts
@@ -1,7 +1,7 @@
 import { AxiosRequestConfig } from 'axios';
 import fs from 'fs';
-import https from 'https';
-import createHttpsProxyAgent, { HttpsProxyAgent, HttpsProxyAgentOptions } from 'https-proxy-agent';
+import { Agent, AgentOptions } from 'https';
+import { HttpsProxyAgent, HttpsProxyAgentOptions } from 'https-proxy-agent';
 import * as url from 'url';
 import { Logger } from './logger/logger';
 import { IVSCodeWorkspace } from './vscode/workspace';
@@ -24,6 +24,7 @@ export function getProxyOptions(
 
   const defaultOptions: HttpsProxyAgentOptions = {
     rejectUnauthorized: workspace.getConfiguration<boolean>('http', 'proxyStrictSSL') ?? true,
+    ...getDefaultAgentOptions(),
   };
 
   if (!proxy) {
@@ -65,26 +66,18 @@ export function getVsCodeProxy(workspace: IVSCodeWorkspace): string | undefined 
 
 export function getAxiosConfig(workspace: IVSCodeWorkspace): AxiosRequestConfig {
   // if proxying, we need to configure getHttpsProxyAgent, else configure getHttpsAgent
-  let agentOptions: HttpsProxyAgent | https.Agent | undefined = getHttpsProxyAgent(workspace);
-  if (!agentOptions) {
-    agentOptions = getHttpsAgent(workspace);
-  }
+  let agentOptions: HttpsProxyAgent | Agent | undefined = getHttpsProxyAgent(workspace);
+  if (!agentOptions) agentOptions = getHttpsAgent();
 
   return {
     // proxy false as we're using https-proxy-agent library for proxying
     proxy: false,
-    httpAgent: {
-      ...agentOptions,
-    },
-    httpsAgent: {
-      ...agentOptions,
-    },
+    httpAgent: agentOptions,
+    httpsAgent: agentOptions,
   };
 }
 
-export function getProxyEnvVariable(
-  proxyOptions: createHttpsProxyAgent.HttpsProxyAgentOptions | undefined,
-): string | undefined {
+export function getProxyEnvVariable(proxyOptions: HttpsProxyAgentOptions | undefined): string | undefined {
   if (!proxyOptions) {
     return;
   }
@@ -99,26 +92,21 @@ function getVSCodeStrictProxy(workspace: IVSCodeWorkspace): boolean {
   return workspace.getConfiguration<boolean>('http', 'proxyStrictSSL') ?? true;
 }
 
-function getHttpsAgent(workspace: IVSCodeWorkspace): https.Agent {
-  return new https.Agent({
-    ...getDefaultAgentOptions(workspace),
+function getHttpsAgent(): Agent {
+  return new Agent({
+    ...getDefaultAgentOptions(),
   });
 }
 
-function getDefaultAgentOptions(
-  workspace: IVSCodeWorkspace,
-  processEnv: NodeJS.ProcessEnv = process.env,
-): https.AgentOptions {
-  const defaultOptions: https.AgentOptions = {
-    rejectUnauthorized: getVSCodeStrictProxy(workspace),
-  };
+function getDefaultAgentOptions(processEnv: NodeJS.ProcessEnv = process.env): AgentOptions | undefined {
+  let defaultOptions: AgentOptions | undefined = undefined;
 
   // use custom certs if provided
   if (processEnv.NODE_EXTRA_CA_CERTS) {
     try {
       fs.accessSync(processEnv.NODE_EXTRA_CA_CERTS);
       const certs = fs.readFileSync(processEnv.NODE_EXTRA_CA_CERTS);
-      defaultOptions.ca = [certs];
+      defaultOptions = { ca: [certs] };
     } catch (error) {
       Logger.error(`Failed to read NODE_EXTRA_CA_CERTS file: ${error}`);
     }

--- a/src/snyk/common/proxy.ts
+++ b/src/snyk/common/proxy.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig } from 'axios';
-import fs from 'fs';
+import fs from 'fs/promises';
 import { Agent, AgentOptions, globalAgent } from 'https';
 import { HttpsProxyAgent, HttpsProxyAgentOptions } from 'https-proxy-agent';
 import * as url from 'url';
@@ -7,28 +7,28 @@ import { IVSCodeWorkspace } from './vscode/workspace';
 import { IConfiguration } from './configuration/configuration';
 import { ILog } from './logger/interfaces';
 
-export function getHttpsProxyAgent(
+export async function getHttpsProxyAgent(
   workspace: IVSCodeWorkspace,
   configuration: IConfiguration,
   logger: ILog,
   processEnv: NodeJS.ProcessEnv = process.env,
-): HttpsProxyAgent | undefined {
-  const proxyOptions = getProxyOptions(workspace, configuration, logger, processEnv);
+): Promise<HttpsProxyAgent | undefined> {
+  const proxyOptions = await getProxyOptions(workspace, configuration, logger, processEnv);
   if (proxyOptions == undefined) return undefined;
 
   return new HttpsProxyAgent(proxyOptions);
 }
 
-export function getProxyOptions(
+export async function getProxyOptions(
   workspace: IVSCodeWorkspace,
   configuration: IConfiguration,
   logger: ILog,
   processEnv: NodeJS.ProcessEnv = process.env,
-): HttpsProxyAgentOptions | undefined {
+): Promise<HttpsProxyAgentOptions | undefined> {
   let proxy: string | undefined = getVsCodeProxy(workspace);
 
   const defaultOptions: HttpsProxyAgentOptions = {
-    ...getDefaultAgentOptions(configuration, logger),
+    ...(await getDefaultAgentOptions(configuration, logger)),
   };
 
   if (!proxy) {
@@ -66,14 +66,14 @@ export function getVsCodeProxy(workspace: IVSCodeWorkspace): string | undefined 
   return workspace.getConfiguration<string>('http', 'proxy');
 }
 
-export function getAxiosConfig(
+export async function getAxiosConfig(
   workspace: IVSCodeWorkspace,
   configuration: IConfiguration,
   logger: ILog,
-): AxiosRequestConfig {
+): Promise<AxiosRequestConfig> {
   // if proxying, we need to configure getHttpsProxyAgent, else configure getHttpsAgent
-  let agentOptions: HttpsProxyAgent | Agent | undefined = getHttpsProxyAgent(workspace, configuration, logger);
-  if (!agentOptions) agentOptions = getHttpsAgent(configuration, logger);
+  let agentOptions: HttpsProxyAgent | Agent | undefined = await getHttpsProxyAgent(workspace, configuration, logger);
+  if (!agentOptions) agentOptions = await getHttpsAgent(configuration, logger);
 
   return {
     // proxy false as we're using https-proxy-agent library for proxying
@@ -94,17 +94,17 @@ export function getProxyEnvVariable(proxyOptions: HttpsProxyAgentOptions | undef
   return `${protocol}//${auth ? `${auth}@` : ''}${host}${port ? `:${port}` : ''}`;
 }
 
-function getHttpsAgent(configuration: IConfiguration, logger: ILog): Agent {
+async function getHttpsAgent(configuration: IConfiguration, logger: ILog): Promise<Agent> {
   return new Agent({
-    ...getDefaultAgentOptions(configuration, logger),
+    ...(await getDefaultAgentOptions(configuration, logger)),
   });
 }
 
-function getDefaultAgentOptions(
+async function getDefaultAgentOptions(
   configuration: IConfiguration,
   logger: ILog,
   processEnv: NodeJS.ProcessEnv = process.env,
-): AgentOptions | undefined {
+): Promise<AgentOptions | undefined> {
   let defaultOptions: AgentOptions | undefined;
 
   const sslCheck = !configuration.getInsecure();
@@ -115,8 +115,10 @@ function getDefaultAgentOptions(
     // use custom certs if provided
     if (processEnv.NODE_EXTRA_CA_CERTS) {
       try {
-        fs.accessSync(processEnv.NODE_EXTRA_CA_CERTS);
-        const certs = fs.readFileSync(processEnv.NODE_EXTRA_CA_CERTS);
+        // fs.accessSync(processEnv.NODE_EXTRA_CA_CERTS);
+        // const certs = fs.readFileSync(processEnv.NODE_EXTRA_CA_CERTS);
+        await fs.access(processEnv.NODE_EXTRA_CA_CERTS);
+        const certs = await fs.readFile(processEnv.NODE_EXTRA_CA_CERTS);
         defaultOptions = { ca: [certs] };
         globalAgent.options.ca = [certs];
       } catch (error) {

--- a/src/snyk/common/proxy.ts
+++ b/src/snyk/common/proxy.ts
@@ -115,8 +115,6 @@ async function getDefaultAgentOptions(
     // use custom certs if provided
     if (processEnv.NODE_EXTRA_CA_CERTS) {
       try {
-        // fs.accessSync(processEnv.NODE_EXTRA_CA_CERTS);
-        // const certs = fs.readFileSync(processEnv.NODE_EXTRA_CA_CERTS);
         await fs.access(processEnv.NODE_EXTRA_CA_CERTS);
         const certs = await fs.readFile(processEnv.NODE_EXTRA_CA_CERTS);
         defaultOptions = { ca: [certs] };

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -160,7 +160,7 @@ class SnykExtension extends SnykLib implements IExtension {
     this.downloadService = new DownloadService(
       this.context,
       configuration,
-      new StaticLsApi(vsCodeWorkspace),
+      new StaticLsApi(vsCodeWorkspace, configuration, Logger),
       vsCodeWindow,
       Logger,
     );

--- a/src/snyk/snykCode/views/issueTreeProvider.ts
+++ b/src/snyk/snykCode/views/issueTreeProvider.ts
@@ -39,7 +39,7 @@ export class IssueTreeProvider extends AnalysisTreeNodeProvder {
 
   getRootChildren(): TreeNode[] {
     const review: TreeNode[] = [];
-    let nIssues = 0;
+    const nIssues = 0;
 
     if (!this.contextService.shouldShowCodeAnalysis) return review;
     if (!this.codeService.isLsDownloadSuccessful) {

--- a/src/snyk/snykOss/api/npmTestApi.ts
+++ b/src/snyk/snykOss/api/npmTestApi.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { DEFAULT_API_HEADERS } from '../../common/api/headers';
 import { configuration } from '../../common/configuration/instance';
 import { ILog } from '../../common/logger/interfaces';
-import { getAxiosProxyConfig } from '../../common/proxy';
+import { getAxiosConfig } from '../../common/proxy';
 import { IVSCodeWorkspace } from '../../common/vscode/workspace';
 
 export class NpmTestApi {
@@ -19,7 +19,7 @@ export class NpmTestApi {
       headers: DEFAULT_API_HEADERS,
       responseType: 'json',
       baseURL: configuration.authHost + '/test',
-      ...getAxiosProxyConfig(this.workspace),
+      ...getAxiosConfig(this.workspace),
     });
 
     http.interceptors.response.use(

--- a/src/snyk/snykOss/api/npmTestApi.ts
+++ b/src/snyk/snykOss/api/npmTestApi.ts
@@ -19,7 +19,7 @@ export class NpmTestApi {
       headers: DEFAULT_API_HEADERS,
       responseType: 'json',
       baseURL: configuration.authHost + '/test',
-      ...getAxiosConfig(this.workspace),
+      ...getAxiosConfig(this.workspace, configuration, this.logger),
     });
 
     http.interceptors.response.use(

--- a/src/test/unit/common/languageServer/languageServer.test.ts
+++ b/src/test/unit/common/languageServer/languageServer.test.ts
@@ -26,6 +26,9 @@ suite('Language Server', () => {
   let downloadService: DownloadService;
   setup(() => {
     configuration = {
+      getInsecure(): boolean {
+        return true;
+      },
       getCliPath(): string | undefined {
         return 'testPath';
       },
@@ -103,6 +106,7 @@ suite('Language Server', () => {
       filterSeverity: { critical: true, high: true, medium: true, low: true },
       enableTrustedFoldersFeature: 'true',
       trustedFolders: ['/trusted/test/folder'],
+      insecure: 'true',
     };
 
     deepStrictEqual(await languageServer.getInitializationOptions(), expectedInitializationOptions);

--- a/src/test/unit/common/languageServer/middleware.test.ts
+++ b/src/test/unit/common/languageServer/middleware.test.ts
@@ -25,6 +25,9 @@ suite('Language Server: Middleware', () => {
       getToken: () => Promise.resolve('token'),
       isAutomaticDependencyManagementEnabled: () => true,
       getCliPath: () => '/path/to/cli',
+      getInsecure(): boolean {
+        return true;
+      },
       getPreviewFeatures: () => {
         return {
           advisor: false,

--- a/src/test/unit/common/proxy.test.ts
+++ b/src/test/unit/common/proxy.test.ts
@@ -23,7 +23,7 @@ suite('Proxy', () => {
     sinon.restore();
   });
 
-  test('No proxy set', () => {
+  test('No proxy set', async () => {
     const getConfiguration = sinon.stub();
     const getInsecure = sinon.stub();
     getInsecure.returns(!proxyStrictSSL);
@@ -38,7 +38,7 @@ suite('Proxy', () => {
       getConfiguration,
     } as unknown as IVSCodeWorkspace;
 
-    const configOptions = getAxiosConfig(workspace, configuration, logger);
+    const configOptions = await getAxiosConfig(workspace, configuration, logger);
 
     // should still set rejectUnauthorized flag
     // @ts-ignore: cannot test options otherwise
@@ -60,8 +60,8 @@ suite('Proxy', () => {
         getInsecure,
       } as unknown as IConfiguration;
 
-      test('should return rejectUnauthorized true', () => {
-        const config = getAxiosConfig(workspace, configuration, logger);
+      test('should return rejectUnauthorized true', async () => {
+        const config = await getAxiosConfig(workspace, configuration, logger);
         assert.deepStrictEqual(config.httpAgent?.options.rejectUnauthorized, true);
       });
     });
@@ -79,14 +79,14 @@ suite('Proxy', () => {
         getInsecure,
       } as unknown as IConfiguration;
 
-      test('should return rejectUnauthorized false', () => {
-        const config = getAxiosConfig(workspace, configuration, logger);
+      test('should return rejectUnauthorized false', async () => {
+        const config = await getAxiosConfig(workspace, configuration, logger);
         assert.deepStrictEqual(config.httpsAgent?.options.rejectUnauthorized, false);
       });
     });
   });
 
-  test('Proxy is set in VS Code settings', () => {
+  test('Proxy is set in VS Code settings', async () => {
     const getConfiguration = sinon.stub();
     getConfiguration.withArgs('http', 'proxy').returns(proxy);
     getConfiguration.withArgs('http', 'proxyStrictSSL').returns(proxyStrictSSL);
@@ -102,7 +102,7 @@ suite('Proxy', () => {
       getInsecure,
     } as unknown as IConfiguration;
 
-    const agent = getHttpsProxyAgent(workspace, configuration, logger);
+    const agent = await getHttpsProxyAgent(workspace, configuration, logger);
 
     // @ts-ignore: cannot test options otherwise
     assert.deepStrictEqual(agent?.proxy.host, host);
@@ -114,7 +114,7 @@ suite('Proxy', () => {
     assert.deepStrictEqual(agent?.proxy.rejectUnauthorized, proxyStrictSSL);
   });
 
-  test('Proxy is set in environment', () => {
+  test('Proxy is set in environment', async () => {
     const getConfiguration = sinon.stub();
     getConfiguration.withArgs('http', 'proxy').returns(undefined);
     getConfiguration.withArgs('http', 'proxyStrictSSL').returns(proxyStrictSSL);
@@ -129,7 +129,7 @@ suite('Proxy', () => {
       getInsecure,
     } as unknown as IConfiguration;
 
-    const agent = getHttpsProxyAgent(workspace, configuration, logger, {
+    const agent = await getHttpsProxyAgent(workspace, configuration, logger, {
       https_proxy: proxy,
       http_proxy: proxy,
     });
@@ -144,7 +144,7 @@ suite('Proxy', () => {
     assert.deepStrictEqual(agent?.proxy.rejectUnauthorized, proxyStrictSSL);
   });
 
-  test('getProxyEnvVariable should return the https proxy as env var', () => {
+  test('getProxyEnvVariable should return the https proxy as env var', async () => {
     const getConfiguration = sinon.stub();
     getConfiguration.withArgs('http', 'proxy').returns(proxy);
     getConfiguration.withArgs('http', 'proxyStrictSSL').returns(proxyStrictSSL);
@@ -160,7 +160,7 @@ suite('Proxy', () => {
       getInsecure,
     } as unknown as IConfiguration;
 
-    const envVariable = getProxyEnvVariable(getProxyOptions(workspace, configuration, logger));
+    const envVariable = getProxyEnvVariable(await getProxyOptions(workspace, configuration, logger));
 
     // noinspection HttpUrlsUsage
     assert.deepStrictEqual(envVariable, `${protocol}//${auth}@${host}:${port}`);

--- a/src/test/unit/common/proxy.test.ts
+++ b/src/test/unit/common/proxy.test.ts
@@ -23,7 +23,7 @@ suite('Proxy', () => {
     sinon.restore();
   });
 
-  test('No proxy set', async () => {
+  test('No proxy configured by user (default case)', async () => {
     const getConfiguration = sinon.stub();
     const getInsecure = sinon.stub();
     getInsecure.returns(!proxyStrictSSL);
@@ -47,7 +47,7 @@ suite('Proxy', () => {
   });
 
   suite('.getAxiosConfig()', () => {
-    suite('when proxyStrictSsl is set', () => {
+    suite('when proxyStrictSsl checkbox is checked', () => {
       const getConfiguration = sinon.stub();
       const workspace = {
         getConfiguration,
@@ -66,7 +66,7 @@ suite('Proxy', () => {
       });
     });
 
-    suite('when proxyStrictSsl is not set', () => {
+    suite('when proxyStrictSsl checkbox is not checked', () => {
       const getConfiguration = sinon.stub();
       const workspace = {
         getConfiguration,
@@ -86,7 +86,7 @@ suite('Proxy', () => {
     });
   });
 
-  test('Proxy is set in VS Code settings', async () => {
+  test('Proxy is configured in VS Code settings', async () => {
     const getConfiguration = sinon.stub();
     getConfiguration.withArgs('http', 'proxy').returns(proxy);
     getConfiguration.withArgs('http', 'proxyStrictSSL').returns(proxyStrictSSL);
@@ -114,7 +114,7 @@ suite('Proxy', () => {
     assert.deepStrictEqual(agent?.proxy.rejectUnauthorized, proxyStrictSSL);
   });
 
-  test('Proxy is set in environment', async () => {
+  test('Proxy is configured in environment', async () => {
     const getConfiguration = sinon.stub();
     getConfiguration.withArgs('http', 'proxy').returns(undefined);
     getConfiguration.withArgs('http', 'proxyStrictSSL').returns(proxyStrictSSL);


### PR DESCRIPTION
### Description

Tested with https://github.com/bastiandoetsch/jvm-development-environment/. 

- provide `insecure=true` to language server when strict proxy is deactivated
- ignore invalid SSL certs if strict proxy deactivated
- use custom cert if defined via env variable and strict proxy activated

Tested:
- LS download
- Snyk API Client
- Snyk Code
- Snyk Open Source

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
