### PR TITLE
fix: ensure LS is downloaded when LSP version is bumped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Snyk Security - Code and Open Source Dependencies Changelog
 
+## [1.15.1]
+
+### Fixed
+
+- Force Language Server redownload when LSP version increases.
+
 ## [1.15.0]
 
 ### Changed

--- a/src/snyk/common/constants/globalState.ts
+++ b/src/snyk/common/constants/globalState.ts
@@ -1,4 +1,5 @@
 export const MEMENTO_FIRST_INSTALL_DATE_KEY = 'snyk.firstInstallDate';
 export const MEMENTO_ANONYMOUS_ID = 'snyk.anonymousId';
 export const MEMENTO_LS_LAST_UPDATE_DATE = 'snyk.lsLastUpdateDate';
+export const MEMENTO_LS_PROTOCOL_VERSION = 'snyk.lsProtocolVersion';
 export const MEMENTO_LS_CHECKSUM = 'snyk.lsChecksum';

--- a/src/snyk/common/languageServer/languageServer.ts
+++ b/src/snyk/common/languageServer/languageServer.ts
@@ -155,7 +155,7 @@ export class LanguageServer implements ILanguageServer {
     });
 
     client.onNotification(SNYK_SCAN, (scan: Scan<CodeIssueData | OssIssueData>) => {
-      this.logger.info(`${_.capitalize(scan.product)} scan ${scan.status}.`);
+      this.logger.info(`${_.capitalize(scan.product)} scan for ${scan.folderPath}: ${scan.status}.`);
       this.scan$.next(scan);
     });
   }


### PR DESCRIPTION
### Description

We haven't guaranteed the update upon LSP version bump so far, that led to the following case being possible:
1. LSP version has been increased
2. Extension is released with the increased LSP version
3. Users who had LS recently updated (<4 days) wouldn't obtain the latest LS binary.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
