### PR TITLE
feat: enable dynamic Snyk Code scans via Language Server rollout [HEAD-122]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Snyk Security - Code and Open Source Dependencies Changelog
 
+## [1.15.5]
+
+### Changed
+
+- Enabled dynamic Snyk Code scans via Language Server rollout.
+
 ## [1.15.3]
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "snyk-vulnerability-scanner",
       "version": "0.0.0",
       "dependencies": {
-        "@amplitude/experiment-node-server": "^1.0.2",
+        "@amplitude/experiment-node-server": "^1.3.0",
         "@babel/parser": "^7.12.11",
         "@babel/traverse": "^7.12.12",
         "@babel/types": "^7.12.12",
@@ -230,10 +230,18 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@amplitude/evaluation-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/evaluation-js/-/evaluation-js-1.0.0.tgz",
+      "integrity": "sha512-U2ibGJ+5XLwfyHPmwDdxkqWhxxmZBs/gnPWalKBnmcY4zGXfBi2XkGbHsghlAD3XD3vZ1eMl7xqhHp3CWtpp/g=="
+    },
     "node_modules/@amplitude/experiment-node-server": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@amplitude/experiment-node-server/-/experiment-node-server-1.0.2.tgz",
-      "integrity": "sha512-2CWoEzgz5fBQGOIJqEv+mr77NpUGPM/Apydl8lbMVAC6q1x1lNZcIuYtXSUeWGfnZg/9Ni/1vtBirMEDgqWntw=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/experiment-node-server/-/experiment-node-server-1.3.0.tgz",
+      "integrity": "sha512-ahkN1H+9nHteqVaktitzjs43UTUJ0iwVplz0Brm6XKd7wT/w7ICbyPjvfPepqu6l71j5065DhVA7g1hdufkP/Q==",
+      "dependencies": {
+        "@amplitude/evaluation-js": "1.0.0"
+      }
     },
     "node_modules/@amplitude/identify": {
       "version": "1.10.2",
@@ -8724,10 +8732,18 @@
         }
       }
     },
+    "@amplitude/evaluation-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/evaluation-js/-/evaluation-js-1.0.0.tgz",
+      "integrity": "sha512-U2ibGJ+5XLwfyHPmwDdxkqWhxxmZBs/gnPWalKBnmcY4zGXfBi2XkGbHsghlAD3XD3vZ1eMl7xqhHp3CWtpp/g=="
+    },
     "@amplitude/experiment-node-server": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@amplitude/experiment-node-server/-/experiment-node-server-1.0.2.tgz",
-      "integrity": "sha512-2CWoEzgz5fBQGOIJqEv+mr77NpUGPM/Apydl8lbMVAC6q1x1lNZcIuYtXSUeWGfnZg/9Ni/1vtBirMEDgqWntw=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/experiment-node-server/-/experiment-node-server-1.3.0.tgz",
+      "integrity": "sha512-ahkN1H+9nHteqVaktitzjs43UTUJ0iwVplz0Brm6XKd7wT/w7ICbyPjvfPepqu6l71j5065DhVA7g1hdufkP/Q==",
+      "requires": {
+        "@amplitude/evaluation-js": "1.0.0"
+      }
     },
     "@amplitude/identify": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -449,7 +449,7 @@
     "yalc": "^1.0.0-pre.44"
   },
   "dependencies": {
-    "@amplitude/experiment-node-server": "^1.0.2",
+    "@amplitude/experiment-node-server": "^1.3.0",
     "@babel/parser": "^7.12.11",
     "@babel/traverse": "^7.12.12",
     "@babel/types": "^7.12.12",

--- a/package.json
+++ b/package.json
@@ -258,32 +258,32 @@
         {
           "id": "snyk.views.analysis.code.security.old",
           "name": "Code Security",
-          "when": "snyk:loggedIn && snyk:featuresSelected && snyk:codeEnabled && !snyk:codeLocalEngineEnabled && snyk:workspaceFound && !snyk:error"
+          "when": "snyk:loggedIn && !snyk:lsCodePreview && snyk:featuresSelected && snyk:codeEnabled && !snyk:codeLocalEngineEnabled && snyk:workspaceFound && !snyk:error"
         },
         {
           "id": "snyk.views.analysis.code.quality.old",
           "name": "Code Quality",
-          "when": "snyk:loggedIn && snyk:featuresSelected && snyk:codeEnabled && !snyk:codeLocalEngineEnabled && snyk:workspaceFound && !snyk:error"
+          "when": "snyk:loggedIn && !snyk:lsCodePreview && snyk:featuresSelected && snyk:codeEnabled && !snyk:codeLocalEngineEnabled && snyk:workspaceFound && !snyk:error"
         },
         {
           "id": "snyk.views.analysis.code.security",
-          "name": "Code Security (LS)",
+          "name": "Code Security",
           "when": "snyk:lsCodePreview && snyk:loggedIn && snyk:featuresSelected && snyk:codeEnabled && !snyk:codeLocalEngineEnabled && snyk:workspaceFound && !snyk:error"
         },
         {
           "id": "snyk.views.analysis.code.quality",
-          "name": "Code Quality (LS)",
+          "name": "Code Quality",
           "when": "snyk:lsCodePreview && snyk:loggedIn && snyk:featuresSelected && snyk:codeEnabled && !snyk:codeLocalEngineEnabled && snyk:workspaceFound && !snyk:error"
         },
         {
           "id": "snyk.views.analysis.code.enablement",
           "name": "Code Security & Quality",
-          "when": "snyk:loggedIn && snyk:featuresSelected && !snyk:codeEnabled && snyk:workspaceFound && !snyk:error"
+          "when": "snyk:loggedIn && !snyk:lsCodePreview && snyk:featuresSelected && !snyk:codeEnabled && snyk:workspaceFound && !snyk:error"
         },
         {
           "id": "snyk.views.analysis.code.localEngine",
           "name": "Code Security & Quality",
-          "when": "snyk:loggedIn && snyk:featuresSelected && snyk:codeEnabled && snyk:codeLocalEngineEnabled && snyk:workspaceFound && !snyk:error"
+          "when": "snyk:loggedIn && !snyk:lsCodePreview && snyk:featuresSelected && snyk:codeEnabled && snyk:codeLocalEngineEnabled && snyk:workspaceFound && !snyk:error"
         },
         {
           "id": "snyk.views.support",

--- a/package.json
+++ b/package.json
@@ -205,12 +205,6 @@
             "description": "Preview features that are currently in development. Setting keys will be removed when features become stable.",
             "propertyNames": true,
             "properties": {
-              "lsCode": {
-                "type": "boolean",
-                "title": "Enable \"Code\" using Snyk Language Server",
-                "description": "Enables Snyk Code results delivery using Snyk Language Server.",
-                "default": false
-              },
               "reportFalsePositives": {
                 "type": "boolean",
                 "title": "Enable \"report false positives\"",

--- a/src/snyk/base/modules/baseSnykModule.ts
+++ b/src/snyk/base/modules/baseSnykModule.ts
@@ -7,6 +7,7 @@ import { CommandController } from '../../common/commands/commandController';
 import { configuration } from '../../common/configuration/instance';
 import { IWorkspaceTrust, WorkspaceTrust } from '../../common/configuration/trustedFolders';
 import { ExperimentService } from '../../common/experiment/services/experimentService';
+import { CodeScanOrchestrator } from '../../common/languageServer/experiments/codeScanOrchestrator';
 import { ILanguageServer } from '../../common/languageServer/languageServer';
 import { Logger } from '../../common/logger/logger';
 import { ContextService, IContextService } from '../../common/services/contextService';
@@ -66,6 +67,7 @@ export default abstract class BaseSnykModule implements IBaseSnykModule {
   snykCodeOld: ISnykCodeServiceOld;
   snykCode: ISnykCodeService;
   protected codeSettings: ICodeSettings;
+  protected codeScanOrchestrator: CodeScanOrchestrator;
 
   readonly loadingBadge: ILoadingBadge;
   protected user: User;

--- a/src/snyk/base/modules/snykLib.ts
+++ b/src/snyk/base/modules/snykLib.ts
@@ -6,6 +6,7 @@ import { configuration } from '../../common/configuration/instance';
 import { DEFAULT_SCAN_DEBOUNCE_INTERVAL, IDE_NAME, OSS_SCAN_DEBOUNCE_INTERVAL } from '../../common/constants/general';
 import { SNYK_CONTEXT } from '../../common/constants/views';
 import { ErrorHandler } from '../../common/error/errorHandler';
+import { ExperimentKey } from '../../common/experiment/services/experimentService';
 import { Logger } from '../../common/logger/logger';
 import { vsCodeWorkspace } from '../../common/vscode/workspace';
 import BaseSnykModule from './baseSnykModule';
@@ -39,6 +40,14 @@ export default class SnykLib extends BaseSnykModule implements ISnykLib {
       await this.setWorkspaceContext(workspacePaths);
 
       await this.user.identify(this.snykApiClient, this.analytics);
+
+      const codeScansViaLs = await this.experimentService.isUserPartOfExperiment(
+        ExperimentKey.CodeScansViaLanguageServer,
+      );
+
+      if (codeScansViaLs) {
+        await this.contextService.setContext(SNYK_CONTEXT.LS_CODE_PREVIEW, true);
+      }
 
       if (workspacePaths.length) {
         this.logFullAnalysisIsTriggered(manual);

--- a/src/snyk/base/modules/snykLib.ts
+++ b/src/snyk/base/modules/snykLib.ts
@@ -41,14 +41,6 @@ export default class SnykLib extends BaseSnykModule implements ISnykLib {
 
       await this.user.identify(this.snykApiClient, this.analytics);
 
-      const codeScansViaLs = await this.experimentService.isUserPartOfExperiment(
-        ExperimentKey.CodeScansViaLanguageServer,
-      );
-
-      if (codeScansViaLs) {
-        await this.contextService.setContext(SNYK_CONTEXT.LS_CODE_PREVIEW, true);
-      }
-
       if (workspacePaths.length) {
         this.logFullAnalysisIsTriggered(manual);
 
@@ -92,6 +84,14 @@ export default class SnykLib extends BaseSnykModule implements ISnykLib {
 
     const codeEnabled = await this.codeSettings.checkCodeEnabled();
     if (!codeEnabled) {
+      return;
+    }
+
+    // if LS is used to scan, don't proceed
+    const codeScansViaLs = await this.experimentService.isUserPartOfExperiment(
+      ExperimentKey.CodeScansViaLanguageServer,
+    );
+    if (codeScansViaLs) {
       return;
     }
 

--- a/src/snyk/base/services/authenticationService.ts
+++ b/src/snyk/base/services/authenticationService.ts
@@ -1,10 +1,11 @@
 import { validate as uuidValidate } from 'uuid';
 import { IAnalytics } from '../../common/analytics/itly';
 import { IConfiguration } from '../../common/configuration/configuration';
-import { DID_CHANGE_CONFIGURATION_METHOD } from '../../common/constants/languageServer';
+import { DID_CHANGE_CONFIGURATION_METHOD, SNYK_WORKSPACE_SCAN_COMMAND } from '../../common/constants/languageServer';
 import { SNYK_CONTEXT } from '../../common/constants/views';
 import { ILog } from '../../common/logger/interfaces';
 import { IContextService } from '../../common/services/contextService';
+import { IVSCodeCommands } from '../../common/vscode/commands';
 import { ILanguageClientAdapter } from '../../common/vscode/languageClient';
 import { IVSCodeWindow } from '../../common/vscode/window';
 import { IBaseSnykModule } from '../modules/interfaces';
@@ -25,6 +26,7 @@ export class AuthenticationService implements IAuthenticationService {
     private readonly analytics: IAnalytics,
     private readonly logger: ILog,
     private readonly clientAdapter: ILanguageClientAdapter,
+    private commands: IVSCodeCommands,
   ) {}
 
   async initiateLogin(): Promise<void> {
@@ -66,6 +68,7 @@ export class AuthenticationService implements IAuthenticationService {
       await this.contextService.setContext(SNYK_CONTEXT.LOGGEDIN, true);
 
       this.baseModule.loadingBadge.setLoadingBadge(false);
+      await this.commands.executeCommand(SNYK_WORKSPACE_SCAN_COMMAND);
     }
   }
 }

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -45,7 +45,6 @@ export interface SeverityFilter {
 }
 
 export type PreviewFeatures = {
-  lsCode: boolean | undefined;
   reportFalsePositives: boolean | undefined;
   advisor: boolean | undefined;
 };
@@ -416,7 +415,6 @@ export class Configuration implements IConfiguration {
 
   getPreviewFeatures(): PreviewFeatures {
     const defaultSetting: PreviewFeatures = {
-      lsCode: false,
       reportFalsePositives: false,
       advisor: false,
     };

--- a/src/snyk/common/configuration/snykConfiguration.ts
+++ b/src/snyk/common/configuration/snykConfiguration.ts
@@ -8,6 +8,12 @@ export class SnykConfiguration {
   readonly amplitudeExperimentApiKey: string;
   readonly sentryKey: string;
 
+  constructor(segmentWriteKey: string, amplitudeExperimentApiKey: string, sentryKey: string) {
+    this.segmentWriteKey = segmentWriteKey;
+    this.amplitudeExperimentApiKey = amplitudeExperimentApiKey;
+    this.sentryKey = sentryKey;
+  }
+
   static get(extensionPath: string, isDevelopment: boolean): Promise<SnykConfiguration> {
     const configFilename = isDevelopment ? this.localConfigFileName : this.configFileName;
     return import(path.join(extensionPath, configFilename)) as Promise<SnykConfiguration>;

--- a/src/snyk/common/constants/views.ts
+++ b/src/snyk/common/constants/views.ts
@@ -20,6 +20,7 @@ export const SNYK_CONTEXT = {
   FEATURES_SELECTED: 'featuresSelected',
   CODE_ENABLED: 'codeEnabled',
   CODE_LOCAL_ENGINE_ENABLED: 'codeLocalEngineEnabled',
+  LS_CODE_PREVIEW: 'lsCodePreview',
   WORKSPACE_FOUND: 'workspaceFound',
   ERROR: 'error',
   MODE: 'mode',

--- a/src/snyk/common/constants/views.ts
+++ b/src/snyk/common/constants/views.ts
@@ -20,7 +20,6 @@ export const SNYK_CONTEXT = {
   FEATURES_SELECTED: 'featuresSelected',
   CODE_ENABLED: 'codeEnabled',
   CODE_LOCAL_ENGINE_ENABLED: 'codeLocalEngineEnabled',
-  LS_CODE_PREVIEW: 'lsCodePreview',
   WORKSPACE_FOUND: 'workspaceFound',
   ERROR: 'error',
   MODE: 'mode',

--- a/src/snyk/common/experiment/services/experimentService.ts
+++ b/src/snyk/common/experiment/services/experimentService.ts
@@ -36,12 +36,12 @@ export class ExperimentService {
     return true;
   }
 
-  async isUserPartOfExperiment(variantFlag: ExperimentKey): Promise<boolean> {
+  async isUserPartOfExperiment(variantFlag: ExperimentKey, forceFetchVariants = false): Promise<boolean> {
     if (!this.canExperiment) {
       return false;
     }
 
-    const variants = await this.fetchVariants();
+    const variants = await this.fetchVariants(forceFetchVariants);
     const variant = variants[variantFlag];
     if (variant?.value === 'on') {
       return true;
@@ -50,8 +50,8 @@ export class ExperimentService {
     return false;
   }
 
-  private async fetchVariants(): Promise<Variants> {
-    if (!this.variants) {
+  private async fetchVariants(forceFetchVariants: boolean): Promise<Variants> {
+    if (!this.variants || forceFetchVariants) {
       try {
         this.variants = await this.client.fetch({
           /* eslint-disable camelcase */

--- a/src/snyk/common/experiment/services/experimentService.ts
+++ b/src/snyk/common/experiment/services/experimentService.ts
@@ -7,6 +7,7 @@ import { User } from '../../user';
 export enum ExperimentKey {
   // to be populated with running experiment keys
   TestExperiment = 'vscode-test-experiment',
+  CodeScansViaLanguageServer = 'snyk-code-via-ls-in-vs-code-integration',
 }
 
 export class ExperimentService {
@@ -42,7 +43,7 @@ export class ExperimentService {
 
     const variants = await this.fetchVariants();
     const variant = variants[variantFlag];
-    if (variant?.value === 'test') {
+    if (variant?.value === 'on') {
       return true;
     }
 

--- a/src/snyk/common/experiment/services/experimentService.ts
+++ b/src/snyk/common/experiment/services/experimentService.ts
@@ -1,4 +1,4 @@
-import { Experiment, ExperimentClient, Variants } from '@amplitude/experiment-node-server';
+import { Experiment, RemoteEvaluationClient, Variants } from '@amplitude/experiment-node-server';
 import { IConfiguration } from '../../configuration/configuration';
 import { SnykConfiguration } from '../../configuration/snykConfiguration';
 import { ILog } from '../../logger/interfaces';
@@ -11,7 +11,7 @@ export enum ExperimentKey {
 }
 
 export class ExperimentService {
-  private client: ExperimentClient;
+  private client: RemoteEvaluationClient;
   private variants?: Variants;
 
   constructor(

--- a/src/snyk/common/languageServer/experiments/codeScanOrchestrator.ts
+++ b/src/snyk/common/languageServer/experiments/codeScanOrchestrator.ts
@@ -1,0 +1,64 @@
+import { Subscription } from 'rxjs';
+import { IExtension } from '../../../base/modules/interfaces';
+import { SNYK_CONTEXT } from '../../constants/views';
+import { ExperimentKey, ExperimentService } from '../../experiment/services/experimentService';
+import { ILog } from '../../logger/interfaces';
+import { IContextService } from '../../services/contextService';
+import { ILanguageServer } from '../languageServer';
+import { CodeIssueData, Scan, ScanProduct, ScanStatus } from '../types';
+
+export class CodeScanOrchestrator {
+  private lastExperimentCheck: number;
+  private lsSubscription: Subscription;
+  private waitTimeInMs: number;
+
+  constructor(
+    private readonly experimentService: ExperimentService,
+    readonly languageServer: ILanguageServer,
+    private readonly logger: ILog,
+    private readonly contextService: IContextService,
+    private extension: IExtension,
+  ) {
+    this.lastExperimentCheck = new Date().getTime();
+    this.setWaitTimeInMs(1000 * 60 * 15); // 15 minutes
+    this.lsSubscription = languageServer.scan$.subscribe(
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      async (scan: Scan<CodeIssueData>) => await this.handleExperimentCheck(scan),
+    );
+  }
+
+  dispose(): void {
+    this.lsSubscription.unsubscribe();
+  }
+
+  async handleExperimentCheck(scan: Scan<CodeIssueData>): Promise<void> {
+    if (!this.isCheckRequired() || scan.status !== ScanStatus.InProgress || scan.product !== ScanProduct.Code) {
+      this.logger.debug('Code scan update not required.');
+      return;
+    }
+
+    // check if the user is part of the experiment
+    const isPartOfLSCodeExperiment = await this.experimentService.isUserPartOfExperiment(
+      ExperimentKey.CodeScansViaLanguageServer,
+      true,
+    );
+
+    if (!isPartOfLSCodeExperiment) {
+      await this.contextService.setContext(SNYK_CONTEXT.LS_CODE_PREVIEW, false);
+      await this.extension.runCodeScan();
+      await this.extension.restartLanguageServer();
+    }
+
+    // update lastExperimentCheckTime
+    this.lastExperimentCheck = new Date().getTime();
+  }
+
+  setWaitTimeInMs(ms: number) {
+    this.waitTimeInMs = ms;
+  }
+
+  isCheckRequired(): boolean {
+    const currentTimestamp = new Date().getTime();
+    return currentTimestamp - this.lastExperimentCheck > this.waitTimeInMs;
+  }
+}

--- a/src/snyk/common/languageServer/languageServer.ts
+++ b/src/snyk/common/languageServer/languageServer.ts
@@ -12,6 +12,7 @@ import {
 } from '../constants/languageServer';
 import { CONFIGURATION_IDENTIFIER } from '../constants/settings';
 import { ErrorHandler } from '../error/errorHandler';
+import { ExperimentService } from '../experiment/services/experimentService';
 import { ILog } from '../logger/interfaces';
 import { getProxyEnvVariable, getProxyOptions } from '../proxy';
 import { DownloadService } from '../services/downloadService';
@@ -48,6 +49,7 @@ export class LanguageServer implements ILanguageServer {
     private authenticationService: IAuthenticationService,
     private readonly logger: ILog,
     private downloadService: DownloadService,
+    private experimentService: ExperimentService,
   ) {
     this.downloadService = downloadService;
   }
@@ -95,7 +97,7 @@ export class LanguageServer implements ILanguageServer {
       synchronize: {
         configurationSection: CONFIGURATION_IDENTIFIER,
       },
-      middleware: new LanguageClientMiddleware(this.configuration),
+      middleware: new LanguageClientMiddleware(this.configuration, this.experimentService),
       /**
        * We reuse the output channel here as it's not properly disposed of by the language client (vscode-languageclient@8.0.0-next.2)
        * See: https://github.com/microsoft/vscode-languageserver-node/blob/cdf4d6fdaefe329ce417621cf0f8b14e0b9bb39d/client/src/common/client.ts#L2789
@@ -163,7 +165,8 @@ export class LanguageServer implements ILanguageServer {
   // Initialization options are not semantically equal to server settings, thus separated here
   // https://github.com/microsoft/language-server-protocol/issues/567
   async getInitializationOptions(): Promise<InitializationOptions> {
-    const settings = await LanguageServerSettings.fromConfiguration(this.configuration);
+    const settings = await LanguageServerSettings.fromConfiguration(this.configuration, this.experimentService);
+
     return {
       ...settings,
       integrationName: CLI_INTEGRATION_NAME,

--- a/src/snyk/common/languageServer/middleware.ts
+++ b/src/snyk/common/languageServer/middleware.ts
@@ -1,4 +1,5 @@
 import { IConfiguration } from '../configuration/configuration';
+import { ExperimentService } from '../experiment/services/experimentService';
 import {
   CancellationToken,
   ConfigurationParams,
@@ -18,7 +19,7 @@ export type LanguageClientWorkspaceMiddleware = Partial<WorkspaceMiddleware> & {
 };
 
 export class LanguageClientMiddleware implements Middleware {
-  constructor(private configuration: IConfiguration) {}
+  constructor(private configuration: IConfiguration, private experimentService: ExperimentService) {}
 
   workspace: LanguageClientWorkspaceMiddleware = {
     configuration: async (
@@ -39,7 +40,7 @@ export class LanguageClientMiddleware implements Middleware {
         return [];
       }
 
-      const serverSettings = await LanguageServerSettings.fromConfiguration(this.configuration);
+      const serverSettings = await LanguageServerSettings.fromConfiguration(this.configuration, this.experimentService);
       return [serverSettings];
     },
   };

--- a/src/snyk/common/languageServer/settings.ts
+++ b/src/snyk/common/languageServer/settings.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { IConfiguration, SeverityFilter } from '../configuration/configuration';
+import { ExperimentKey, ExperimentService } from '../experiment/services/experimentService';
 
 export type InitializationOptions = ServerSettings & {
   integrationName?: string;
@@ -30,16 +31,29 @@ export type ServerSettings = {
 };
 
 export class LanguageServerSettings {
-  static async fromConfiguration(configuration: IConfiguration): Promise<ServerSettings> {
+  static async fromConfiguration(
+    configuration: IConfiguration,
+    experimentService: ExperimentService,
+  ): Promise<ServerSettings> {
     const featuresConfiguration = configuration.getFeaturesConfiguration();
 
     const iacEnabled = _.isUndefined(featuresConfiguration.iacEnabled) ? true : featuresConfiguration.iacEnabled;
-    const codeSecurityEnabled = configuration.getPreviewFeatures().lsCode && featuresConfiguration?.codeSecurityEnabled;
-    const codeQualityEnabled = configuration.getPreviewFeatures().lsCode && featuresConfiguration?.codeQualityEnabled;
+    let codeSecurityEnabled = _.isUndefined(featuresConfiguration.codeSecurityEnabled)
+      ? true
+      : featuresConfiguration.codeSecurityEnabled;
+    let codeQualityEnabled = _.isUndefined(featuresConfiguration.codeQualityEnabled)
+      ? true
+      : featuresConfiguration.codeQualityEnabled;
+
+    const codeScansViaLs = await experimentService.isUserPartOfExperiment(ExperimentKey.CodeScansViaLanguageServer);
+    if (!codeScansViaLs) {
+      codeSecurityEnabled = false;
+      codeQualityEnabled = false;
+    }
 
     return {
-      activateSnykCodeSecurity: `${codeSecurityEnabled ?? false}`,
-      activateSnykCodeQuality: `${codeQualityEnabled ?? false}`,
+      activateSnykCodeSecurity: `${codeSecurityEnabled}`,
+      activateSnykCodeQuality: `${codeQualityEnabled}`,
       activateSnykOpenSource: 'false',
       activateSnykIac: `${iacEnabled}`,
       enableTelemetry: `${configuration.shouldReportEvents}`,

--- a/src/snyk/common/views/analysisTreeNodeProviderOld.ts
+++ b/src/snyk/common/views/analysisTreeNodeProviderOld.ts
@@ -2,12 +2,12 @@ import _ from 'lodash';
 import * as path from 'path';
 import { AnalysisStatusProvider } from '../analysis/statusProvider';
 import { IConfiguration } from '../configuration/configuration';
-import { SNYK_SHOW_LS_OUTPUT_COMMAND } from '../constants/commands';
+import { SNYK_SHOW_OUTPUT_COMMAND } from '../constants/commands';
 import { messages } from '../messages/analysisMessages';
 import { NODE_ICONS, TreeNode } from './treeNode';
 import { TreeNodeProvider } from './treeNodeProvider';
 
-export abstract class AnalysisTreeNodeProvider extends TreeNodeProvider {
+export abstract class AnalysisTreeNodeProviderOld extends TreeNodeProvider {
   constructor(protected readonly configuration: IConfiguration, private statusProvider: AnalysisStatusProvider) {
     super();
   }
@@ -66,7 +66,7 @@ export abstract class AnalysisTreeNodeProvider extends TreeNodeProvider {
         isError: true,
       },
       command: {
-        command: SNYK_SHOW_LS_OUTPUT_COMMAND,
+        command: SNYK_SHOW_OUTPUT_COMMAND,
         title: '',
       },
     });
@@ -76,7 +76,7 @@ export abstract class AnalysisTreeNodeProvider extends TreeNodeProvider {
     return new TreeNode({
       text: messages.noWorkspaceTrust,
       command: {
-        command: SNYK_SHOW_LS_OUTPUT_COMMAND,
+        command: SNYK_SHOW_OUTPUT_COMMAND,
         title: '',
       },
     });

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -45,6 +45,7 @@ import {
 import { ErrorHandler } from './common/error/errorHandler';
 import { ErrorReporter } from './common/error/errorReporter';
 import { ExperimentKey, ExperimentService } from './common/experiment/services/experimentService';
+import { CodeScanOrchestrator } from './common/languageServer/experiments/codeScanOrchestrator';
 import { LanguageServer } from './common/languageServer/languageServer';
 import { StaticLsApi } from './common/languageServer/staticLsApi';
 import { Logger } from './common/logger/logger';
@@ -403,6 +404,14 @@ class SnykExtension extends SnykLib implements IExtension {
 
     await this.languageServer.start();
 
+    this.codeScanOrchestrator = new CodeScanOrchestrator(
+      this.experimentService,
+      this.languageServer,
+      Logger,
+      this.contextService,
+      this,
+    );
+
     // noinspection ES6MissingAwait
     void this.advisorScoreDisposable.activate();
 
@@ -414,6 +423,7 @@ class SnykExtension extends SnykLib implements IExtension {
     this.snykCodeOld.dispose();
     this.ossVulnerabilityCountService.dispose();
     await this.languageServer.stop();
+    this.codeScanOrchestrator.dispose();
     await this.analytics.flush();
     await ErrorReporter.flush();
   }

--- a/src/snyk/snykCode/codeActions/codeIssuesActionsProvider.ts
+++ b/src/snyk/snykCode/codeActions/codeIssuesActionsProvider.ts
@@ -35,7 +35,7 @@ export class SnykCodeActionsProvider implements CodeActionProvider {
     for (const result of this.issues.entries()) {
       const folderPath = result[0];
       const issues = result[1];
-      if (issues instanceof Error) {
+      if (issues instanceof Error || !issues) {
         continue;
       }
 

--- a/src/snyk/snykCode/utils/issueUtils.ts
+++ b/src/snyk/snykCode/utils/issueUtils.ts
@@ -65,14 +65,12 @@ export class IssueUtils {
     };
   };
 
+  // Creates zero-based range
   static createVsCodeRange = (issueData: CodeIssueData, languages: IVSCodeLanguages): Range => {
     return IssueUtils.createVsCodeRangeFromRange(issueData.rows, issueData.cols, languages);
   };
 
   static createVsCodeRangeFromRange(rows: number[], cols: number[], languages: IVSCodeLanguages): Range {
-    const rowOffset = 1;
-    const createPosition = (i: number): number => (i - rowOffset < 0 ? 0 : i - rowOffset);
-
-    return languages.createRange(createPosition(rows[0]), createPosition(cols[0]), createPosition(rows[1]), cols[1]);
+    return languages.createRange(rows[0], cols[0], rows[1], cols[1]);
   }
 }

--- a/src/snyk/snykCode/views/issueTreeProvider.ts
+++ b/src/snyk/snykCode/views/issueTreeProvider.ts
@@ -6,7 +6,7 @@ import { SNYK_OPEN_ISSUE_COMMAND } from '../../common/constants/commands';
 import { IssueSeverity } from '../../common/languageServer/types';
 import { messages as commonMessages } from '../../common/messages/analysisMessages';
 import { IContextService } from '../../common/services/contextService';
-import { AnalysisTreeNodeProvder } from '../../common/views/analysisTreeNodeProvider';
+import { AnalysisTreeNodeProvider } from '../../common/views/analysisTreeNodeProvider';
 import { INodeIcon, InternalType, NODE_ICONS, TreeNode } from '../../common/views/treeNode';
 import { IVSCodeLanguages } from '../../common/vscode/languages';
 import { Command } from '../../common/vscode/types';
@@ -19,7 +19,7 @@ interface ISeverityCounts {
   [severity: string]: number;
 }
 
-export class IssueTreeProvider extends AnalysisTreeNodeProvder {
+export class IssueTreeProvider extends AnalysisTreeNodeProvider {
   constructor(
     protected readonly contextService: IContextService,
     protected readonly codeService: ISnykCodeService,

--- a/src/snyk/snykCode/views/issueTreeProvider.ts
+++ b/src/snyk/snykCode/views/issueTreeProvider.ts
@@ -70,6 +70,12 @@ export class IssueTreeProvider extends AnalysisTreeNodeProvder {
     const [resultNodes, nIssues] = this.getResultNodes();
     nodes.push(...resultNodes);
 
+    const folderResults = Array.from(this.codeService.result.values());
+    const allFailed = folderResults.every(folderResult => folderResult instanceof Error);
+    if (allFailed) {
+      return nodes;
+    }
+
     nodes.sort(this.compareNodes);
 
     const topNodes = [

--- a/src/snyk/snykCode/views/issueTreeProviderOld.ts
+++ b/src/snyk/snykCode/views/issueTreeProviderOld.ts
@@ -3,7 +3,7 @@ import { OpenCommandIssueType, OpenIssueCommandArg } from '../../common/commands
 import { IConfiguration } from '../../common/configuration/configuration';
 import { SNYK_OPEN_ISSUE_COMMAND } from '../../common/constants/commands';
 import { IContextService } from '../../common/services/contextService';
-import { AnalysisTreeNodeProvder } from '../../common/views/analysisTreeNodeProvider';
+import { AnalysisTreeNodeProviderOld } from '../../common/views/analysisTreeNodeProviderOld';
 import { INodeIcon, NODE_ICONS, TreeNode } from '../../common/views/treeNode';
 import { ISnykCodeServiceOld } from '../codeServiceOld';
 import { SNYK_SEVERITIES } from '../constants/analysis';
@@ -15,7 +15,7 @@ interface ISeverityCounts {
   [severity: number]: number;
 }
 
-export class IssueTreeProviderOld extends AnalysisTreeNodeProvder {
+export class IssueTreeProviderOld extends AnalysisTreeNodeProviderOld {
   constructor(
     protected contextService: IContextService,
     protected snykCode: ISnykCodeServiceOld,

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import * as vscode from 'vscode';
 import { OpenCommandIssueType } from '../../../common/commands/types';
 import {
@@ -24,16 +25,10 @@ import { getAbsoluteMarkerFilePath } from '../../utils/analysisUtils';
 import { IssueUtils } from '../../utils/issueUtils';
 import { ICodeSuggestionWebviewProvider } from '../interfaces';
 
-export declare enum AnalysisSeverity {
-  info = 1,
-  warning = 2,
-  critical = 3,
-}
-
 type Suggestion = {
   id: string;
   message: string;
-  severity: AnalysisSeverity;
+  severity: string;
   leadURL?: string;
   rule: string;
   repoDatasetSize: number;
@@ -147,25 +142,11 @@ export class CodeSuggestionWebviewProvider
   }
 
   private mapToModel(issue: Issue<CodeIssueData>): Suggestion {
-    // TODO: avoid mapping severity to ints. Remove when releasing Code scans using LS & update codeSuggestionWebviewScript.ts respectively.
-    let severity;
-    switch (issue.severity) {
-      case 'low':
-        severity = 1;
-        break;
-      case 'medium':
-        severity = 2;
-        break;
-      default:
-        severity = 3;
-        break;
-    }
-
     return {
       id: issue.id,
       title: issue.title,
-      severity,
       uri: issue.filePath,
+      severity: _.capitalize(issue.severity),
       ...issue.additionalData,
     };
   }

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProviderOld.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProviderOld.ts
@@ -22,7 +22,7 @@ import { ICodeSettings } from '../../codeSettings';
 import { WEBVIEW_PANEL_QUALITY_TITLE, WEBVIEW_PANEL_SECURITY_TITLE } from '../../constants/analysis';
 import { completeFileSuggestionType, ISnykCodeAnalyzer } from '../../interfaces';
 import { messages as errorMessages } from '../../messages/error';
-import { createIssueCorrectRange, getAbsoluteMarkerFilePath, getVSCodeSeverity } from '../../utils/analysisUtils';
+import { createIssueCorrectRange, getAbsoluteMarkerFilePath } from '../../utils/analysisUtils';
 import { ICodeSuggestionWebviewProviderOld } from '../interfaces';
 
 export class CodeSuggestionWebviewProviderOld
@@ -216,7 +216,7 @@ export class CodeSuggestionWebviewProviderOld
       'snykCode',
       'views',
       'suggestion',
-      'codeSuggestionWebviewScript.js',
+      'codeSuggestionWebviewScriptOld.js',
     );
     const styleUri = this.getWebViewUri('media', 'views', 'snykCode', 'suggestion', 'suggestion.css');
     const styleVSCodeUri = this.getWebViewUri('media', 'views', 'common', 'vscode.css');

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScriptOld.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScriptOld.ts
@@ -115,14 +115,14 @@
   }
   function getCurrentSeverity() {
     const stringMap = {
-      Low: 1,
-      Medium: 2,
-      High: 3,
+      1: 'Low',
+      2: 'Medium',
+      3: 'High',
     };
     return suggestion
       ? {
-          value: stringMap[suggestion.severity],
-          text: suggestion.severity,
+          value: suggestion.severity,
+          text: stringMap[suggestion.severity],
         }
       : undefined;
   }
@@ -190,8 +190,7 @@
         let markLineText = ' [';
         let first = true;
         for (const p of m.pos) {
-          const rowStart = Number(p.rows[0]) + 1; // editors are 1-based
-          markLineText += (first ? '' : ', ') + ':' + rowStart.toString();
+          markLineText += (first ? '' : ', ') + ':' + (p.rows[0] as string);
           first = false;
         }
         markLineText += ']';
@@ -212,9 +211,9 @@
     moreInfo.className = suggestion.leadURL ? 'clickable' : 'clickable hidden';
 
     const suggestionPosition = document.getElementById('line-position')!;
-    suggestionPosition.innerHTML = (Number(suggestion.rows[0]) + 1).toString(); // editors are 1-based
+    suggestionPosition.innerHTML = suggestion.rows[0];
     const suggestionPosition2 = document.getElementById('line-position2')!;
-    suggestionPosition2.innerHTML = (Number(suggestion.rows[0]) + 1).toString();
+    suggestionPosition2.innerHTML = suggestion.rows[0];
 
     const dataset = document.getElementById('dataset-number')!;
     const infoTop = document.getElementById('info-top')!;

--- a/src/snyk/snykOss/views/ossVulnerabilityTreeProvider.ts
+++ b/src/snyk/snykOss/views/ossVulnerabilityTreeProvider.ts
@@ -5,7 +5,7 @@ import { SNYK_ANALYSIS_STATUS } from '../../common/constants/views';
 import { messages as commonMessages } from '../../common/messages/analysisMessages';
 import { IContextService } from '../../common/services/contextService';
 import { IViewManagerService } from '../../common/services/viewManagerService';
-import { AnalysisTreeNodeProvder } from '../../common/views/analysisTreeNodeProvider';
+import { AnalysisTreeNodeProviderOld } from '../../common/views/analysisTreeNodeProviderOld';
 import { INodeIcon, NODE_ICONS, TreeNode } from '../../common/views/treeNode';
 import { messages } from '../messages/treeView';
 import { isResultCliError, OssFileResult, OssSeverity, OssVulnerability } from '../ossResult';
@@ -20,7 +20,7 @@ export type OssIssueCommandArg = OssVulnerability & {
   overviewHtml: string;
 };
 
-export class OssVulnerabilityTreeProvider extends AnalysisTreeNodeProvder {
+export class OssVulnerabilityTreeProvider extends AnalysisTreeNodeProviderOld {
   constructor(
     protected readonly viewManagerService: IViewManagerService,
     protected readonly contextService: IContextService,

--- a/src/test/unit/base/services/authenticationService.test.ts
+++ b/src/test/unit/base/services/authenticationService.test.ts
@@ -10,6 +10,7 @@ import { IConfiguration } from '../../../../snyk/common/configuration/configurat
 import { DID_CHANGE_CONFIGURATION_METHOD } from '../../../../snyk/common/constants/languageServer';
 import { SNYK_CONTEXT } from '../../../../snyk/common/constants/views';
 import { IContextService } from '../../../../snyk/common/services/contextService';
+import { IVSCodeCommands } from '../../../../snyk/common/vscode/commands';
 import { ILanguageClientAdapter } from '../../../../snyk/common/vscode/languageClient';
 import { LanguageClient } from '../../../../snyk/common/vscode/types';
 import { LoggerMock } from '../../mocks/logger.mock';
@@ -80,6 +81,7 @@ suite('AuthenticationService', () => {
       analytics,
       new LoggerMock(),
       languageClientAdapter,
+      {} as IVSCodeCommands,
     );
 
     await service.initiateLogin();
@@ -142,6 +144,7 @@ suite('AuthenticationService', () => {
       {} as IAnalytics,
       new LoggerMock(),
       languageClientAdapter,
+      {} as IVSCodeCommands,
     );
     sinon.replace(windowMock, 'showInputBox', sinon.fake.returns(''));
 
@@ -160,6 +163,7 @@ suite('AuthenticationService', () => {
       {} as IAnalytics,
       new LoggerMock(),
       languageClientAdapter,
+      {} as IVSCodeCommands,
     );
     const tokenValue = 'token-value';
     sinon.replace(windowMock, 'showInputBox', sinon.fake.returns(tokenValue));
@@ -189,6 +193,9 @@ suite('AuthenticationService', () => {
         {} as IAnalytics,
         new LoggerMock(),
         languageClientAdapter,
+        {
+          executeCommand: sinon.fake(),
+        } as IVSCodeCommands,
       );
     });
 

--- a/src/test/unit/common/configuration.test.ts
+++ b/src/test/unit/common/configuration.test.ts
@@ -184,7 +184,6 @@ suite('Configuration', () => {
     const configuration = new Configuration({}, workspace);
 
     deepStrictEqual(configuration.getPreviewFeatures(), {
-      lsCode: false,
       reportFalsePositives: false,
       advisor: false,
     } as PreviewFeatures);
@@ -193,7 +192,6 @@ suite('Configuration', () => {
   test('Preview features: some features enabled', () => {
     const previewFeatures = {
       reportFalsePositives: true,
-      lsCode: false,
       advisor: false,
     } as PreviewFeatures;
     const workspace = stubWorkspaceConfiguration(FEATURES_PREVIEW_SETTING, previewFeatures);

--- a/src/test/unit/common/experiment/services/experimentService.test.ts
+++ b/src/test/unit/common/experiment/services/experimentService.test.ts
@@ -1,3 +1,4 @@
+import { Experiment, RemoteEvaluationClient } from '@amplitude/experiment-node-server';
 import { strictEqual } from 'assert';
 import sinon from 'sinon';
 import { IConfiguration } from '../../../../../snyk/common/configuration/configuration';
@@ -8,6 +9,7 @@ import { LoggerMock } from '../../../mocks/logger.mock';
 
 suite('ExperimentService', () => {
   let user: User;
+  let fetchStub: sinon.SinonStub;
 
   setup(() => {
     user = new User(undefined, undefined);
@@ -16,6 +18,11 @@ suite('ExperimentService', () => {
       amplitudeExperimentApiKey: 'test',
       segmentWriteKey: 'test',
     } as SnykConfiguration);
+
+    fetchStub = sinon.stub();
+    sinon.stub(Experiment, 'initialize').returns({
+      fetch: fetchStub,
+    } as unknown as RemoteEvaluationClient);
   });
 
   teardown(() => {
@@ -43,5 +50,39 @@ suite('ExperimentService', () => {
     const isUserPartOfExperiment = await service.isUserPartOfExperiment(ExperimentKey.TestExperiment);
 
     strictEqual(isUserPartOfExperiment, false);
+  });
+
+  test('Should force a fetch of variants even if cache is available', async () => {
+    const config = {
+      shouldReportEvents: true,
+    } as unknown as IConfiguration;
+
+    const snykConfig = new SnykConfiguration('test', 'test', 'test');
+    const service = new ExperimentService(user, new LoggerMock(), config, snykConfig);
+    service.load();
+
+    fetchStub.returns({});
+
+    await service.isUserPartOfExperiment(ExperimentKey.TestExperiment);
+    await service.isUserPartOfExperiment(ExperimentKey.TestExperiment, true);
+
+    strictEqual(fetchStub.callCount, 2);
+  });
+
+  test('Should use cached variants by default', async () => {
+    const config = {
+      shouldReportEvents: true,
+    } as unknown as IConfiguration;
+
+    const snykConfig = new SnykConfiguration('test', 'test', 'test');
+    const service = new ExperimentService(user, new LoggerMock(), config, snykConfig);
+    service.load();
+
+    fetchStub.returns({});
+
+    await service.isUserPartOfExperiment(ExperimentKey.TestExperiment);
+    await service.isUserPartOfExperiment(ExperimentKey.TestExperiment);
+
+    strictEqual(fetchStub.callCount, 1);
   });
 });

--- a/src/test/unit/common/languageServer/experiments/codeScanOrchestrator.test.ts
+++ b/src/test/unit/common/languageServer/experiments/codeScanOrchestrator.test.ts
@@ -60,7 +60,7 @@ suite('Code Scan Orchestrator', () => {
   test('Orchestrates only when check is required', async () => {
     // check is required if 10ms passed since last check
     codeScanOrchestrator.setWaitTimeInMs(10);
-    await sleepInMs(5);
+    await sleepInMs(50);
 
     ls.scan$.next({
       product: ScanProduct.Code,
@@ -114,7 +114,7 @@ suite('Code Scan Orchestrator', () => {
 
   test('Correctly updates code scan settings when user is NOT part of experiment', async () => {
     codeScanOrchestrator.setWaitTimeInMs(10);
-    await sleepInMs(15);
+    await sleepInMs(20);
 
     ls.scan$.next({
       product: ScanProduct.Code,
@@ -124,7 +124,7 @@ suite('Code Scan Orchestrator', () => {
     });
 
     // wait for the orchestrator to finish, possible race condition still exists
-    await sleepInMs(15);
+    await sleepInMs(20);
     sinon.assert.calledWith(setContextSpy, SNYK_CONTEXT.LS_CODE_PREVIEW, false);
   });
 });

--- a/src/test/unit/common/languageServer/experiments/codeScanOrchestrator.test.ts
+++ b/src/test/unit/common/languageServer/experiments/codeScanOrchestrator.test.ts
@@ -1,0 +1,130 @@
+import { strictEqual } from 'assert';
+import sinon from 'sinon';
+import { IExtension } from '../../../../../snyk/base/modules/interfaces';
+import { IConfiguration } from '../../../../../snyk/common/configuration/configuration';
+import { SnykConfiguration } from '../../../../../snyk/common/configuration/snykConfiguration';
+import { SNYK_CONTEXT } from '../../../../../snyk/common/constants/views';
+import { ExperimentService } from '../../../../../snyk/common/experiment/services/experimentService';
+import { CodeScanOrchestrator } from '../../../../../snyk/common/languageServer/experiments/codeScanOrchestrator';
+import { ILanguageServer } from '../../../../../snyk/common/languageServer/languageServer';
+import { ScanProduct, ScanStatus } from '../../../../../snyk/common/languageServer/types';
+import { IContextService } from '../../../../../snyk/common/services/contextService';
+import { User } from '../../../../../snyk/common/user';
+import { LanguageServerMock } from '../../../mocks/languageServer.mock';
+import { LoggerMock } from '../../../mocks/logger.mock';
+
+suite('Code Scan Orchestrator', () => {
+  let ls: ILanguageServer;
+  let codeScanOrchestrator: CodeScanOrchestrator;
+  let experimentService: ExperimentService;
+  let user: User;
+  let config: IConfiguration;
+  let snykConfig: SnykConfiguration;
+  let logger: LoggerMock;
+  let contextServiceMock: IContextService;
+  let setContextSpy: sinon.SinonSpy;
+  let isUserPartOfExperimentStub: sinon.SinonStub;
+
+  const sleepInMs = (duration: number) => new Promise(resolve => setTimeout(resolve, duration));
+
+  setup(() => {
+    ls = new LanguageServerMock();
+    user = new User(undefined, undefined);
+    snykConfig = new SnykConfiguration('test', 'test', 'test');
+    logger = new LoggerMock();
+    config = {
+      shouldReportEvents: true,
+    } as unknown as IConfiguration;
+    experimentService = new ExperimentService(user, logger, config, snykConfig);
+    isUserPartOfExperimentStub = sinon.stub(experimentService, 'isUserPartOfExperiment').resolves(false);
+
+    setContextSpy = sinon.fake();
+    contextServiceMock = {
+      setContext: setContextSpy,
+      shouldShowCodeAnalysis: false,
+      shouldShowOssAnalysis: false,
+      viewContext: {},
+    };
+
+    const extension = {
+      runCodeScan: sinon.fake(),
+    } as unknown as IExtension;
+
+    codeScanOrchestrator = new CodeScanOrchestrator(experimentService, ls, logger, contextServiceMock, extension);
+  });
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('Orchestrates only when check is required', async () => {
+    // check is required if 10ms passed since last check
+    codeScanOrchestrator.setWaitTimeInMs(10);
+    await sleepInMs(5);
+
+    ls.scan$.next({
+      product: ScanProduct.Code,
+      folderPath: 'test/path',
+      issues: [],
+      status: ScanStatus.InProgress,
+    });
+
+    strictEqual(isUserPartOfExperimentStub.called, false);
+  });
+
+  for (const status in ScanStatus) {
+    test(`Orchestrates only when scan is in progres - currently: ${status}`, async () => {
+      codeScanOrchestrator.setWaitTimeInMs(10);
+      await sleepInMs(15);
+
+      ls.scan$.next({
+        product: ScanProduct.Code,
+        folderPath: 'test/path',
+        issues: [],
+        status: ScanStatus[status],
+      });
+
+      if (ScanStatus[status] === ScanStatus.InProgress) {
+        strictEqual(isUserPartOfExperimentStub.called, true);
+      } else {
+        strictEqual(isUserPartOfExperimentStub.called, false);
+      }
+    });
+  }
+
+  for (const product in ScanProduct) {
+    test(`Orchestrates only when product is code - currently: ${product}`, async () => {
+      codeScanOrchestrator.setWaitTimeInMs(10);
+      await sleepInMs(15);
+
+      ls.scan$.next({
+        product: ScanProduct[product],
+        folderPath: 'test/path',
+        issues: [],
+        status: ScanStatus.InProgress,
+      });
+
+      if (ScanProduct[product] === ScanProduct.Code) {
+        strictEqual(isUserPartOfExperimentStub.called, true);
+      } else {
+        strictEqual(isUserPartOfExperimentStub.called, false);
+      }
+    });
+  }
+
+  test('Correctly updates code scan settings when user is NOT part of experiment', async () => {
+    codeScanOrchestrator.setWaitTimeInMs(10);
+    await sleepInMs(15);
+
+    ls.scan$.next({
+      product: ScanProduct.Code,
+      folderPath: 'test/path',
+      issues: [],
+      status: ScanStatus.InProgress,
+    });
+
+    // wait for the orchestrator to finish, possible race condition still exists
+    await sleepInMs(15);
+    sinon.assert.calledWith(setContextSpy, SNYK_CONTEXT.LS_CODE_PREVIEW, false);
+  });
+});

--- a/src/test/unit/common/languageServer/experiments/codeScanOrchestrator.test.ts
+++ b/src/test/unit/common/languageServer/experiments/codeScanOrchestrator.test.ts
@@ -59,8 +59,8 @@ suite('Code Scan Orchestrator', () => {
 
   test('Orchestrates only when check is required', async () => {
     // check is required if 10ms passed since last check
-    codeScanOrchestrator.setWaitTimeInMs(10);
-    await sleepInMs(50);
+    codeScanOrchestrator.setWaitTimeInMs(100);
+    await sleepInMs(20);
 
     ls.scan$.next({
       product: ScanProduct.Code,

--- a/src/test/unit/common/languageServer/middleware.test.ts
+++ b/src/test/unit/common/languageServer/middleware.test.ts
@@ -1,9 +1,12 @@
 import assert from 'assert';
 import sinon from 'sinon';
+import { v4 } from 'uuid';
 import { CliExecutable } from '../../../../snyk/cli/cliExecutable';
 import { IConfiguration } from '../../../../snyk/common/configuration/configuration';
+import { ExperimentService } from '../../../../snyk/common/experiment/services/experimentService';
 import { LanguageClientMiddleware } from '../../../../snyk/common/languageServer/middleware';
 import { ServerSettings } from '../../../../snyk/common/languageServer/settings';
+import { User } from '../../../../snyk/common/user';
 import {
   CancellationToken,
   ConfigurationParams,
@@ -12,6 +15,7 @@ import {
 } from '../../../../snyk/common/vscode/types';
 import { defaultFeaturesConfigurationStub } from '../../mocks/configuration.mock';
 import { extensionContextMock } from '../../mocks/extensionContext.mock';
+import { LoggerMock } from '../../mocks/logger.mock';
 
 suite('Language Server: Middleware', () => {
   let configuration: IConfiguration;
@@ -52,7 +56,10 @@ suite('Language Server: Middleware', () => {
   });
 
   test('Configuration request should translate settings', async () => {
-    const middleware = new LanguageClientMiddleware(configuration);
+    const middleware = new LanguageClientMiddleware(
+      configuration,
+      new ExperimentService(new User(v4(), undefined), new LoggerMock(), configuration),
+    );
     const params: ConfigurationParams = {
       items: [
         {
@@ -97,7 +104,10 @@ suite('Language Server: Middleware', () => {
   });
 
   test('Configuration request should return an error', async () => {
-    const middleware = new LanguageClientMiddleware(configuration);
+    const middleware = new LanguageClientMiddleware(
+      configuration,
+      new ExperimentService(new User(v4(), undefined), new LoggerMock(), configuration),
+    );
     const params: ConfigurationParams = {
       items: [
         {

--- a/src/test/unit/mocks/configuration.mock.ts
+++ b/src/test/unit/mocks/configuration.mock.ts
@@ -2,7 +2,7 @@ import { FeaturesConfiguration } from '../../../snyk/common/configuration/config
 
 export const defaultFeaturesConfigurationStub: FeaturesConfiguration = {
   ossEnabled: false,
-  codeQualityEnabled: false,
-  codeSecurityEnabled: false,
+  codeQualityEnabled: true,
+  codeSecurityEnabled: true,
   iacEnabled: true,
 };


### PR DESCRIPTION
### Description

- Uses Amplitude to control Code scans via LS rollout. 
- Ports fix to the tree view that was done in https://github.com/snyk/vscode-extension/pull/330.
- Ports off-by-one error fix that was done in https://github.com/snyk/vscode-extension/pull/330.

Current rollout % is set to 0, until we get a green light from Code team. The PR is safe to merge as-is, as all analysis will be running via old `code-client` until we start the rollout in Amplitude.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
