### PR TITLE
fix: redundant ls restart, if not part of experiment [HEAD-122]

### DIFF
--- a/src/snyk/common/languageServer/experiments/codeScanOrchestrator.ts
+++ b/src/snyk/common/languageServer/experiments/codeScanOrchestrator.ts
@@ -37,6 +37,10 @@ export class CodeScanOrchestrator {
       return;
     }
 
+    if (!this.contextService.isCodeInLsPreview) {
+      return;
+    }
+
     // check if the user is part of the experiment
     const isPartOfLSCodeExperiment = await this.experimentService.isUserPartOfExperiment(
       ExperimentKey.CodeScansViaLanguageServer,

--- a/src/snyk/common/services/contextService.ts
+++ b/src/snyk/common/services/contextService.ts
@@ -6,6 +6,7 @@ export interface IContextService {
   readonly viewContext: { [key: string]: unknown };
   shouldShowCodeAnalysis: boolean;
   shouldShowOssAnalysis: boolean;
+  isCodeInLsPreview: boolean;
 
   setContext(key: string, value: unknown): Promise<void>;
 }
@@ -21,6 +22,10 @@ export class ContextService implements IContextService {
     Logger.debug(`Snyk context ${key}: ${value}`);
     this.viewContext[key] = value;
     await setContext(key, value);
+  }
+
+  get isCodeInLsPreview(): boolean {
+    return !!this.viewContext[SNYK_CONTEXT.LS_CODE_PREVIEW];
   }
 
   get shouldShowCodeAnalysis(): boolean {

--- a/src/test/unit/common/languageServer/experiments/codeScanOrchestrator.test.ts
+++ b/src/test/unit/common/languageServer/experiments/codeScanOrchestrator.test.ts
@@ -43,6 +43,7 @@ suite('Code Scan Orchestrator', () => {
       setContext: setContextSpy,
       shouldShowCodeAnalysis: false,
       shouldShowOssAnalysis: false,
+      isCodeInLsPreview: true,
       viewContext: {},
     };
 

--- a/src/test/unit/snykCode/codeSettings.test.ts
+++ b/src/test/unit/snykCode/codeSettings.test.ts
@@ -19,6 +19,7 @@ suite('Snyk Code Settings', () => {
       setContext: setContextFake,
       shouldShowCodeAnalysis: false,
       shouldShowOssAnalysis: false,
+      isCodeInLsPreview: false,
       viewContext: {},
     };
 


### PR DESCRIPTION
### Description

We currently would assume a user is always part of an experiment, which is false. We shouldn't restart LS and toggle a code scan using old implementation if user isn't.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
