### PR TITLE
feat: add IaC code action to open issue details panel [HEAD-148]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [1.18.0]
 
+### Added
 - Snyk IaC: Added details panel body.
+- Snyk IaC: Added code action to navigate from issue in editor to issue details panel.
 
 ## [1.17.0]
 

--- a/src/snyk/common/editor/codeActionsProvider.ts
+++ b/src/snyk/common/editor/codeActionsProvider.ts
@@ -1,0 +1,79 @@
+import { IAnalytics, SupportedQuickFixProperties } from '../../common/analytics/itly';
+import { IDE_NAME } from '../../common/constants/general';
+import { Issue } from '../../common/languageServer/types';
+import { ICodeActionKindAdapter } from '../../common/vscode/codeAction';
+import { CodeAction, CodeActionKind, CodeActionProvider, Range, TextDocument } from '../../common/vscode/types';
+import { ProductResult } from '../services/productService';
+
+export abstract class CodeActionsProvider<T> implements CodeActionProvider {
+  protected readonly providedCodeActionKinds = [this.codeActionKindAdapter.getQuickFix()];
+
+  constructor(
+    private readonly issues: ProductResult<T>,
+    private readonly codeActionKindAdapter: ICodeActionKindAdapter,
+    private readonly analytics: IAnalytics,
+  ) {}
+
+  abstract getActions(folderPath: string, document: TextDocument, issue: Issue<T>, issueRange: Range): CodeAction[];
+
+  abstract getAnalyticsActionTypes(): [string, ...string[]] &
+    [SupportedQuickFixProperties, ...SupportedQuickFixProperties[]];
+
+  abstract getIssueRange(issue: Issue<T>): Range;
+
+  getProvidedCodeActionKinds(): CodeActionKind[] {
+    return this.providedCodeActionKinds;
+  }
+
+  public provideCodeActions(document: TextDocument, clickedRange: Range): CodeAction[] | undefined {
+    if (this.issues.size === 0) {
+      return undefined;
+    }
+
+    for (const result of this.issues.entries()) {
+      const folderPath = result[0];
+      const issues = result[1];
+      if (issues instanceof Error || !issues) {
+        continue;
+      }
+
+      const { issue, range } = this.findIssueWithRange(issues, document, clickedRange);
+      if (!issue || !range) {
+        continue;
+      }
+
+      const codeActions = this.getActions(folderPath, document, issue, range);
+      const analyticsType = this.getAnalyticsActionTypes();
+
+      this.analytics.logQuickFixIsDisplayed({
+        quickFixType: analyticsType,
+        ide: IDE_NAME,
+      });
+
+      // returns list of actions, all new actions should be added to this list
+      return codeActions;
+    }
+
+    return undefined;
+  }
+
+  private findIssueWithRange(
+    result: Issue<T>[],
+    document: TextDocument,
+    clickedRange: Range,
+  ): { issue: Issue<T> | undefined; range: Range | undefined } {
+    let range = undefined;
+
+    const issue = result.find(issue => {
+      if (issue.filePath !== document.uri.fsPath) {
+        return false;
+      }
+
+      range = this.getIssueRange(issue);
+
+      return range.contains(clickedRange);
+    });
+
+    return { issue, range };
+  }
+}

--- a/src/snyk/common/messages/codeActionMessages.ts
+++ b/src/snyk/common/messages/codeActionMessages.ts
@@ -1,0 +1,3 @@
+export const codeActionMessages = {
+  showSuggestion: 'Show this suggestion (Snyk)',
+};

--- a/src/snyk/common/services/productService.ts
+++ b/src/snyk/common/services/productService.ts
@@ -2,12 +2,14 @@ import { Subscription } from 'rxjs';
 import { AnalysisStatusProvider } from '../analysis/statusProvider';
 import { IConfiguration } from '../configuration/configuration';
 import { IWorkspaceTrust } from '../configuration/trustedFolders';
+import { CodeActionsProvider } from '../editor/codeActionsProvider';
 import { ILanguageServer } from '../languageServer/languageServer';
 import { Issue, Scan, ScanStatus } from '../languageServer/types';
 import { ILog } from '../logger/interfaces';
 import { IViewManagerService } from '../services/viewManagerService';
 import { IProductWebviewProvider } from '../views/webviewProvider';
 import { ExtensionContext } from '../vscode/extensionContext';
+import { IVSCodeLanguages } from '../vscode/languages';
 import { Disposable } from '../vscode/types';
 import { IVSCodeWorkspace } from '../vscode/workspace';
 
@@ -40,32 +42,25 @@ export abstract class ProductService<T> extends AnalysisStatusProvider implement
     readonly extensionContext: ExtensionContext,
     private readonly config: IConfiguration,
     private readonly suggestionProvider: IProductWebviewProvider<Issue<T>>,
-    // readonly codeActionAdapter: ICodeActionAdapter,
-    // readonly codeActionKindAdapter: ICodeActionKindAdapter,
     protected readonly viewManagerService: IViewManagerService,
     readonly workspace: IVSCodeWorkspace,
     private readonly workspaceTrust: IWorkspaceTrust,
     readonly languageServer: ILanguageServer,
-    // readonly window: IVSCodeWindow,
-    // readonly languages: IVSCodeLanguages,
-    private readonly logger: ILog, // readonly analytics: IAnalytics,
+    readonly languages: IVSCodeLanguages,
+    private readonly logger: ILog,
   ) {
     super();
     this._result = new Map<string, WorkspaceFolderResult<T>>();
-    // const provider = new iacCodeActionsProvider(
-    //   this.result,
-    //   codeActionAdapter,
-    //   codeActionKindAdapter,
-    //   languages,
-    //   analytics,
-    // );
-    // this.languages.registerCodeActionsProvider({ scheme: 'file', language: '*' }, provider);
     this.lsSubscription = this.subscribeToLsScanMessages();
   }
 
   abstract subscribeToLsScanMessages(): Subscription;
 
   abstract refreshTreeView(): void;
+
+  registerCodeActionsProvider(provider: CodeActionsProvider<T>) {
+    this.languages.registerCodeActionsProvider({ scheme: 'file', language: '*' }, provider);
+  }
 
   getIssue(folderPath: string, issueId: string): Issue<T> | undefined {
     const folderResult = this._result.get(folderPath);

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -243,16 +243,15 @@ class SnykExtension extends SnykLib implements IExtension {
       this.context,
       configuration,
       iacSuggestionProvider,
-      // new CodeActionAdapter(),
-      // this.codeActionKindAdapter,
+      new CodeActionAdapter(),
+      this.codeActionKindAdapter,
       this.viewManagerService,
       vsCodeWorkspace,
       this.workspaceTrust,
       this.languageServer,
-      // vsCodeWindow,
-      // vsCodeLanguages,
+      vsCodeLanguages,
       Logger,
-      // this.analytics,
+      this.analytics,
     );
 
     this.commandController = new CommandController(

--- a/src/snyk/snykCode/codeResult.ts
+++ b/src/snyk/snykCode/codeResult.ts
@@ -1,4 +1,0 @@
-import { CodeIssueData, Issue } from '../common/languageServer/types';
-
-export type CodeWorkspaceFolderResult = Issue<CodeIssueData>[] | Error;
-export type CodeResult = Map<string, CodeWorkspaceFolderResult>; // map of a workspace folder to results array or an error occurred in this folder

--- a/src/snyk/snykCode/codeService.ts
+++ b/src/snyk/snykCode/codeService.ts
@@ -25,7 +25,7 @@ export class SnykCodeService extends ProductService<CodeIssueData> {
     workspace: IVSCodeWorkspace,
     workspaceTrust: IWorkspaceTrust,
     languageServer: ILanguageServer,
-    private readonly languages: IVSCodeLanguages,
+    languages: IVSCodeLanguages,
     logger: ILog,
     readonly analytics: IAnalytics,
   ) {
@@ -37,16 +37,13 @@ export class SnykCodeService extends ProductService<CodeIssueData> {
       workspace,
       workspaceTrust,
       languageServer,
+      languages,
       logger,
     );
-    const provider = new SnykCodeActionsProvider(
-      this.result,
-      codeActionAdapter,
-      codeActionKindAdapter,
-      languages,
-      analytics,
-    ); // todo: consider moving this to the base class
-    this.languages.registerCodeActionsProvider({ scheme: 'file', language: '*' }, provider);
+
+    this.registerCodeActionsProvider(
+      new SnykCodeActionsProvider(this.result, codeActionAdapter, codeActionKindAdapter, languages, analytics),
+    );
   }
 
   subscribeToLsScanMessages(): Subscription {

--- a/src/snyk/snykIac/codeActions/iacCodeActionsProvider.ts
+++ b/src/snyk/snykIac/codeActions/iacCodeActionsProvider.ts
@@ -1,0 +1,64 @@
+import { CodeAction, Range, TextDocument } from 'vscode';
+import { IAnalytics, SupportedQuickFixProperties } from '../../common/analytics/itly';
+import { OpenCommandIssueType, OpenIssueCommandArg } from '../../common/commands/types';
+import { SNYK_OPEN_ISSUE_COMMAND } from '../../common/constants/commands';
+import { CodeActionsProvider } from '../../common/editor/codeActionsProvider';
+import { IacIssueData, Issue } from '../../common/languageServer/types';
+import { codeActionMessages } from '../../common/messages/codeActionMessages';
+import { ProductResult } from '../../common/services/productService';
+import { ICodeActionAdapter, ICodeActionKindAdapter } from '../../common/vscode/codeAction';
+import { IVSCodeLanguages } from '../../common/vscode/languages';
+import { IacIssue } from '../issue';
+import { IacIssueCommandArg } from '../views/interfaces';
+
+export class IacCodeActionsProvider extends CodeActionsProvider<IacIssueData> {
+  constructor(
+    issues: Readonly<ProductResult<IacIssueData>>,
+    private readonly codeActionAdapter: ICodeActionAdapter,
+    codeActionKindAdapter: ICodeActionKindAdapter,
+    private readonly languages: IVSCodeLanguages,
+    analytics: IAnalytics,
+  ) {
+    super(issues, codeActionKindAdapter, analytics);
+  }
+
+  getActions(folderPath: string, _: TextDocument, issue: Issue<IacIssueData>, range: Range): CodeAction[] {
+    const openIssueAction = this.createOpenIssueAction(folderPath, issue, range);
+
+    // returns list of actions, all new actions should be added to this list
+    return [openIssueAction];
+  }
+
+  getAnalyticsActionTypes(): [string, ...string[]] & [SupportedQuickFixProperties, ...SupportedQuickFixProperties[]] {
+    return ['Show Suggestion'];
+  }
+
+  getIssueRange(issue: Issue<IacIssueData>): Range {
+    return IacIssue.getRange(issue, this.languages);
+  }
+
+  private createOpenIssueAction(folderPath: string, issue: Issue<IacIssueData>, issueRange: Range): CodeAction {
+    const openIssueAction = this.codeActionAdapter.create(
+      codeActionMessages.showSuggestion,
+      this.providedCodeActionKinds[0],
+    );
+
+    openIssueAction.command = {
+      command: SNYK_OPEN_ISSUE_COMMAND,
+      title: SNYK_OPEN_ISSUE_COMMAND,
+      arguments: [
+        {
+          issueType: OpenCommandIssueType.IacIssue,
+          issue: {
+            id: issue.id,
+            folderPath,
+            filePath: issue.filePath,
+            range: issueRange,
+          } as IacIssueCommandArg,
+        } as OpenIssueCommandArg,
+      ],
+    };
+
+    return openIssueAction;
+  }
+}

--- a/src/snyk/snykIac/iacResult.ts
+++ b/src/snyk/snykIac/iacResult.ts
@@ -1,4 +1,0 @@
-import { IacIssueData, Issue } from '../common/languageServer/types';
-
-export type IacWorkspaceFolderResult = Issue<IacIssueData>[] | Error;
-export type IacResult = Map<string, IacWorkspaceFolderResult>; // map of a workspace folder to results array or an error occurred in this folder

--- a/src/snyk/snykIac/iacService.ts
+++ b/src/snyk/snykIac/iacService.ts
@@ -1,8 +1,51 @@
 import { Subscription } from 'rxjs';
+import { IAnalytics } from '../common/analytics/itly';
+import { IConfiguration } from '../common/configuration/configuration';
+import { IWorkspaceTrust } from '../common/configuration/trustedFolders';
+import { ILanguageServer } from '../common/languageServer/languageServer';
 import { IacIssueData, Scan, ScanProduct } from '../common/languageServer/types';
+import { ILog } from '../common/logger/interfaces';
 import { ProductService } from '../common/services/productService';
+import { IViewManagerService } from '../common/services/viewManagerService';
+import { ICodeActionAdapter, ICodeActionKindAdapter } from '../common/vscode/codeAction';
+import { ExtensionContext } from '../common/vscode/extensionContext';
+import { IVSCodeLanguages } from '../common/vscode/languages';
+import { IVSCodeWorkspace } from '../common/vscode/workspace';
+import { IacCodeActionsProvider } from './codeActions/iacCodeActionsProvider';
+import { IIacSuggestionWebviewProvider } from './views/interfaces';
 
 export class IacService extends ProductService<IacIssueData> {
+  constructor(
+    extensionContext: ExtensionContext,
+    config: IConfiguration,
+    suggestionProvider: IIacSuggestionWebviewProvider,
+    readonly codeActionAdapter: ICodeActionAdapter,
+    readonly codeActionKindAdapter: ICodeActionKindAdapter,
+    viewManagerService: IViewManagerService,
+    workspace: IVSCodeWorkspace,
+    workspaceTrust: IWorkspaceTrust,
+    languageServer: ILanguageServer,
+    languages: IVSCodeLanguages,
+    logger: ILog,
+    readonly analytics: IAnalytics,
+  ) {
+    super(
+      extensionContext,
+      config,
+      suggestionProvider,
+      viewManagerService,
+      workspace,
+      workspaceTrust,
+      languageServer,
+      languages,
+      logger,
+    );
+
+    this.registerCodeActionsProvider(
+      new IacCodeActionsProvider(this.result, codeActionAdapter, codeActionKindAdapter, languages, analytics),
+    );
+  }
+
   subscribeToLsScanMessages(): Subscription {
     return this.languageServer.scan$.subscribe((scan: Scan<IacIssueData>) => {
       if (scan.product !== ScanProduct.InfrastructureAsCode) {

--- a/src/snyk/snykIac/issue.ts
+++ b/src/snyk/snykIac/issue.ts
@@ -1,0 +1,9 @@
+import { IacIssueData, Issue } from '../common/languageServer/types';
+import { IVSCodeLanguages } from '../common/vscode/languages';
+import { Range } from '../common/vscode/types';
+
+export class IacIssue {
+  static getRange(issue: Issue<IacIssueData>, languages: IVSCodeLanguages): Range {
+    return languages.createRange(issue.additionalData.lineNumber, 0, issue.additionalData.lineNumber, Number.MAX_VALUE);
+  }
+}

--- a/src/snyk/snykIac/views/iacIssueTreeProvider.ts
+++ b/src/snyk/snykIac/views/iacIssueTreeProvider.ts
@@ -11,6 +11,7 @@ import { IViewManagerService } from '../../common/services/viewManagerService';
 import { ProductIssueTreeProvider } from '../../common/views/issueTreeProvider';
 import { TreeNode } from '../../common/views/treeNode';
 import { IVSCodeLanguages } from '../../common/vscode/languages';
+import { IacIssue } from '../issue';
 import { messages } from '../messages/analysis';
 import { IacIssueCommandArg } from './interfaces';
 
@@ -56,12 +57,7 @@ export default class IacIssueTreeProvider extends ProductIssueTreeProvider<IacIs
   getIssueTitle = (issue: Issue<IacIssueData>) => issue.title;
 
   getIssueRange(issue: Issue<IacIssueData>): Range {
-    return this.languages.createRange(
-      issue.additionalData.lineNumber,
-      0,
-      issue.additionalData.lineNumber,
-      Number.MAX_VALUE,
-    );
+    return IacIssue.getRange(issue, this.languages);
   }
 
   getOpenIssueCommand(issue: Issue<IacIssueData>, folderPath: string, filePath: string): Command {

--- a/src/test/unit/common/editor/codeActionsProvider.test.ts
+++ b/src/test/unit/common/editor/codeActionsProvider.test.ts
@@ -1,0 +1,109 @@
+import { strictEqual } from 'assert';
+import sinon from 'sinon';
+import { IAnalytics, SupportedQuickFixProperties } from '../../../../snyk/common/analytics/itly';
+import { SNYK_OPEN_ISSUE_COMMAND, SNYK_OPEN_LOCAL_COMMAND } from '../../../../snyk/common/constants/commands';
+import { CodeActionsProvider } from '../../../../snyk/common/editor/codeActionsProvider';
+import { Issue } from '../../../../snyk/common/languageServer/types';
+import { WorkspaceFolderResult } from '../../../../snyk/common/services/productService';
+import { ICodeActionKindAdapter } from '../../../../snyk/common/vscode/codeAction';
+import { CodeAction, Range, TextDocument } from '../../../../snyk/common/vscode/types';
+
+type ProductData = {
+  issueType: string;
+};
+
+class MockProductService extends CodeActionsProvider<ProductData> {
+  getActions(
+    _folderPath: string,
+    _document: TextDocument,
+    _issue: Issue<ProductData>,
+    _issueRange: Range,
+  ): CodeAction[] {
+    return [
+      {
+        command: {
+          title: 'Open Issue',
+          command: SNYK_OPEN_ISSUE_COMMAND,
+        },
+      } as unknown as CodeAction,
+      {
+        command: {
+          title: 'Open File',
+          command: SNYK_OPEN_LOCAL_COMMAND,
+        },
+      } as unknown as CodeAction,
+    ];
+  }
+  getAnalyticsActionTypes(): [string, ...string[]] & [SupportedQuickFixProperties, ...SupportedQuickFixProperties[]] {
+    return ['Show Suggestion'];
+  }
+  getIssueRange(_: Issue<ProductData>): Range {
+    return {
+      contains: () => true,
+    } as unknown as Range;
+  }
+}
+
+suite('Code Actions Provider', () => {
+  let issuesActionsProvider: CodeActionsProvider<ProductData>;
+  let logQuickFixIsDisplayed: sinon.SinonSpy;
+
+  setup(() => {
+    const codeResults = new Map<string, WorkspaceFolderResult<ProductData>>();
+    codeResults.set('folderName', [
+      {
+        filePath: '//folderName//test.js',
+        additionalData: {
+          rule: 'some-rule',
+        },
+      } as unknown as Issue<ProductData>,
+    ]);
+
+    logQuickFixIsDisplayed = sinon.fake();
+    const analytics = {
+      logQuickFixIsDisplayed,
+    } as unknown as IAnalytics;
+
+    const codeActionKindAdapter = {
+      getQuickFix: sinon.fake(),
+    } as ICodeActionKindAdapter;
+
+    issuesActionsProvider = new MockProductService(codeResults, codeActionKindAdapter, analytics);
+  });
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('Provides code actions', () => {
+    // arrange
+    const document = {
+      uri: {
+        fsPath: '//folderName//test.js',
+      },
+    } as unknown as TextDocument;
+
+    // act
+    const codeActions = issuesActionsProvider.provideCodeActions(document, {} as Range);
+
+    // verify
+    strictEqual(codeActions?.length, 2);
+    strictEqual(codeActions[0].command?.command, SNYK_OPEN_ISSUE_COMMAND);
+    strictEqual(codeActions[1].command?.command, SNYK_OPEN_LOCAL_COMMAND);
+  });
+
+  test("Logs 'Quick Fix is Displayed' analytical event", () => {
+    // arrange
+    const document = {
+      uri: {
+        fsPath: '//folderName//test.js',
+      },
+    } as unknown as TextDocument;
+
+    // act
+    issuesActionsProvider.provideCodeActions(document, {} as Range);
+
+    // verify
+    strictEqual(logQuickFixIsDisplayed.calledOnce, true);
+  });
+});

--- a/src/test/unit/common/services/productService.test.ts
+++ b/src/test/unit/common/services/productService.test.ts
@@ -9,6 +9,7 @@ import { IProductService, ProductService } from '../../../../snyk/common/service
 import { IViewManagerService } from '../../../../snyk/common/services/viewManagerService';
 import { IProductWebviewProvider } from '../../../../snyk/common/views/webviewProvider';
 import { ExtensionContext } from '../../../../snyk/common/vscode/extensionContext';
+import { IVSCodeLanguages } from '../../../../snyk/common/vscode/languages';
 import { IVSCodeWorkspace } from '../../../../snyk/common/vscode/workspace';
 import { LanguageServerMock } from '../../mocks/languageServer.mock';
 import { LoggerMock } from '../../mocks/logger.mock';
@@ -51,6 +52,7 @@ suite('Product Service', () => {
       } as IVSCodeWorkspace,
       new WorkspaceTrust(),
       ls,
+      {} as IVSCodeLanguages,
       new LoggerMock(),
     );
   });

--- a/src/test/unit/snykIac/codeActions/iacCodeActionsProvider.test.ts
+++ b/src/test/unit/snykIac/codeActions/iacCodeActionsProvider.test.ts
@@ -1,28 +1,26 @@
 import { strictEqual } from 'assert';
 import sinon from 'sinon';
 import { IAnalytics } from '../../../../snyk/common/analytics/itly';
-import { SNYK_IGNORE_ISSUE_COMMAND, SNYK_OPEN_ISSUE_COMMAND } from '../../../../snyk/common/constants/commands';
-import { CodeIssueData, Issue } from '../../../../snyk/common/languageServer/types';
+import { SNYK_OPEN_ISSUE_COMMAND } from '../../../../snyk/common/constants/commands';
+import { IacIssueData, Issue } from '../../../../snyk/common/languageServer/types';
 import { WorkspaceFolderResult } from '../../../../snyk/common/services/productService';
 import { ICodeActionAdapter, ICodeActionKindAdapter } from '../../../../snyk/common/vscode/codeAction';
 import { IVSCodeLanguages } from '../../../../snyk/common/vscode/languages';
 import { CodeActionKind, Range, TextDocument } from '../../../../snyk/common/vscode/types';
-import { SnykCodeActionsProvider } from '../../../../snyk/snykCode/codeActions/codeIssuesActionsProvider';
-import { IssueUtils } from '../../../../snyk/snykCode/utils/issueUtils';
+import { IacCodeActionsProvider } from '../../../../snyk/snykIac/codeActions/iacCodeActionsProvider';
+import { IacIssue } from '../../../../snyk/snykIac/issue';
 
-suite('Snyk Code actions provider', () => {
-  let issuesActionsProvider: SnykCodeActionsProvider;
+suite('IaC code actions provider', () => {
+  let issuesActionsProvider: IacCodeActionsProvider;
   let logQuickFixIsDisplayed: sinon.SinonSpy;
 
   setup(() => {
-    const codeResults = new Map<string, WorkspaceFolderResult<CodeIssueData>>();
+    const codeResults = new Map<string, WorkspaceFolderResult<IacIssueData>>();
     codeResults.set('folderName', [
       {
         filePath: '//folderName//test.js',
-        additionalData: {
-          rule: 'some-rule',
-        },
-      } as unknown as Issue<CodeIssueData>,
+        additionalData: {},
+      } as unknown as Issue<IacIssueData>,
     ]);
 
     logQuickFixIsDisplayed = sinon.fake();
@@ -44,9 +42,9 @@ suite('Snyk Code actions provider', () => {
       contains: () => true,
     } as unknown as Range;
 
-    sinon.stub(IssueUtils, 'createVsCodeRange').returns(rangeMock);
+    sinon.stub(IacIssue, 'getRange').returns(rangeMock);
 
-    issuesActionsProvider = new SnykCodeActionsProvider(
+    issuesActionsProvider = new IacCodeActionsProvider(
       codeResults,
       codeActionAdapter,
       codeActionKindAdapter,
@@ -71,10 +69,8 @@ suite('Snyk Code actions provider', () => {
     const codeActions = issuesActionsProvider.provideCodeActions(document, {} as Range);
 
     // verify
-    strictEqual(codeActions?.length, 3);
+    strictEqual(codeActions?.length, 1);
     strictEqual(codeActions[0].command?.command, SNYK_OPEN_ISSUE_COMMAND);
-    strictEqual(codeActions[1].command?.command, SNYK_IGNORE_ISSUE_COMMAND);
-    strictEqual(codeActions[2].command?.command, SNYK_IGNORE_ISSUE_COMMAND);
   });
 
   test("Logs 'Quick Fix is Displayed' analytical event", () => {

--- a/src/test/unit/snykIac/iacService.test.ts
+++ b/src/test/unit/snykIac/iacService.test.ts
@@ -1,12 +1,15 @@
 import { strictEqual } from 'assert';
 import sinon from 'sinon';
+import { IAnalytics } from '../../../snyk/common/analytics/itly';
 import { IConfiguration } from '../../../snyk/common/configuration/configuration';
 import { WorkspaceTrust } from '../../../snyk/common/configuration/trustedFolders';
 import { ILanguageServer } from '../../../snyk/common/languageServer/languageServer';
 import { IacIssueData, ScanProduct, ScanStatus } from '../../../snyk/common/languageServer/types';
 import { IProductService } from '../../../snyk/common/services/productService';
 import { IViewManagerService } from '../../../snyk/common/services/viewManagerService';
+import { ICodeActionAdapter, ICodeActionKindAdapter } from '../../../snyk/common/vscode/codeAction';
 import { ExtensionContext } from '../../../snyk/common/vscode/extensionContext';
+import { IVSCodeLanguages } from '../../../snyk/common/vscode/languages';
 import { IVSCodeWorkspace } from '../../../snyk/common/vscode/workspace';
 import { IacService } from '../../../snyk/snykIac/iacService';
 import { IacSuggestionWebviewProvider } from '../../../snyk/snykIac/views/suggestion/iacSuggestionWebviewProvider';
@@ -30,13 +33,21 @@ suite('IaC Service', () => {
       {} as ExtensionContext,
       {} as IConfiguration,
       {} as IacSuggestionWebviewProvider,
+      {} as ICodeActionAdapter,
+      {
+        getQuickFix: sinon.fake(),
+      } as ICodeActionKindAdapter,
       viewManagerService,
       {
         getWorkspaceFolders: () => [''],
       } as IVSCodeWorkspace,
       new WorkspaceTrust(),
       ls,
+      {
+        registerCodeActionsProvider: sinon.fake(),
+      } as unknown as IVSCodeLanguages,
       new LoggerMock(),
+      {} as IAnalytics,
     );
   });
 


### PR DESCRIPTION
### Description

- Adds IaC code actions to open an IaC issue details panel.
- Introduces base class for code actions used by Code and IaC, with Open Source to inherit from it in future.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs
<img width="1075" alt="Screenshot 2023-03-15 at 12 01 38" src="https://user-images.githubusercontent.com/2239563/225290089-1c5f1d0a-7325-438d-a5c7-fa518cf16f7f.png">

