### PR TITLE
chore: configures secret scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2.1
+
+orbs:
+  prodsec: snyk/prodsec-orb@1.0
+
+workflows:
+  version: 2
+  CICD:
+    jobs:
+      - prodsec/secrets-scan:
+          name: Scan repository for secrets
+          context:
+            - snyk-bot-slack
+          channel: hammerhead-alerts

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,5 @@
+# add false positives here
+
+167c8da2a48acd42b43ed52f70bab864c7de5d7b:src/test/unit/base/services/authenticationService.test.ts:generic-api-key:203
+167c8da2a48acd42b43ed52f70bab864c7de5d7b:src/test/unit/base/services/authenticationService.test.ts:generic-api-key:217
+167c8da2a48acd42b43ed52f70bab864c7de5d7b:src/test/unit/base/services/authenticationService.test.ts:generic-api-key:225

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.17.0
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
### Description

This PR adds secrets scanning to the repository. Developers should use the provided pre-commit hooks to prevent the secrets from being pushed to the repository. See https://pre-commit.com/ for details.

