### PR TITLE
Update README.md with correct Vulnerability DB link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Results appear in context, in line with code in your IDE.
 
 This single plugin provides a Java vulnerability scanner, a custom code vulnerability scanner, and an open-source security scanner.
 
-In using the Visual Studio Code extension, you have the advantage of relying on the [Snyk Vulnerability Database](https://docs.snyk.io/introducing-snyk/getting-started-snyk-intel-vuln-db-access). You also have available the [Snyk Code AI Engine](https://docs.snyk.io/products/snyk-code/introducing-snyk-code/key-features/ai-engine).
+In using the Visual Studio Code extension, you have the advantage of relying on the [Snyk Vulnerability Database](https://docs.snyk.io/scan-application-code/snyk-open-source/starting-to-fix-vulnerabilities/using-the-snyk-vulnerability-database). You also have available the [Snyk Code AI Engine](https://docs.snyk.io/products/snyk-code/introducing-snyk-code/key-features/ai-engine).
 
 Snyk scans for the following types of issues:
 


### PR DESCRIPTION
### Description

The link to the Snyk Vulnerability Database is broken and redirects to a 404 [Page Not Found](https://docs.snyk.io/introducing-snyk/getting-started-snyk-intel-vuln-db-access):

### Checklist

- [X] README.md updated, if user-facing

### Screenshots / GIFs

![404](https://github.com/snyk/vscode-extension/assets/1638325/8ef33425-9959-405a-81af-c932ca74bcab)
