### PR TITLE
fix: Snyk Learn link missing [HEAD-558]

### DIFF
--- a/src/snyk/common/views/webviewProvider.ts
+++ b/src/snyk/common/views/webviewProvider.ts
@@ -64,11 +64,11 @@ export abstract class WebviewProvider<ViewModel> implements IWebViewProvider<Vie
     }
   }
 
-  protected async checkVisibility(): Promise<void> {
+  protected checkVisibility(): void {
     if (this.panel && this.panel.visible) {
       try {
-        await this.panel.webview.postMessage({ type: 'get' });
-        await this.panel.webview.postMessage({ type: 'getLesson' });
+        void this.panel.webview.postMessage({ type: 'get' });
+        void this.panel.webview.postMessage({ type: 'getLesson' });
       } catch (e) {
         if (!this.panel) return; // can happen due to asynchronicity, ignore such cases
         Logger.error(`Failed to restore the '${this.panel.title}' webview.`);

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
@@ -10,6 +10,7 @@ import { ErrorHandler } from '../../../common/error/errorHandler';
 import { CodeIssueData, ExampleCommitFix, Issue, Marker, Point } from '../../../common/languageServer/types';
 import { ILog } from '../../../common/logger/interfaces';
 import { messages as learnMessages } from '../../../common/messages/learn';
+import { LearnService } from '../../../common/services/learnService';
 import { getNonce } from '../../../common/views/nonce';
 import { WebviewPanelSerializer } from '../../../common/views/webviewPanelSerializer';
 import { WebviewProvider } from '../../../common/views/webviewProvider';
@@ -22,7 +23,6 @@ import { messages as errorMessages } from '../../messages/error';
 import { getAbsoluteMarkerFilePath } from '../../utils/analysisUtils';
 import { IssueUtils } from '../../utils/issueUtils';
 import { ICodeSuggestionWebviewProvider } from '../interfaces';
-import { LearnService } from '../../../common/services/learnService';
 
 type Suggestion = {
   id: string;
@@ -114,7 +114,7 @@ export class CodeSuggestionWebviewProvider
 
       this.panel.webview.html = this.getHtmlForWebview(this.panel.webview);
 
-      await this.panel.webview.postMessage({ type: 'set', args: this.mapToModel(issue) });
+      void this.panel.webview.postMessage({ type: 'set', args: this.mapToModel(issue) });
       void this.postLearnLessonMessage(issue);
 
       this.issue = issue;

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
@@ -16,22 +16,41 @@
     title: string;
   };
 
+  type ExampleCommitFix = {
+    commitURL: string;
+    lines: CommitChangeLine[];
+  };
+  type CommitChangeLine = {
+    line: string;
+    lineNumber: number;
+    lineChange: 'removed' | 'added' | 'none';
+  };
+  type Marker = {
+    msg: Point;
+    pos: MarkerPosition[];
+  };
+  type MarkerPosition = {
+    cols: Point;
+    rows: Point;
+    file: string;
+  };
+  type Point = [number, number];
   type Suggestion = {
-    isSecurityType: boolean;
-    severity: string;
+    id: string;
     message: string;
+    severity: string;
     leadURL?: string;
-    uri?: string;
-    rows?: any;
-    cols?: any;
-    id?: any;
-    rule?: string;
-    exampleCommitFixes?: {
-      commitURL: string;
-      lines: { lineChange: string; line: string }[];
-    }[];
-    markers?: { msg: any; pos: any[] }[];
-    repoDatasetSize?: any;
+    rule: string;
+    repoDatasetSize: number;
+    exampleCommitFixes: ExampleCommitFix[];
+    cwe: string[];
+    title: string;
+    text: string;
+    isSecurityType: boolean;
+    uri: string;
+    markers?: Marker[];
+    cols: Point;
+    rows: Point;
   };
 
   const vscode = acquireVsCodeApi();
@@ -215,7 +234,7 @@
         };
         title.appendChild(mark);
         const markMsg = document.createElement('span');
-        markMsg.innerHTML = suggestion.message.substring(m.msg[0], (m.msg[1] as number) + 1);
+        markMsg.innerHTML = suggestion.message.substring(m.msg[0], m.msg[1] + 1);
         mark.appendChild(markMsg);
         let markLineText = ' [';
         let first = true;
@@ -229,7 +248,7 @@
         markLine.innerHTML = markLineText;
         markLine.className = 'mark-position';
         mark.appendChild(markLine);
-        i = (m.msg[1] as number) + 1;
+        i = m.msg[1] + 1;
       }
       const postText = suggestion.message.substring(i);
       const postMark = document.createTextNode(postText);
@@ -249,7 +268,7 @@
     const dataset = document.getElementById('dataset-number')!;
     const infoTop = document.getElementById('info-top')!;
     if (suggestion.repoDatasetSize) {
-      dataset.innerHTML = suggestion.repoDatasetSize;
+      dataset.innerHTML = suggestion.repoDatasetSize.toString();
       infoTop.className = 'font-light';
     } else {
       infoTop.className = 'font-light hidden';


### PR DESCRIPTION
### Description

Fixed a bug where the Snyk Learn link would sometimes not be restored when VSCode is re-opened.
For some reason the getLesson message that is posted in `WebviewProvider.checkVisibility` does not update the lesson consistently, so the state is restored in the script directly.

Also added a type for Suggestion and proper null checks