### PR TITLE
feat: disable amplitude and sentry when using fedramp endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,27 @@
 # Snyk Security - Code and Open Source Dependencies Changelog
 
+## [1.21.5]
+
+### Added
+
+- Fedrammp endpoints will not send Sentry/Amplitude events
+
 ## [1.21.4]
 
 ### Changed
+
 - Use Language Server to retrieve vulnerability count for HTML files
 
 ## [1.21.1]
+
 ### Fixed
+
 - Snyk Learn links
 
 ## [1.21.0]
+
 ### Fixed
+
 - Plugin Initialization
 
 ## [1.20.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 ## [1.18.3]
 
 ### Added
+
 - Added support for OAuth2 authentication
 - Snyk Learn: now uses language server to retrieve lessons
 

--- a/src/snyk/common/analytics/itly.ts
+++ b/src/snyk/common/analytics/itly.ts
@@ -70,7 +70,7 @@ export class Iteratively implements IAnalytics {
     private isFedramp: boolean,
     private isDevelopment: boolean,
     private snykConfiguration?: SnykConfiguration,
-  ) { }
+  ) {}
 
   setShouldReportEvents(shouldReportEvents: boolean): void {
     this.shouldReportEvents = shouldReportEvents;

--- a/src/snyk/common/analytics/itly.ts
+++ b/src/snyk/common/analytics/itly.ts
@@ -67,9 +67,10 @@ export class Iteratively implements IAnalytics {
     private readonly user: User,
     private logger: ILog,
     private shouldReportEvents: boolean,
+    private isFedramp: boolean,
     private isDevelopment: boolean,
     private snykConfiguration?: SnykConfiguration,
-  ) {}
+  ) { }
 
   setShouldReportEvents(shouldReportEvents: boolean): void {
     this.shouldReportEvents = shouldReportEvents;
@@ -77,7 +78,8 @@ export class Iteratively implements IAnalytics {
   }
 
   load(): Iteratively | null {
-    if (!this.shouldReportEvents) {
+    if (!this.shouldReportEvents || this.isFedramp) {
+      this.logger.debug(`Analytics are disabled. No analytics will be collected.`);
       return null;
     }
 

--- a/src/snyk/common/analytics/itly.ts
+++ b/src/snyk/common/analytics/itly.ts
@@ -1,13 +1,13 @@
 import SegmentPlugin from '@itly/plugin-segment-node';
 import itly, {
   AnalysisIsReadyProperties,
-  AnalysisIsTriggeredProperties as _AnalysisIsTriggeredProperties,
   FalsePositiveIsSubmittedProperties,
   IssueHoverIsDisplayedProperties,
   IssueInTreeIsClickedProperties,
-  QuickFixIsDisplayedProperties as _QuickFixIsDisplayedProperties,
   ScanModeIsSelectedProperties,
   TrackOptions,
+  AnalysisIsTriggeredProperties as _AnalysisIsTriggeredProperties,
+  QuickFixIsDisplayedProperties as _QuickFixIsDisplayedProperties,
 } from '../../../ampli';
 import { Configuration } from '../configuration/configuration';
 import { SnykConfiguration } from '../configuration/snykConfiguration';
@@ -82,6 +82,7 @@ export class Iteratively implements IAnalytics {
       this.logger.debug(`Analytics are disabled. No analytics will be collected.`);
       return null;
     }
+    this.logger.debug(`Analytics are enabled. Analytics will be collected.`);
 
     const segmentWriteKey = this.snykConfiguration?.segmentWriteKey;
     if (!segmentWriteKey) {

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -111,6 +111,8 @@ export interface IConfiguration {
   getTrustedFolders(): string[];
 
   setTrustedFolders(trustedFolders: string[]): Promise<void>;
+
+  setEndpoint(endpoint: string): Promise<void>;
 }
 
 export class Configuration implements IConfiguration {
@@ -180,6 +182,15 @@ export class Configuration implements IConfiguration {
     }
 
     return this.defaultAuthHost;
+  }
+
+  async setEndpoint(endpoint: string): Promise<void> {
+    await this.workspace.updateConfiguration(
+      CONFIGURATION_IDENTIFIER,
+      this.getConfigName(ADVANCED_CUSTOM_ENDPOINT),
+      endpoint.toString(),
+      true,
+    );
   }
 
   get isFedramp(): boolean {

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -23,7 +23,7 @@ import {
   YES_BACKGROUND_OSS_NOTIFICATION_SETTING,
   YES_CRASH_REPORT_SETTING,
   YES_TELEMETRY_SETTING,
-  YES_WELCOME_NOTIFICATION_SETTING
+  YES_WELCOME_NOTIFICATION_SETTING,
 } from '../constants/settings';
 import SecretStorageAdapter from '../vscode/secretStorage';
 import { IVSCodeWorkspace } from '../vscode/workspace';
@@ -120,7 +120,7 @@ export class Configuration implements IConfiguration {
   private readonly defaultOssApiEndpoint = `${this.defaultAuthHost}/api/v1`;
   private readonly defaultBaseApiHost = 'https://api.snyk.io';
 
-  constructor(private processEnv: NodeJS.ProcessEnv = process.env, private workspace: IVSCodeWorkspace) { }
+  constructor(private processEnv: NodeJS.ProcessEnv = process.env, private workspace: IVSCodeWorkspace) {}
 
   getInsecure(): boolean {
     const strictSSL = this.workspace.getConfiguration<boolean>('http', 'proxyStrictSSL') ?? true;

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -196,14 +196,15 @@ export class Configuration implements IConfiguration {
   get isFedramp(): boolean {
     if (!this.customEndpoint) return false;
 
+    // FEDRAMP URL e.g. https://api.fedramp.snykgov.io
     const endpoint = new URL(this.customEndpoint);
 
     // hostname validation
     const hostnameParts = endpoint.hostname.split('.');
     if (hostnameParts.length < 3) return false;
 
-    const isFedrampInstance = hostnameParts[1] === 'fedramp';
-    const isFedrampDomain = hostnameParts[2] === 'snykgov' && hostnameParts[3] === 'io';
+    const isFedrampInstance = hostnameParts[1].includes('fedramp');
+    const isFedrampDomain = hostnameParts[2].includes('snykgov') && hostnameParts[3].includes('io');
     return isFedrampDomain && isFedrampInstance;
   }
 

--- a/src/snyk/common/error/errorReporter.ts
+++ b/src/snyk/common/error/errorReporter.ts
@@ -66,7 +66,7 @@ export class ErrorReporter {
       beforeSend(event) {
         // drop reporting, if user doesn't want to report events here
         // https://github.com/getsentry/sentry-javascript/issues/2039
-        if (!userConfig.shouldReportErrors) {
+        if (!userConfig.shouldReportErrors || userConfig.isFedramp) {
           return null;
         }
 

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -252,12 +252,12 @@ class SnykExtension extends SnykLib implements IExtension {
     this.registerCommands(vscodeContext);
 
     const codeSecurityIssueProvider = new CodeSecurityIssueTreeProvider(
-      this.viewManagerService,
-      this.contextService,
-      this.snykCode,
-      configuration,
-      vsCodeLanguages,
-    ),
+        this.viewManagerService,
+        this.contextService,
+        this.snykCode,
+        configuration,
+        vsCodeLanguages,
+      ),
       codeQualityIssueProvider = new CodeQualityIssueTreeProvider(
         this.viewManagerService,
         this.contextService,

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -115,6 +115,7 @@ class SnykExtension extends SnykLib implements IExtension {
       this.user,
       Logger,
       configuration.shouldReportEvents,
+      configuration.isFedramp,
       configuration.isDevelopment,
       snykConfiguration,
     );
@@ -251,12 +252,12 @@ class SnykExtension extends SnykLib implements IExtension {
     this.registerCommands(vscodeContext);
 
     const codeSecurityIssueProvider = new CodeSecurityIssueTreeProvider(
-        this.viewManagerService,
-        this.contextService,
-        this.snykCode,
-        configuration,
-        vsCodeLanguages,
-      ),
+      this.viewManagerService,
+      this.contextService,
+      this.snykCode,
+      configuration,
+      vsCodeLanguages,
+    ),
       codeQualityIssueProvider = new CodeQualityIssueTreeProvider(
         this.viewManagerService,
         this.contextService,

--- a/src/test/integration/analytics.test.ts
+++ b/src/test/integration/analytics.test.ts
@@ -36,7 +36,7 @@ suite('Analytics', () => {
   });
 
   test('"Welcome Is Viewed" not tracked if using fedramp endpoint', async () => {
-    await configuration.setEndpoint('https://snyk.fedramp.gov');
+    await configuration.setEndpoint('https://api.fedramp.snykgov.io');
     await vscode.commands.executeCommand('workbench.action.toggleSidebarVisibility');
     await vscode.commands.executeCommand(VSCODE_VIEW_CONTAINER_COMMAND);
 

--- a/src/test/integration/analytics.test.ts
+++ b/src/test/integration/analytics.test.ts
@@ -1,9 +1,9 @@
 import { strictEqual } from 'assert';
-import { configuration } from '../../snyk/common/configuration/instance';
-import * as vscode from 'vscode';
-import { VSCODE_VIEW_CONTAINER_COMMAND } from '../../snyk/common/constants/commands';
 import * as sinon from 'sinon';
+import * as vscode from 'vscode';
 import itly from '../../ampli';
+import { configuration } from '../../snyk/common/configuration/instance';
+import { VSCODE_VIEW_CONTAINER_COMMAND } from '../../snyk/common/constants/commands';
 
 suite('Analytics', () => {
   let welcomeIsViewed: sinon.SinonSpy;
@@ -29,6 +29,14 @@ suite('Analytics', () => {
   test('"Welcome Is Viewed" not tracked if telemetry is off', async () => {
     await configuration.setShouldReportEvents(false);
 
+    await vscode.commands.executeCommand('workbench.action.toggleSidebarVisibility');
+    await vscode.commands.executeCommand(VSCODE_VIEW_CONTAINER_COMMAND);
+
+    strictEqual(welcomeIsViewed.notCalled, true);
+  });
+
+  test('"Welcome Is Viewed" not tracked if using fedramp endpoint', async () => {
+    await configuration.setEndpoint('https://snyk.fedramp.gov');
     await vscode.commands.executeCommand('workbench.action.toggleSidebarVisibility');
     await vscode.commands.executeCommand(VSCODE_VIEW_CONTAINER_COMMAND);
 

--- a/src/test/unit/common/analytics/itly.test.ts
+++ b/src/test/unit/common/analytics/itly.test.ts
@@ -1,0 +1,52 @@
+import { strictEqual } from 'assert';
+import { Iteratively } from '../../../../snyk/common/analytics/itly';
+import { SnykConfiguration } from '../../../../snyk/common/configuration/snykConfiguration';
+import { User } from '../../../../snyk/common/user';
+import { LoggerMock } from '../../mocks/logger.mock';
+
+suite.only('Iteratively', () => {
+  const snykConfig = {} as SnykConfiguration;
+  const isDevelopment = false;
+
+  suite('.load()', () => {
+    suite('when connecting to FEDRAMP endpoints', () => {
+      const isFedramp = true;
+      [true, false].forEach(shouldReportEvents => {
+        test(`Returns "null" when shouldReportEvents == ${shouldReportEvents}`, () => {
+          const iteratively = new Iteratively(
+            new User(),
+            new LoggerMock(),
+            shouldReportEvents,
+            isFedramp,
+            isDevelopment,
+            snykConfig,
+          );
+
+          const result = iteratively.load();
+
+          strictEqual(result, null);
+        });
+      });
+    });
+
+    suite('when connecting to non-FEDRAMP endpoints', () => {
+      const isFedramp = false;
+
+      test('Returns "null" when shouldReportEvents == false', () => {
+        const iteratively = new Iteratively(new User(), new LoggerMock(), false, isFedramp, isDevelopment, snykConfig);
+
+        const result = iteratively.load();
+
+        strictEqual(result, null);
+      });
+
+      test('Returns "Iteratively" when shouldReportEvents == true', () => {
+        const iteratively = new Iteratively(new User(), new LoggerMock(), true, isFedramp, isDevelopment, snykConfig);
+
+        const result = iteratively.load();
+
+        strictEqual(result instanceof Iteratively, true);
+      });
+    });
+  });
+});

--- a/src/test/unit/common/error/errorReporter.test.ts
+++ b/src/test/unit/common/error/errorReporter.test.ts
@@ -14,7 +14,7 @@ suite('ErrorReporter', () => {
   let configuration: IConfiguration;
 
   setup(async () => {
-    configuration = {} as IConfiguration;
+    configuration = { isFedramp: false } as IConfiguration;
     await ErrorReporter.init(configuration, snykConfig, '', envMock, new LoggerMock(), sentryTransport);
   });
 
@@ -54,6 +54,14 @@ suite('ErrorReporter', () => {
 
   test("Doesn't report error when shouldReportErrors == false", () => {
     configuration.shouldReportErrors = false;
+
+    ErrorReporter.capture(new Error());
+
+    strictEqual(testkit.reports().length, 0);
+  });
+
+  test("Doesn't report error when isFedramp == true", () => {
+    configuration.isFedramp = true;
 
     ErrorReporter.capture(new Error());
 


### PR DESCRIPTION
### Description

_This PR should disable analytics and sentry events when using a fedramp endpoint._

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

