### PR TITLE
feat: add always start with `language-server` positional arg, add logging args if given [HEAD-693]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Snyk Security - Code and Open Source Dependencies Changelog
 
-## [1.21.6]
+## [1.23.0]
+- add detection for standalone/cli embedded language server based on binary size
+
+## [1.22.0]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Snyk Security - Code and Open Source Dependencies Changelog
 
 ## [1.23.0]
-- add detection for standalone/cli embedded language server based on binary size
+- add `language-server` as first positional argument to language server start
+- enable setting of log level in language server via SNYK_LOG_LEVEL
+- enable setting of debug level in language server via `-d` or `--debug`
 
 ## [1.22.0]
 

--- a/src/snyk/common/languageServer/languageServer.ts
+++ b/src/snyk/common/languageServer/languageServer.ts
@@ -92,14 +92,7 @@ export class LanguageServer implements ILanguageServer {
     }
     logLevel = process.env.SNYK_LOG_LEVEL ?? logLevel;
 
-    // check size of file at lsBinaryPath to determine if cli or ls
-    let args = ['-l', logLevel];
-    const lsBinarySize = fs.statSync(lsBinaryPath).size;
-    const fiftyMB = 50 * 1024 * 1024;
-    if (lsBinarySize > fiftyMB) {
-      args = ['language-server', ...args];
-    }
-
+    const args = ['language-server', '-l', logLevel];
     this.logger.info(`Snyk Language Server - path: ${lsBinaryPath}`);
     this.logger.info(`Snyk Language Server - args: ${args}`);
     const serverOptions: ServerOptions = {

--- a/src/test/unit/common/languageServer/languageServer.test.ts
+++ b/src/test/unit/common/languageServer/languageServer.test.ts
@@ -197,7 +197,7 @@ suite('Language Server', () => {
     sinon.verify();
   });
 
-  test('LanguageServer adds proxy settings to env of started binary', async () => {
+  test('LanguageServer adds proxy settings to env of started binary', () => {
     const expectedProxy = 'http://localhost:8080';
     const lca = sinon.spy({
       create(

--- a/src/test/unit/common/languageServer/languageServer.test.ts
+++ b/src/test/unit/common/languageServer/languageServer.test.ts
@@ -125,14 +125,7 @@ suite('Language Server', () => {
       stubWorkspaceConfiguration('snyk.loglevel', 'trace'),
       windowMock,
       authServiceMock,
-      {
-        info(_msg: string) {},
-        warn(_msg: string) {},
-        log(_msg: string) {},
-        error(msg: string) {
-          fail(msg);
-        },
-      } as unknown as LoggerMock,
+      logger,
       downloadServiceMock,
     );
     downloadServiceMock.downloadReady$.next();
@@ -197,7 +190,7 @@ suite('Language Server', () => {
     sinon.verify();
   });
 
-  test('LanguageServer adds proxy settings to env of started binary', () => {
+  test('LanguageServer adds proxy settings to env of started binary', async () => {
     const expectedProxy = 'http://localhost:8080';
     const lca = sinon.spy({
       create(
@@ -240,6 +233,7 @@ suite('Language Server', () => {
       downloadServiceMock,
     );
     downloadServiceMock.downloadReady$.next();
+    await languageServer.start();
     sinon.assert.called(lca.create);
     sinon.verify();
   });
@@ -280,7 +274,7 @@ suite('Language Server', () => {
         automaticAuthentication: 'false',
         endpoint: undefined,
         organization: undefined,
-        additionalParams: '--all-projects',
+        additionalParams: '--all-projects -d',
         manageBinariesAutomatically: 'true',
         deviceId: user.anonymousId,
         filterSeverity: { critical: true, high: true, medium: true, low: true },


### PR DESCRIPTION
### Description

- always adds `language-server` as first argument to the args of the language server
- SNYK_LOG_DEVEL overrules all log level settings now
- `-d` or `--debug` in additional parameters now puts language server in debug mode

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
