### PR TITLE
fix: show most severe vulnerability code action [HEAD-1022]

### DIFF
--- a/src/snyk/cli/process.ts
+++ b/src/snyk/cli/process.ts
@@ -25,7 +25,7 @@ export class CliProcess {
     return new Promise((resolve, reject) => {
       let output = '';
 
-      // file deepcode ignore ArrayMethodOnNonArray: <please specify a reason of ignoring this>
+      // file deepcode ignore ArrayMethodOnNonArray: readonly string[] is an array of strings
       this.logger.info(`Running "${cliPath} ${args.join(' ')}".`);
 
       this.runningProcess = spawn(cliPath, args, { env: { ...process.env, ...processEnv }, cwd });

--- a/src/snyk/cli/process.ts
+++ b/src/snyk/cli/process.ts
@@ -1,11 +1,11 @@
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
+import { OAuthToken } from '../base/services/authenticationService';
 import { Configuration, IConfiguration } from '../common/configuration/configuration';
 import { ILog } from '../common/logger/interfaces';
 import { getVsCodeProxy } from '../common/proxy';
 import { IVSCodeWorkspace } from '../common/vscode/workspace';
 import { CLI_INTEGRATION_NAME } from './contants/integration';
 import { CliError } from './services/cliService';
-import { OAuthToken } from '../base/services/authenticationService';
 
 export class CliProcess {
   private runningProcess: ChildProcessWithoutNullStreams | null;
@@ -25,6 +25,7 @@ export class CliProcess {
     return new Promise((resolve, reject) => {
       let output = '';
 
+      // file deepcode ignore ArrayMethodOnNonArray: <please specify a reason of ignoring this>
       this.logger.info(`Running "${cliPath} ${args.join(' ')}".`);
 
       this.runningProcess = spawn(cliPath, args, { env: { ...process.env, ...processEnv }, cwd });

--- a/src/snyk/common/commands/commandController.ts
+++ b/src/snyk/common/commands/commandController.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import path from 'path';
 import { IAuthenticationService } from '../../base/services/authenticationService';
 import { ScanModeService } from '../../base/services/scanModeService';
-import { createDCIgnore } from '../../snykCode/utils/ignoreFileUtils';
+import { createDCIgnore as createDCIgnoreUtil } from '../../snykCode/utils/ignoreFileUtils';
 import { IssueUtils } from '../../snykCode/utils/issueUtils';
 import { CodeIssueCommandArg } from '../../snykCode/views/interfaces';
 import { IacIssueCommandArg } from '../../snykIac/views/interfaces';
@@ -89,11 +89,11 @@ export class CommandController {
       const paths = this.workspace.getWorkspaceFolders();
       const promises = [];
       for (const p of paths) {
-        promises.push(createDCIgnore(p, custom, this.workspace, this.window, uriAdapter));
+        promises.push(createDCIgnoreUtil(p, custom, this.workspace, this.window, uriAdapter));
       }
       await Promise.all(promises);
     } else {
-      await createDCIgnore(path, custom, this.workspace, this.window, uriAdapter);
+      await createDCIgnoreUtil(path, custom, this.workspace, this.window, uriAdapter);
     }
   }
 

--- a/src/snyk/common/commands/types.ts
+++ b/src/snyk/common/commands/types.ts
@@ -1,7 +1,7 @@
 import { completeFileSuggestionType } from '../../snykCode/interfaces';
 import { CodeIssueCommandArg } from '../../snykCode/views/interfaces';
 import { IacIssueCommandArg } from '../../snykIac/views/interfaces';
-import { OssIssueCommandArgLanguageServer } from '../../snykOss/interfaces';
+import { OssIssueCommandArg } from '../../snykOss/interfaces';
 import { CodeIssueData, Issue } from '../languageServer/types';
 
 export enum OpenCommandIssueType {
@@ -11,12 +11,12 @@ export enum OpenCommandIssueType {
 }
 
 export type OpenIssueCommandArg = {
-  issue: CodeIssueCommandArg | IacIssueCommandArg | OssIssueCommandArgLanguageServer;
+  issue: CodeIssueCommandArg | IacIssueCommandArg | OssIssueCommandArg;
   issueType: OpenCommandIssueType;
 };
 
 export const isCodeIssue = (
-  _issue: completeFileSuggestionType | Issue<CodeIssueData> | OssIssueCommandArgLanguageServer,
+  _issue: completeFileSuggestionType | Issue<CodeIssueData> | OssIssueCommandArg,
   issueType: OpenCommandIssueType,
 ): _issue is Issue<CodeIssueData> => {
   return issueType === OpenCommandIssueType.CodeIssue;

--- a/src/snyk/common/editor/codeActionsProvider.ts
+++ b/src/snyk/common/editor/codeActionsProvider.ts
@@ -2,19 +2,26 @@ import { IAnalytics, SupportedQuickFixProperties } from '../../common/analytics/
 import { IDE_NAME } from '../../common/constants/general';
 import { Issue } from '../../common/languageServer/types';
 import { ICodeActionKindAdapter } from '../../common/vscode/codeAction';
-import { CodeAction, CodeActionKind, CodeActionProvider, Range, TextDocument } from '../../common/vscode/types';
+import {
+  CodeAction,
+  CodeActionContext,
+  CodeActionKind,
+  CodeActionProvider,
+  Range,
+  TextDocument,
+} from '../../common/vscode/types';
 import { ProductResult } from '../services/productService';
 
 export abstract class CodeActionsProvider<T> implements CodeActionProvider {
   protected readonly providedCodeActionKinds = [this.codeActionKindAdapter.getQuickFix()];
 
   constructor(
-    private readonly issues: ProductResult<T>,
+    protected readonly issues: ProductResult<T>,
     private readonly codeActionKindAdapter: ICodeActionKindAdapter,
-    private readonly analytics: IAnalytics,
+    protected readonly analytics: IAnalytics,
   ) {}
 
-  abstract getActions(folderPath: string, document: TextDocument, issue: Issue<T>, issueRange: Range): CodeAction[];
+  abstract getActions(folderPath: string, document: TextDocument, issue: Issue<T>, issueRange?: Range): CodeAction[];
 
   abstract getAnalyticsActionTypes(): [string, ...string[]] &
     [SupportedQuickFixProperties, ...SupportedQuickFixProperties[]];
@@ -25,7 +32,11 @@ export abstract class CodeActionsProvider<T> implements CodeActionProvider {
     return this.providedCodeActionKinds;
   }
 
-  public provideCodeActions(document: TextDocument, clickedRange: Range): CodeAction[] | undefined {
+  public provideCodeActions(
+    document: TextDocument,
+    clickedRange: Range,
+    _context: CodeActionContext,
+  ): CodeAction[] | undefined {
     if (this.issues.size === 0) {
       return undefined;
     }
@@ -57,7 +68,7 @@ export abstract class CodeActionsProvider<T> implements CodeActionProvider {
     return undefined;
   }
 
-  private findIssueWithRange(
+  protected findIssueWithRange(
     result: Issue<T>[],
     document: TextDocument,
     clickedRange: Range,

--- a/src/snyk/common/languageServer/lsExecutable.ts
+++ b/src/snyk/common/languageServer/lsExecutable.ts
@@ -43,10 +43,10 @@ export class LsExecutable {
       return customPath;
     }
 
-    const platform = this.getCurrentWithArch();
+    const platform = LsExecutable.getCurrentWithArch();
 
     const homeDir = Platform.getHomeDir();
-    const lsFilename = this.getFilename(platform);
+    const lsFilename = LsExecutable.getFilename(platform);
     const defaultPath = this.defaultPaths[platform];
     const lsDir = path.join(homeDir, defaultPath, 'snyk-ls');
     return path.join(lsDir, lsFilename);

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -219,6 +219,8 @@ class SnykExtension extends SnykLib implements IExtension {
       extensionContext,
       configuration,
       ossSuggestionProvider,
+      new CodeActionAdapter(),
+      this.codeActionKindAdapter,
       this.viewManagerService,
       vsCodeWorkspace,
       this.workspaceTrust,

--- a/src/snyk/snykCode/constants/analysis.ts
+++ b/src/snyk/snykCode/constants/analysis.ts
@@ -24,6 +24,7 @@ export const ISSUES_MARKERS_DECORATION_TYPE: { [key: string]: string } = {
 export const DIAGNOSTICS_CODE_SECURITY_COLLECTION_NAME = 'Snyk Code Security';
 export const DIAGNOSTICS_CODE_QUALITY_COLLECTION_NAME = 'Snyk Code Quality';
 export const DIAGNOSTICS_OSS_COLLECTION_NAME = 'Snyk Open Source Security';
+export const DIAGNOSTICS_OSS_COLLECTION_NAME_LS = 'Snyk Open Source';
 
 export const WEBVIEW_PANEL_SECURITY_TITLE = 'Snyk Code Vulnerability';
 export const WEBVIEW_PANEL_QUALITY_TITLE = 'Snyk Code Issue';

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
@@ -341,7 +341,7 @@ declare const acquireVsCodeApi: any;
     ignoreIssue(false);
   });
 
-  // deepcode ignore InsufficientValidation: Content Security Policy applied in provider
+  // file deepcode ignore InsufficientPostmessageValidation: <please specify a reason of ignoring this>
   window.addEventListener('message', event => {
     const { type, args } = event.data;
     switch (type) {

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
@@ -341,7 +341,7 @@ declare const acquireVsCodeApi: any;
     ignoreIssue(false);
   });
 
-  // file deepcode ignore InsufficientPostmessageValidation: <please specify a reason of ignoring this>
+  // deepcode ignore InsufficientValidation: Content Security Policy applied in provider
   window.addEventListener('message', event => {
     const { type, args } = event.data;
     switch (type) {

--- a/src/snyk/snykIac/views/suggestion/iacSuggestionWebviewScript.ts
+++ b/src/snyk/snykIac/views/suggestion/iacSuggestionWebviewScript.ts
@@ -143,7 +143,7 @@
     }
   }
 
-  // file deepcode ignore InsufficientPostmessageValidation: <please specify a reason of ignoring this>
+  // file deepcode ignore InsufficientPostmessageValidation: Content Security Policy applied in provider
   window.addEventListener('message', event => {
     const { type, args } = event.data;
     switch (type) {

--- a/src/snyk/snykIac/views/suggestion/iacSuggestionWebviewScript.ts
+++ b/src/snyk/snykIac/views/suggestion/iacSuggestionWebviewScript.ts
@@ -143,6 +143,7 @@
     }
   }
 
+  // file deepcode ignore InsufficientPostmessageValidation: <please specify a reason of ignoring this>
   window.addEventListener('message', event => {
     const { type, args } = event.data;
     switch (type) {

--- a/src/snyk/snykOss/interfaces.ts
+++ b/src/snyk/snykOss/interfaces.ts
@@ -7,7 +7,7 @@ export interface IOssSuggestionWebviewProvider extends IWebViewProvider<Issue<Os
   openIssueId: string | undefined;
 }
 
-export type OssIssueCommandArgLanguageServer = Issue<OssIssueData> & {
+export type OssIssueCommandArg = Issue<OssIssueData> & {
   matchingIdVulnerabilities: Issue<OssIssueData>[];
   overviewHtml: string;
 };

--- a/src/snyk/snykOss/ossService.ts
+++ b/src/snyk/snykOss/ossService.ts
@@ -7,16 +7,20 @@ import { OssIssueData, Scan, ScanProduct } from '../common/languageServer/types'
 import { ILog } from '../common/logger/interfaces';
 import { ProductService } from '../common/services/productService';
 import { IViewManagerService } from '../common/services/viewManagerService';
+import { ICodeActionAdapter, ICodeActionKindAdapter } from '../common/vscode/codeAction';
 import { ExtensionContext } from '../common/vscode/extensionContext';
 import { IVSCodeLanguages } from '../common/vscode/languages';
 import { IVSCodeWorkspace } from '../common/vscode/workspace';
 import { IOssSuggestionWebviewProvider } from './interfaces';
+import { OssCodeActionsProvider } from './providers/ossCodeActionsProvider';
 
 export class OssService extends ProductService<OssIssueData> {
   constructor(
     extensionContext: ExtensionContext,
     config: IConfiguration,
     suggestionProvider: IOssSuggestionWebviewProvider,
+    codeActionAdapter: ICodeActionAdapter,
+    codeActionKindAdapter: ICodeActionKindAdapter,
     viewManagerService: IViewManagerService,
     workspace: IVSCodeWorkspace,
     workspaceTrust: IWorkspaceTrust,
@@ -35,6 +39,10 @@ export class OssService extends ProductService<OssIssueData> {
       languageServer,
       languages,
       logger,
+    );
+
+    this.registerCodeActionsProvider(
+      new OssCodeActionsProvider(this.result, codeActionAdapter, codeActionKindAdapter, languages, analytics),
     );
   }
 

--- a/src/snyk/snykOss/ossService.ts
+++ b/src/snyk/snykOss/ossService.ts
@@ -42,7 +42,7 @@ export class OssService extends ProductService<OssIssueData> {
     );
 
     this.registerCodeActionsProvider(
-      new OssCodeActionsProvider(this.result, codeActionAdapter, codeActionKindAdapter, languages, analytics),
+      new OssCodeActionsProvider(languages, codeActionAdapter, codeActionKindAdapter, this.result, analytics),
     );
   }
 

--- a/src/snyk/snykOss/providers/ossCodeActionsProvider.ts
+++ b/src/snyk/snykOss/providers/ossCodeActionsProvider.ts
@@ -48,7 +48,7 @@ export class OssCodeActionsProvider extends CodeActionsProvider<OssIssueData> {
     }
 
     // find the corresponding Issue<OssIssueData> objects from ossDiagnostics
-    let vulnerabilities: Issue<OssIssueData>[] = [];
+    const vulnerabilities: Issue<OssIssueData>[] = [];
     for (const diagnostic of ossDiagnostics) {
       const vulnerability = ossResult.find(
         ossIssue => ossIssue.id === (diagnostic.code as { value: string | number; target: Uri }).value,
@@ -58,7 +58,6 @@ export class OssCodeActionsProvider extends CodeActionsProvider<OssIssueData> {
       }
       vulnerabilities.push(vulnerability);
     }
-
 
     // iterate vulnerabilities and get the most severe one
     // if there are multiple of the same severity, get the first one

--- a/src/snyk/snykOss/providers/ossCodeActionsProvider.ts
+++ b/src/snyk/snykOss/providers/ossCodeActionsProvider.ts
@@ -5,7 +5,7 @@ import { OpenCommandIssueType, OpenIssueCommandArg } from '../../common/commands
 import { SNYK_OPEN_ISSUE_COMMAND } from '../../common/constants/commands';
 import { IDE_NAME } from '../../common/constants/general';
 import { CodeActionsProvider } from '../../common/editor/codeActionsProvider';
-import { Issue, OssIssueData } from '../../common/languageServer/types';
+import { Issue, IssueSeverity, OssIssueData } from '../../common/languageServer/types';
 import { ProductResult } from '../../common/services/productService';
 import { ICodeActionAdapter, ICodeActionKindAdapter } from '../../common/vscode/codeAction';
 import { IVSCodeLanguages } from '../../common/vscode/languages';
@@ -24,6 +24,85 @@ export class OssCodeActionsProvider extends CodeActionsProvider<OssIssueData> {
     super(issues, codeActionKindAdapter, analytics);
   }
 
+  override provideCodeActions(
+    document: TextDocument,
+    _clickedRange: Range,
+    context: CodeActionContext,
+  ): CodeAction[] | undefined {
+    // is there a better way to get the folder path?
+    const folderPath = document.uri.fsPath.split('/').slice(0, -1).join('/');
+    if (!folderPath) {
+      return;
+    }
+
+    // get all OSS vulnerabilities for the folder
+    const ossResult = this.issues.get(folderPath);
+    if (!ossResult || ossResult instanceof Error) {
+      return;
+    }
+
+    // get all OSS diagnostics; these contain the relavnt vulnerabilities
+    const ossDiagnostics = context.diagnostics.filter(d => d.source === DIAGNOSTICS_OSS_COLLECTION_NAME_LS);
+    if (!ossDiagnostics.length) {
+      return;
+    }
+
+    // find the corresponding Issue<OssIssueData> objects from ossDiagnostics
+    let vulnerabilities: Issue<OssIssueData>[] = [];
+    for (const diagnostic of ossDiagnostics) {
+      const vulnerability = ossResult.find(
+        ossIssue => ossIssue.id === (diagnostic.code as { value: string | number; target: Uri }).value,
+      );
+      if (!vulnerability) {
+        continue;
+      }
+      vulnerabilities.push(vulnerability);
+    }
+
+
+    // iterate vulnerabilities and get the most severe one
+    // if there are multiple of the same severity, get the first one
+    let highestSeverity = this.issueSeverityToRanking(IssueSeverity.Low);
+    let mostSevereVulnerability: Issue<OssIssueData> | undefined;
+
+    for (const vulnerability of vulnerabilities) {
+      if (this.issueSeverityToRanking(vulnerability.severity) > highestSeverity) {
+        highestSeverity = this.issueSeverityToRanking(vulnerability.severity);
+        mostSevereVulnerability = vulnerability;
+      }
+    }
+
+    if (!mostSevereVulnerability) {
+      return;
+    }
+
+    // create the CodeAction
+    const openIssueAction = this.codeActionAdapter.create(
+      `Show the most severe vulnerability [${mostSevereVulnerability.id}] (Snyk)`,
+      this.providedCodeActionKinds[0],
+    );
+
+    openIssueAction.command = {
+      command: SNYK_OPEN_ISSUE_COMMAND,
+      title: SNYK_OPEN_ISSUE_COMMAND,
+      arguments: [
+        {
+          issueType: OpenCommandIssueType.OssVulnerability,
+          issue: this.getOssIssueCommandArg(mostSevereVulnerability, vulnerabilities),
+        } as OpenIssueCommandArg,
+      ],
+    };
+
+    const analyticsType = this.getAnalyticsActionTypes();
+
+    this.analytics.logQuickFixIsDisplayed({
+      quickFixType: analyticsType,
+      ide: IDE_NAME,
+    });
+
+    return [openIssueAction];
+  }
+
   getActions(folderPath: string, _: TextDocument, issue: Issue<OssIssueData>, range: Range): CodeAction[] {
     const openIssueAction = this.createOpenIssueAction(folderPath, issue, range);
 
@@ -39,55 +118,22 @@ export class OssCodeActionsProvider extends CodeActionsProvider<OssIssueData> {
     return this.languages.createRange(0, 0, 0, 0);
   }
 
-  override provideCodeActions(
-    document: TextDocument,
-    _clickedRange: Range,
-    context: CodeActionContext,
-  ): CodeAction[] | undefined {
-    const folderPath = document.uri.fsPath.split('/').slice(0, -1).join('/');
-    const ossDiagnostics = context.diagnostics.filter(d => d.source === DIAGNOSTICS_OSS_COLLECTION_NAME_LS);
-    if (!ossDiagnostics.length) {
-      return;
+  getOssIssueCommandArg(issue: Issue<OssIssueData>, filteredIssues: Issue<OssIssueData>[]): OssIssueCommandArg {
+    const matchingIdVulnerabilities = filteredIssues.filter(v => v.id === issue.id);
+    let overviewHtml = '';
+
+    try {
+      // TODO: marked.parse does not sanitize the HTML. See: https://marked.js.org/#usage
+      overviewHtml = marked.parse(issue.additionalData.description);
+    } catch (error) {
+      overviewHtml = '<p>There was a problem rendering the vulnerability overview</p>';
     }
 
-    const ossResult = this.issues.get(folderPath);
-    if (!ossResult || ossResult instanceof Error) {
-      return;
-    }
-
-    for (const diagnostic of ossDiagnostics) {
-      const vulnerability = ossResult.find(
-        ossIssue => ossIssue.id === (diagnostic.code as { value: string | number; target: Uri }).value,
-      );
-      if (!vulnerability) {
-        continue;
-      }
-
-      const openIssueAction = this.codeActionAdapter.create(
-        'Show the most severe vulnerability (Snyk)',
-        this.providedCodeActionKinds[0],
-      );
-
-      openIssueAction.command = {
-        command: SNYK_OPEN_ISSUE_COMMAND,
-        title: SNYK_OPEN_ISSUE_COMMAND,
-        arguments: [
-          {
-            issueType: OpenCommandIssueType.OssVulnerability,
-            issue: this.getOssIssueCommandArg(vulnerability, ossResult),
-          } as OpenIssueCommandArg,
-        ],
-      };
-
-      const analyticsType = this.getAnalyticsActionTypes();
-
-      this.analytics.logQuickFixIsDisplayed({
-        quickFixType: analyticsType,
-        ide: IDE_NAME,
-      });
-
-      return [openIssueAction];
-    }
+    return {
+      ...issue,
+      matchingIdVulnerabilities,
+      overviewHtml,
+    };
   }
 
   private createOpenIssueAction(_folderPath: string, issue: Issue<OssIssueData>, _issueRange: Range): CodeAction {
@@ -107,28 +153,23 @@ export class OssCodeActionsProvider extends CodeActionsProvider<OssIssueData> {
             matchingIdVulnerabilities: [issue],
             overviewHtml: '',
           },
-        } as OpenIssueCommandArg,
+        },
       ],
     };
 
     return openIssueAction;
   }
 
-  getOssIssueCommandArg(issue: Issue<OssIssueData>, filteredIssues: Issue<OssIssueData>[]): OssIssueCommandArg {
-    const matchingIdVulnerabilities = filteredIssues.filter(v => v.id === issue.id);
-    let overviewHtml = '';
-
-    try {
-      // TODO: marked.parse does not sanitize the HTML. See: https://marked.js.org/#usage
-      overviewHtml = marked.parse(issue.additionalData.description);
-    } catch (error) {
-      overviewHtml = '<p>There was a problem rendering the vulnerability overview</p>';
+  private issueSeverityToRanking(severity: IssueSeverity): number {
+    switch (severity) {
+      case IssueSeverity.Critical:
+        return 3;
+      case IssueSeverity.High:
+        return 2;
+      case IssueSeverity.Medium:
+        return 1;
+      default:
+        return 0;
     }
-
-    return {
-      ...issue,
-      matchingIdVulnerabilities,
-      overviewHtml,
-    };
   }
 }

--- a/src/snyk/snykOss/providers/ossCodeActionsProvider.ts
+++ b/src/snyk/snykOss/providers/ossCodeActionsProvider.ts
@@ -1,0 +1,134 @@
+import marked from 'marked';
+import { CodeAction, Range, TextDocument, Uri } from 'vscode';
+import { IAnalytics, SupportedQuickFixProperties } from '../../common/analytics/itly';
+import { OpenCommandIssueType, OpenIssueCommandArg } from '../../common/commands/types';
+import { SNYK_OPEN_ISSUE_COMMAND } from '../../common/constants/commands';
+import { IDE_NAME } from '../../common/constants/general';
+import { CodeActionsProvider } from '../../common/editor/codeActionsProvider';
+import { Issue, OssIssueData } from '../../common/languageServer/types';
+import { ProductResult } from '../../common/services/productService';
+import { ICodeActionAdapter, ICodeActionKindAdapter } from '../../common/vscode/codeAction';
+import { IVSCodeLanguages } from '../../common/vscode/languages';
+import { CodeActionContext } from '../../common/vscode/types';
+import { DIAGNOSTICS_OSS_COLLECTION_NAME_LS } from '../../snykCode/constants/analysis';
+import { OssIssueCommandArg } from '../interfaces';
+
+export class OssCodeActionsProvider extends CodeActionsProvider<OssIssueData> {
+  constructor(
+    issues: Readonly<ProductResult<OssIssueData>>,
+    private readonly codeActionAdapter: ICodeActionAdapter,
+    codeActionKindAdapter: ICodeActionKindAdapter,
+    private readonly languages: IVSCodeLanguages,
+    analytics: IAnalytics,
+  ) {
+    super(issues, codeActionKindAdapter, analytics);
+  }
+
+  getActions(folderPath: string, _: TextDocument, issue: Issue<OssIssueData>, range: Range): CodeAction[] {
+    const openIssueAction = this.createOpenIssueAction(folderPath, issue, range);
+
+    // returns list of actions, all new actions should be added to this list
+    return [openIssueAction];
+  }
+
+  getAnalyticsActionTypes(): [string, ...string[]] & [SupportedQuickFixProperties, ...SupportedQuickFixProperties[]] {
+    return ['Show Suggestion'];
+  }
+
+  getIssueRange(_issue: Issue<OssIssueData>): Range {
+    return this.languages.createRange(0, 0, 0, 0);
+  }
+
+  override provideCodeActions(
+    document: TextDocument,
+    _clickedRange: Range,
+    context: CodeActionContext,
+  ): CodeAction[] | undefined {
+    const folderPath = document.uri.fsPath.split('/').slice(0, -1).join('/');
+    const ossDiagnostics = context.diagnostics.filter(d => d.source === DIAGNOSTICS_OSS_COLLECTION_NAME_LS);
+    if (!ossDiagnostics.length) {
+      return;
+    }
+
+    const ossResult = this.issues.get(folderPath);
+    if (!ossResult || ossResult instanceof Error) {
+      return;
+    }
+
+    for (const diagnostic of ossDiagnostics) {
+      const vulnerability = ossResult.find(
+        ossIssue => ossIssue.id === (diagnostic.code as { value: string | number; target: Uri }).value,
+      );
+      if (!vulnerability) {
+        continue;
+      }
+
+      const openIssueAction = this.codeActionAdapter.create(
+        'Show the most severe vulnerability (Snyk)',
+        this.providedCodeActionKinds[0],
+      );
+
+      openIssueAction.command = {
+        command: SNYK_OPEN_ISSUE_COMMAND,
+        title: SNYK_OPEN_ISSUE_COMMAND,
+        arguments: [
+          {
+            issueType: OpenCommandIssueType.OssVulnerability,
+            issue: this.getOssIssueCommandArg(vulnerability, ossResult),
+          } as OpenIssueCommandArg,
+        ],
+      };
+
+      const analyticsType = this.getAnalyticsActionTypes();
+
+      this.analytics.logQuickFixIsDisplayed({
+        quickFixType: analyticsType,
+        ide: IDE_NAME,
+      });
+
+      return [openIssueAction];
+    }
+  }
+
+  private createOpenIssueAction(_folderPath: string, issue: Issue<OssIssueData>, _issueRange: Range): CodeAction {
+    const openIssueAction = this.codeActionAdapter.create(
+      'Show the most severe vulnerability (Snyk)',
+      this.providedCodeActionKinds[0],
+    );
+
+    openIssueAction.command = {
+      command: SNYK_OPEN_ISSUE_COMMAND,
+      title: SNYK_OPEN_ISSUE_COMMAND,
+      arguments: [
+        {
+          issueType: OpenCommandIssueType.OssVulnerability,
+          issue: {
+            ...issue,
+            matchingIdVulnerabilities: [issue],
+            overviewHtml: '',
+          },
+        } as OpenIssueCommandArg,
+      ],
+    };
+
+    return openIssueAction;
+  }
+
+  getOssIssueCommandArg(issue: Issue<OssIssueData>, filteredIssues: Issue<OssIssueData>[]): OssIssueCommandArg {
+    const matchingIdVulnerabilities = filteredIssues.filter(v => v.id === issue.id);
+    let overviewHtml = '';
+
+    try {
+      // TODO: marked.parse does not sanitize the HTML. See: https://marked.js.org/#usage
+      overviewHtml = marked.parse(issue.additionalData.description);
+    } catch (error) {
+      overviewHtml = '<p>There was a problem rendering the vulnerability overview</p>';
+    }
+
+    return {
+      ...issue,
+      matchingIdVulnerabilities,
+      overviewHtml,
+    };
+  }
+}

--- a/src/snyk/snykOss/providers/ossCodeActionsProvider.ts
+++ b/src/snyk/snykOss/providers/ossCodeActionsProvider.ts
@@ -13,10 +13,10 @@ import { DIAGNOSTICS_OSS_COLLECTION_NAME_LS } from '../../snykCode/constants/ana
 
 export class OssCodeActionsProvider extends CodeActionsProvider<OssIssueData> {
   constructor(
-    issues: Readonly<ProductResult<OssIssueData>>,
+    private readonly languages: IVSCodeLanguages,
     private readonly codeActionAdapter: ICodeActionAdapter,
     codeActionKindAdapter: ICodeActionKindAdapter,
-    private readonly languages: IVSCodeLanguages,
+    issues: Readonly<ProductResult<OssIssueData>>,
     analytics: IAnalytics,
   ) {
     super(issues, codeActionKindAdapter, analytics);

--- a/src/snyk/snykOss/providers/ossCodeActionsProvider.ts
+++ b/src/snyk/snykOss/providers/ossCodeActionsProvider.ts
@@ -113,6 +113,7 @@ export class OssCodeActionsProvider extends CodeActionsProvider<OssIssueData> {
     return ['Show Suggestion'];
   }
 
+  // noop
   getIssueRange(_issue: Issue<OssIssueData>): Range {
     return this.languages.createRange(0, 0, 0, 0);
   }

--- a/src/snyk/snykOss/providers/ossVulnerabilityCountProvider.ts
+++ b/src/snyk/snykOss/providers/ossVulnerabilityCountProvider.ts
@@ -2,7 +2,7 @@ import { CliError } from '../../cli/services/cliService';
 import { Language, languageToString } from '../../common/types';
 import { ILanguageClientAdapter } from '../../common/vscode/languageClient';
 import { ITextDocumentAdapter } from '../../common/vscode/textdocument';
-import { InlineValueText, LanguageClient, LSPTextDocument } from '../../common/vscode/types';
+import { InlineValueText, LSPTextDocument } from '../../common/vscode/types';
 import { IUriAdapter } from '../../common/vscode/uri';
 import { convertIssue, isResultCliError, OssFileResult, OssResultBody } from '../interfaces';
 import { OssService } from '../ossService';

--- a/src/snyk/snykOss/providers/ossVulnerabilityTreeProvider.ts
+++ b/src/snyk/snykOss/providers/ossVulnerabilityTreeProvider.ts
@@ -14,7 +14,7 @@ import { ProductIssueTreeProvider } from '../../common/views/issueTreeProvider';
 import { TreeNode } from '../../common/views/treeNode';
 import { IVSCodeLanguages } from '../../common/vscode/languages';
 import { messages } from '../constants/messages';
-import { OssIssueCommandArgLanguageServer } from '../interfaces';
+import { OssIssueCommandArg } from '../interfaces';
 
 export default class OssIssueTreeProvider extends ProductIssueTreeProvider<OssIssueData> {
   constructor(
@@ -201,10 +201,7 @@ export default class OssIssueTreeProvider extends ProductIssueTreeProvider<OssIs
     };
   }
 
-  getOssIssueCommandArg(
-    vuln: Issue<OssIssueData>,
-    filteredVulns: Issue<OssIssueData>[],
-  ): OssIssueCommandArgLanguageServer {
+  getOssIssueCommandArg(vuln: Issue<OssIssueData>, filteredVulns: Issue<OssIssueData>[]): OssIssueCommandArg {
     const matchingIdVulnerabilities = filteredVulns.filter(v => v.id === vuln.id);
     let overviewHtml = '';
 

--- a/src/test/unit/common/editor/codeActionsProvider.test.ts
+++ b/src/test/unit/common/editor/codeActionsProvider.test.ts
@@ -6,7 +6,7 @@ import { CodeActionsProvider } from '../../../../snyk/common/editor/codeActionsP
 import { Issue } from '../../../../snyk/common/languageServer/types';
 import { WorkspaceFolderResult } from '../../../../snyk/common/services/productService';
 import { ICodeActionKindAdapter } from '../../../../snyk/common/vscode/codeAction';
-import { CodeAction, Range, TextDocument } from '../../../../snyk/common/vscode/types';
+import { CodeAction, CodeActionContext, Range, TextDocument } from '../../../../snyk/common/vscode/types';
 
 type ProductData = {
   issueType: string;
@@ -84,7 +84,7 @@ suite('Code Actions Provider', () => {
     } as unknown as TextDocument;
 
     // act
-    const codeActions = issuesActionsProvider.provideCodeActions(document, {} as Range);
+    const codeActions = issuesActionsProvider.provideCodeActions(document, {} as Range, {} as CodeActionContext);
 
     // verify
     strictEqual(codeActions?.length, 2);
@@ -101,7 +101,7 @@ suite('Code Actions Provider', () => {
     } as unknown as TextDocument;
 
     // act
-    issuesActionsProvider.provideCodeActions(document, {} as Range);
+    issuesActionsProvider.provideCodeActions(document, {} as Range, {} as CodeActionContext);
 
     // verify
     strictEqual(logQuickFixIsDisplayed.calledOnce, true);

--- a/src/test/unit/snykCode/codeActions/codeIssuesActionsProvider.test.ts
+++ b/src/test/unit/snykCode/codeActions/codeIssuesActionsProvider.test.ts
@@ -6,7 +6,7 @@ import { CodeIssueData, Issue } from '../../../../snyk/common/languageServer/typ
 import { WorkspaceFolderResult } from '../../../../snyk/common/services/productService';
 import { ICodeActionAdapter, ICodeActionKindAdapter } from '../../../../snyk/common/vscode/codeAction';
 import { IVSCodeLanguages } from '../../../../snyk/common/vscode/languages';
-import { CodeActionKind, Range, TextDocument } from '../../../../snyk/common/vscode/types';
+import { CodeActionContext, CodeActionKind, Range, TextDocument } from '../../../../snyk/common/vscode/types';
 import { SnykCodeActionsProvider } from '../../../../snyk/snykCode/codeActions/codeIssuesActionsProvider';
 import { IssueUtils } from '../../../../snyk/snykCode/utils/issueUtils';
 
@@ -68,7 +68,7 @@ suite('Snyk Code actions provider', () => {
     } as unknown as TextDocument;
 
     // act
-    const codeActions = issuesActionsProvider.provideCodeActions(document, {} as Range);
+    const codeActions = issuesActionsProvider.provideCodeActions(document, {} as Range, {} as CodeActionContext);
 
     // verify
     strictEqual(codeActions?.length, 3);
@@ -86,7 +86,7 @@ suite('Snyk Code actions provider', () => {
     } as unknown as TextDocument;
 
     // act
-    issuesActionsProvider.provideCodeActions(document, {} as Range);
+    issuesActionsProvider.provideCodeActions(document, {} as Range, {} as CodeActionContext);
 
     // verify
     strictEqual(logQuickFixIsDisplayed.calledOnce, true);

--- a/src/test/unit/snykIac/codeActions/iacCodeActionsProvider.test.ts
+++ b/src/test/unit/snykIac/codeActions/iacCodeActionsProvider.test.ts
@@ -6,7 +6,7 @@ import { IacIssueData, Issue } from '../../../../snyk/common/languageServer/type
 import { WorkspaceFolderResult } from '../../../../snyk/common/services/productService';
 import { ICodeActionAdapter, ICodeActionKindAdapter } from '../../../../snyk/common/vscode/codeAction';
 import { IVSCodeLanguages } from '../../../../snyk/common/vscode/languages';
-import { CodeActionKind, Range, TextDocument } from '../../../../snyk/common/vscode/types';
+import { CodeActionContext, CodeActionKind, Range, TextDocument } from '../../../../snyk/common/vscode/types';
 import { IacCodeActionsProvider } from '../../../../snyk/snykIac/codeActions/iacCodeActionsProvider';
 import { IacIssue } from '../../../../snyk/snykIac/issue';
 
@@ -66,7 +66,7 @@ suite('IaC code actions provider', () => {
     } as unknown as TextDocument;
 
     // act
-    const codeActions = issuesActionsProvider.provideCodeActions(document, {} as Range);
+    const codeActions = issuesActionsProvider.provideCodeActions(document, {} as Range, {} as CodeActionContext);
 
     // verify
     strictEqual(codeActions?.length, 1);
@@ -82,7 +82,7 @@ suite('IaC code actions provider', () => {
     } as unknown as TextDocument;
 
     // act
-    issuesActionsProvider.provideCodeActions(document, {} as Range);
+    issuesActionsProvider.provideCodeActions(document, {} as Range, {} as CodeActionContext);
 
     // verify
     strictEqual(logQuickFixIsDisplayed.calledOnce, true);

--- a/src/test/unit/snykOss/ossService.test.ts
+++ b/src/test/unit/snykOss/ossService.test.ts
@@ -7,11 +7,12 @@ import { ILanguageServer } from '../../../snyk/common/languageServer/languageSer
 import { OssIssueData, ScanProduct, ScanStatus } from '../../../snyk/common/languageServer/types';
 import { IProductService } from '../../../snyk/common/services/productService';
 import { IViewManagerService } from '../../../snyk/common/services/viewManagerService';
+import { ICodeActionAdapter, ICodeActionKindAdapter } from '../../../snyk/common/vscode/codeAction';
 import { ExtensionContext } from '../../../snyk/common/vscode/extensionContext';
 import { IVSCodeLanguages } from '../../../snyk/common/vscode/languages';
 import { IVSCodeWorkspace } from '../../../snyk/common/vscode/workspace';
+import { IOssSuggestionWebviewProvider } from '../../../snyk/snykOss/interfaces';
 import { OssService } from '../../../snyk/snykOss/ossService';
-import { OssDetailPanelProvider } from '../../../snyk/snykOss/providers/ossDetailPanelProvider';
 import { LanguageServerMock } from '../mocks/languageServer.mock';
 import { LoggerMock } from '../mocks/logger.mock';
 
@@ -31,7 +32,9 @@ suite('OSS Service', () => {
     service = new OssService(
       {} as ExtensionContext,
       {} as IConfiguration,
-      {} as OssDetailPanelProvider,
+      {} as IOssSuggestionWebviewProvider,
+      {} as ICodeActionAdapter,
+      { getQuickFix: sinon.fake() } as ICodeActionKindAdapter,
       viewManagerService,
       {
         getWorkspaceFolders: () => [''],

--- a/src/test/unit/snykOss/providers/ossCodeActionsProvider.test.ts
+++ b/src/test/unit/snykOss/providers/ossCodeActionsProvider.test.ts
@@ -1,0 +1,118 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import { CodeAction, CodeActionContext, CodeActionKind, Range, TextDocument } from 'vscode';
+import { IAnalytics } from '../../../../snyk/common/analytics/itly';
+import { OpenCommandIssueType, OpenIssueCommandArg } from '../../../../snyk/common/commands/types';
+import { SNYK_OPEN_ISSUE_COMMAND } from '../../../../snyk/common/constants/commands';
+import { Issue, IssueSeverity, OssIssueData } from '../../../../snyk/common/languageServer/types';
+import { WorkspaceFolderResult } from '../../../../snyk/common/services/productService';
+import { ICodeActionAdapter, ICodeActionKindAdapter } from '../../../../snyk/common/vscode/codeAction';
+import { IVSCodeLanguages } from '../../../../snyk/common/vscode/languages';
+import { OssCodeActionsProvider } from '../../../../snyk/snykOss/providers/ossCodeActionsProvider';
+
+suite('OSS code actions provider', () => {
+  let ossActionsProvider: OssCodeActionsProvider;
+  let logQuickFixIsDisplayed: sinon.SinonSpy;
+  let rangeMock: Range;
+
+  setup(() => {
+    const ossResults = new Map<string, WorkspaceFolderResult<OssIssueData>>();
+    ossResults.set('folderName', [
+      {
+        filePath: '//folderName//package.json',
+        additionalData: {},
+      } as unknown as Issue<OssIssueData>,
+    ]);
+
+    logQuickFixIsDisplayed = sinon.fake();
+    const analytics = {
+      logQuickFixIsDisplayed,
+    } as unknown as IAnalytics;
+
+    const codeActionAdapter = {
+      create: (_: string, _kind?: CodeActionKind) => ({
+        command: {},
+      }),
+    } as ICodeActionAdapter;
+
+    const codeActionKindAdapter = {
+      getQuickFix: sinon.fake(),
+    } as ICodeActionKindAdapter;
+
+    rangeMock = {
+      contains: () => true,
+    } as unknown as Range;
+
+    ossActionsProvider = new OssCodeActionsProvider(
+      {} as IVSCodeLanguages,
+      codeActionAdapter,
+      codeActionKindAdapter,
+      ossResults,
+      analytics,
+    );
+  });
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('Provides the most severe vulnerability CodeAction', () => {
+    // arrange
+    const document = {
+      uri: {
+        fsPath: '//folderName//package.json',
+      },
+    } as unknown as TextDocument;
+
+    const clickedRange = {} as Range;
+    const context = {} as CodeActionContext;
+
+    const vulnerabilities = [
+      {
+        id: 'vulnerability1',
+        severity: IssueSeverity.High,
+      },
+      {
+        id: 'vulnerability2',
+        severity: IssueSeverity.Medium,
+      },
+      {
+        id: 'vulnerability3',
+        severity: IssueSeverity.Critical,
+      },
+    ] as Issue<OssIssueData>[];
+
+    const mostSevereVulnerability = {
+      id: 'vulnerability3',
+      severity: IssueSeverity.Critical,
+    } as Issue<OssIssueData>;
+
+    const codeActions = [
+      {
+        command: {
+          command: SNYK_OPEN_ISSUE_COMMAND,
+          title: SNYK_OPEN_ISSUE_COMMAND,
+          arguments: [
+            {
+              issueType: OpenCommandIssueType.OssVulnerability,
+              issue: mostSevereVulnerability,
+            } as OpenIssueCommandArg,
+          ],
+        },
+      },
+    ] as CodeAction[];
+
+    sinon.stub(ossActionsProvider, 'getIssueRange').returns(rangeMock);
+    // stubbing private methods workaround is to cast to any
+    sinon.stub(ossActionsProvider, <any>'getVulnerabilities').returns(vulnerabilities);
+    sinon.stub(ossActionsProvider, <any>'getMostSevereVulnerability').returns(mostSevereVulnerability);
+    sinon.stub(ossActionsProvider, <any>'getActions').returns(codeActions);
+
+    // act
+    const result = ossActionsProvider.provideCodeActions(document, clickedRange, context);
+
+    // assert
+    sinon.assert.calledOnce(logQuickFixIsDisplayed);
+    assert.deepStrictEqual(result, codeActions);
+  });
+});


### PR DESCRIPTION
### Description

_This PR should reintroduced the `Show the most severe vulnerability` OSS CodeAction._

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots
![Screenshot 2023-11-21 at 15 47 03](https://github.com/snyk/vscode-extension/assets/16223568/ab37d30e-ce31-4fcf-aaea-ab4734cddb43)

