### PR TITLE
chore: change preview release branch to release OSS via LS as preview [HEAD-943]

### DIFF
--- a/.github/workflows/release-preview.yaml
+++ b/.github/workflows/release-preview.yaml
@@ -2,7 +2,8 @@ name: Build and Release "Preview"
 on:
   push:
     branches:
-      - main
+      # TODO: revert back to main once this feature is released
+      - feat/HEAD-78_oss_via_ls
 jobs:
   build:
     uses: snyk/vscode-extension/.github/workflows/ci.yaml@main


### PR DESCRIPTION
### Description

_Updates the preview release branch to `feat/HEAD-78_oss_via_ls` so that people can test this new feature before release._
