### PR TITLE
fix: oss with multi-module projects

### DIFF
--- a/src/snyk/common/commands/commandController.ts
+++ b/src/snyk/common/commands/commandController.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 import _ from 'lodash';
-import path from 'path';
 import { IAuthenticationService } from '../../base/services/authenticationService';
 import { ScanModeService } from '../../base/services/scanModeService';
 import { createDCIgnore as createDCIgnoreUtil } from '../../snykCode/utils/ignoreFileUtils';
@@ -122,7 +121,7 @@ export class CommandController {
       });
     } else if (arg.issueType == OpenCommandIssueType.OssVulnerability) {
       const issueArgs = arg.issue as CodeIssueCommandArg;
-      const folderPath = path.dirname(issueArgs.filePath);
+      const folderPath = issueArgs.folderPath;
       const issue = this.ossService.getIssue(folderPath, issueArgs.id);
 
       if (!issue) {

--- a/src/snyk/snykOss/interfaces.ts
+++ b/src/snyk/snykOss/interfaces.ts
@@ -10,6 +10,7 @@ export interface IOssSuggestionWebviewProvider extends IWebViewProvider<Issue<Os
 export type OssIssueCommandArg = Issue<OssIssueData> & {
   matchingIdVulnerabilities: Issue<OssIssueData>[];
   overviewHtml: string;
+  folderPath: string;
 };
 
 export type OssResult = OssFileResult[] | OssFileResult;

--- a/src/snyk/snykOss/providers/ossVulnerabilityTreeProvider.ts
+++ b/src/snyk/snykOss/providers/ossVulnerabilityTreeProvider.ts
@@ -88,7 +88,7 @@ export default class OssIssueTreeProvider extends ProductIssueTreeProvider<OssIs
             internal: {
               severity: ProductIssueTreeProvider.getSeverityComparatorIndex(issue.severity),
             },
-            command: this.getOpenIssueCommand(issue, '', '', filteredIssues),
+            command: this.getOpenIssueCommand(issue, folderPath, '', filteredIssues),
           });
         });
 
@@ -185,7 +185,7 @@ export default class OssIssueTreeProvider extends ProductIssueTreeProvider<OssIs
 
   getOpenIssueCommand(
     issue: Issue<OssIssueData>,
-    _folderPath: string,
+    folderPath: string,
     _filePath: string,
     filteredIssues: Issue<OssIssueData>[],
   ): Command {
@@ -195,13 +195,17 @@ export default class OssIssueTreeProvider extends ProductIssueTreeProvider<OssIs
       arguments: [
         {
           issueType: OpenCommandIssueType.OssVulnerability,
-          issue: this.getOssIssueCommandArg(issue, filteredIssues),
+          issue: this.getOssIssueCommandArg(issue, folderPath, filteredIssues),
         } as OpenIssueCommandArg,
       ],
     };
   }
 
-  getOssIssueCommandArg(vuln: Issue<OssIssueData>, filteredVulns: Issue<OssIssueData>[]): OssIssueCommandArg {
+  getOssIssueCommandArg(
+    vuln: Issue<OssIssueData>,
+    folderPath: string,
+    filteredVulns: Issue<OssIssueData>[],
+  ): OssIssueCommandArg {
     const matchingIdVulnerabilities = filteredVulns.filter(v => v.id === vuln.id);
     let overviewHtml = '';
 
@@ -216,6 +220,7 @@ export default class OssIssueTreeProvider extends ProductIssueTreeProvider<OssIs
       ...vuln,
       matchingIdVulnerabilities,
       overviewHtml,
+      folderPath,
     };
   }
 }


### PR DESCRIPTION
### Description

TL;DR: This fixes the display and navigation in the custom UI for Snyk Open Source in multi-module repositories.

Previously, the folder path was assumed to be the parent directory of the package manager manifest file. This is incorrect for multi-module projects, where the opened folder is much higher in the file tree. This PR fixes this, by taking the folder path not from the issue, but from the actual folder configuration.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
