### PR TITLE
fix: add flag to track encoding state of example lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Snyk Security - Code and Open Source Dependencies Changelog
 
+## [2.2.3]
+
+### Fixed
+
+- Snyk Code: Added `isExampleLineEncoded` boolean flag to `CommitChangeLine` type to prevent re-encoding strings in the UI of the example code blocks.
+
 ## [2.2.2]
 
 ### Fixed

--- a/src/snyk/common/languageServer/types.ts
+++ b/src/snyk/common/languageServer/types.ts
@@ -58,6 +58,7 @@ type CommitChangeLine = {
   line: string;
   lineNumber: number;
   lineChange: 'removed' | 'added' | 'none';
+  isExampleLineEncoded?: boolean;
 };
 export type Marker = {
   msg: Point;

--- a/src/snyk/snykCode/utils/htmlEncoder.ts
+++ b/src/snyk/snykCode/utils/htmlEncoder.ts
@@ -2,14 +2,19 @@ import he from 'he';
 import { ExampleCommitFix } from '../../common/languageServer/types';
 
 export const encodeExampleCommitFixes = (exampleCommitFixes: ExampleCommitFix[]): ExampleCommitFix[] => {
-  return exampleCommitFixes.map(exampleCommitFixes => {
+  return exampleCommitFixes.map(example => {
     return {
-      ...exampleCommitFixes,
-      lines: exampleCommitFixes.lines.map(line => {
-        return {
-          ...line,
-          line: he.encode(line.line),
-        };
+      ...example,
+      lines: example.lines.map(commitLine => {
+        if (!commitLine.isExampleLineEncoded) {
+          return {
+            ...commitLine,
+            line: he.encode(commitLine.line),
+            isExampleLineEncoded: true,
+          };
+        }
+
+        return commitLine;
       }),
     };
   });

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
@@ -27,6 +27,7 @@ declare const acquireVsCodeApi: any;
     line: string;
     lineNumber: number;
     lineChange: 'removed' | 'added' | 'none';
+    isExampleLineEncoded?: boolean;
   };
   type Marker = {
     msg: Point;


### PR DESCRIPTION
### Description

This PR adds `isExampleLineEncoded` boolean property to `CommitChangeLine` type to ensure that the `htmlEncoder` function only encodes each line once, preventing double encoding on subsequent function calls.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

🐛  Before

https://github.com/snyk/vscode-extension/assets/1948377/a247141d-0bdb-4c37-ab46-98b644cab940

✅ After

https://github.com/snyk/vscode-extension/assets/1948377/32642656-f031-4011-94cf-c804207b449b





