### PR TITLE
[IDE-189] fix: shortened plugin's name to just Snyk Security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
-# Snyk Security - Code and Open Source Dependencies Changelog
+# Snyk Security Changelog
 
-## [2.3.6
+## [2.3.7]
+
+### Fixes
+- fix: shortened plugin name to just Snyk Security
+
+## [2.3.6]
+
 ### Changes
 - Removed Amplitude telemetry and corresponding setting from VSCode
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "snyk-vulnerability-scanner",
   "//": "Changing display name requires change in general.ts",
-  "displayName": "Snyk Security - Code, Open Source Dependencies, IaC Configurations",
+  "displayName": "Snyk Security",
   "version": "0.0.0",
   "description": "Easily find and fix vulnerabilities in your code, open source dependencies, infrastructure as code configurations with fast and accurate scans.",
   "icon": "media/images/readme/snyk_extension_icon.png",
@@ -52,7 +52,7 @@
   "contributes": {
     "configuration": [
       {
-        "title": "Snyk Security - Code and Open Source Dependencies",
+        "title": "Snyk Security",
         "properties": {
           "snyk.yesCrashReport": {
             "//": "Name starts with y to put it at the end, as configs are sorted alphbetically",

--- a/src/snyk/common/constants/general.ts
+++ b/src/snyk/common/constants/general.ts
@@ -1,5 +1,5 @@
 // Changing this requires changing display name in package.json.
-export const SNYK_NAME = 'Snyk Security - Code, Open Source Dependencies, IaC Configurations';
+export const SNYK_NAME = 'Snyk Security';
 export const SNYK_TOKEN_KEY = 'snyk.token';
 export const SNYK_UNIQUE_EXTENSION_NAME = 'Snyk Vulnerability Scanner';
 export const SNYK_PUBLISHER = 'snyk-security';


### PR DESCRIPTION
### Description

This PR shortens the name of the plugin to just "Snyk Security"
This change is based on multiple complaints from the field and customers.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
