### PR TITLE
fix: custom endpoint validation [IDE-126]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Snyk Security Changelog
+## [2.6.1]
+- Improve the validation of the custom endpoint and change the default to https://api.snyk.io.
+
 ## [2.6.0]
 - Improve UX of AI fixes by adding previews and options
 

--- a/package.json
+++ b/package.json
@@ -103,8 +103,10 @@
           },
           "snyk.advanced.customEndpoint": {
             "type": "string",
-            "markdownDescription": "Sets API endpoint to use for Snyk requests. Useful for custom Snyk setups. E.g. `https://app.eu.snyk.io/api`.",
-            "scope": "window"
+            "markdownDescription": "Sets API endpoint to use for Snyk requests. Useful for custom Snyk setups. E.g. `https://api.eu.snyk.io`.",
+            "scope": "window",
+            "format": "uri",
+            "pattern": "^(https?://)api.?[a-zA-Z0-9]{0,19}.(snyk|snykgov).io$"
           },
           "snyk.advanced.organization": {
             "type": "string",

--- a/package.json
+++ b/package.json
@@ -105,8 +105,7 @@
             "type": "string",
             "markdownDescription": "Sets API endpoint to use for Snyk requests. Useful for custom Snyk setups. E.g. `https://api.eu.snyk.io`.",
             "scope": "window",
-            "format": "uri",
-            "pattern": "^(https?://)api.?[a-zA-Z0-9]{0,19}.(snyk|snykgov).io$"
+            "pattern": "^(|(https?://)api.?[a-zA-Z0-9]{0,19}.(snyk|snykgov).io)$"
           },
           "snyk.advanced.organization": {
             "type": "string",

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -53,7 +53,6 @@ export interface IConfiguration {
   source: string;
 
   authHost: string;
-  baseApiUrl: string;
 
   getToken(): Promise<string | undefined>;
 
@@ -97,8 +96,6 @@ export interface IConfiguration {
 
   isFedramp: boolean;
 
-  analyticsPermitted: boolean;
-
   severityFilter: SeverityFilter;
 
   scanningMode: string | undefined;
@@ -117,8 +114,6 @@ export class Configuration implements IConfiguration {
   private readonly defaultSnykCodeBaseURL = 'https://deeproxy.snyk.io';
   private readonly defaultAuthHost = 'https://snyk.io';
   private readonly defaultOssApiEndpoint = `${this.defaultAuthHost}/api/v1`;
-  private readonly defaultBaseApiHost = 'https://api.snyk.io';
-  private readonly analyticsPermittedEnvironments = { 'app.snyk.io': true, 'app.us.snyk.io': true };
 
   constructor(private processEnv: NodeJS.ProcessEnv = process.env, private workspace: IVSCodeWorkspace) {}
 
@@ -204,13 +199,6 @@ export class Configuration implements IConfiguration {
     return `${hostnameParts[2]}.${hostnameParts[3]}`.includes('snykgov.io');
   }
 
-  get analyticsPermitted(): boolean {
-    if (!this.customEndpoint) return true;
-
-    const hostname = new URL(this.customEndpoint).hostname;
-    return hostname in this.analyticsPermittedEnvironments;
-  }
-
   get snykOssApiEndpoint(): string {
     if (this.customEndpoint) {
       return this.customEndpoint; // E.g. https://app.eu.snyk.io/api
@@ -290,10 +278,6 @@ export class Configuration implements IConfiguration {
 
   get source(): string {
     return Configuration.source;
-  }
-
-  get baseApiUrl(): string {
-    return this.defaultBaseApiHost;
   }
 
   getFeaturesConfiguration(): FeaturesConfiguration {

--- a/src/test/unit/common/configuration.test.ts
+++ b/src/test/unit/common/configuration.test.ts
@@ -229,45 +229,4 @@ suite('Configuration', () => {
       strictEqual(configuration.isFedramp, false);
     });
   });
-
-  suite('.analyticsPermitted()', () => {
-    test('returns true when no custom endpoint configured', () => {
-      const workspace = stubWorkspaceConfiguration(ADVANCED_CUSTOM_ENDPOINT, undefined);
-
-      const configuration = new Configuration({}, workspace);
-      strictEqual(configuration.analyticsPermitted, true);
-    });
-
-    test('returns true for app.snyk.io', () => {
-      const customEndpoint = 'https://app.snyk.io';
-      const workspace = stubWorkspaceConfiguration(ADVANCED_CUSTOM_ENDPOINT, customEndpoint);
-
-      const configuration = new Configuration({}, workspace);
-      strictEqual(configuration.analyticsPermitted, true);
-    });
-
-    test('returns true for app.us.snyk.io', () => {
-      const customEndpoint = 'https://app.us.snyk.io';
-      const workspace = stubWorkspaceConfiguration(ADVANCED_CUSTOM_ENDPOINT, customEndpoint);
-
-      const configuration = new Configuration({}, workspace);
-      strictEqual(configuration.analyticsPermitted, true);
-    });
-
-    test('returns false for app.snykgov.io', () => {
-      const customEndpoint = 'https://app.snykgov.io';
-      const workspace = stubWorkspaceConfiguration(ADVANCED_CUSTOM_ENDPOINT, customEndpoint);
-
-      const configuration = new Configuration({}, workspace);
-      strictEqual(configuration.analyticsPermitted, false);
-    });
-
-    test('returns false for app.eu.snyk.io', () => {
-      const customEndpoint = 'https://app.eu.snyk.io';
-      const workspace = stubWorkspaceConfiguration(ADVANCED_CUSTOM_ENDPOINT, customEndpoint);
-
-      const configuration = new Configuration({}, workspace);
-      strictEqual(configuration.analyticsPermitted, false);
-    });
-  });
 });


### PR DESCRIPTION
### Description

Improves the validation so that only `http(s)://api.` APIs are configured in the custom endpoint field.

Tested manually by running the extension with the latest CLI.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs
<img width="782" alt="Screenshot 2024-05-01 at 09 32 31" src="https://github.com/snyk/vscode-extension/assets/81559517/7875283f-9e66-4d1e-8612-61f81a81cfc8">
<img width="839" alt="Screenshot 2024-05-01 at 09 32 26" src="https://github.com/snyk/vscode-extension/assets/81559517/5072f514-9ea2-4656-b7ad-08bdd84748b0">


