### PR TITLE
feat: add Snyk Code feature flag to settings and configuration [IDE-274]

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,13 @@
             "title": "Preview feature toggles",
             "description": "Preview features that are currently in development. Setting keys will be removed when features become stable.",
             "propertyNames": true,
-            "properties": {}
+            "properties": {
+              "snykCodeLsp": {
+                "type": "boolean",
+                "default": false,
+                "description": "Enable Snyk Code Panel Rendering via Language Server Protocol."
+              }
+            }
           }
         }
       }

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -45,6 +45,7 @@ export interface SeverityFilter {
 
 export type PreviewFeatures = {
   advisor: boolean | undefined;
+  snykCodeLsp: boolean | undefined;
 };
 
 export interface IConfiguration {
@@ -423,6 +424,7 @@ export class Configuration implements IConfiguration {
   getPreviewFeatures(): PreviewFeatures {
     const defaultSetting: PreviewFeatures = {
       advisor: false,
+      snykCodeLsp: false,
     };
 
     const userSetting =

--- a/src/snyk/common/languageServer/settings.ts
+++ b/src/snyk/common/languageServer/settings.ts
@@ -33,6 +33,7 @@ export type ServerSettings = {
   // Trusted folders feature
   enableTrustedFoldersFeature?: string;
   trustedFolders?: string[];
+  isSnykCodeLsp?: boolean;
 
   // Snyk integration settings
   integrationName?: string;
@@ -75,6 +76,7 @@ export class LanguageServerSettings {
       integrationName: CLI_INTEGRATION_NAME,
       integrationVersion: await Configuration.getVersion(),
       deviceId: user.anonymousId,
+      isSnykCodeLsp: configuration.getPreviewFeatures().snykCodeLsp,
     };
   }
 }

--- a/src/test/unit/common/configuration.test.ts
+++ b/src/test/unit/common/configuration.test.ts
@@ -186,12 +186,14 @@ suite('Configuration', () => {
 
     deepStrictEqual(configuration.getPreviewFeatures(), {
       advisor: false,
+      snykCodeLsp: false,
     } as PreviewFeatures);
   });
 
   test('Preview features: some features enabled', () => {
     const previewFeatures = {
       advisor: false,
+      snykCodeLsp: false,
     } as PreviewFeatures;
     const workspace = stubWorkspaceConfiguration(FEATURES_PREVIEW_SETTING, previewFeatures);
 

--- a/src/test/unit/common/languageServer/languageServer.test.ts
+++ b/src/test/unit/common/languageServer/languageServer.test.ts
@@ -58,6 +58,7 @@ suite('Language Server', () => {
       getPreviewFeatures() {
         return {
           advisor: false,
+          snykCodeLsp: false,
         };
       },
       getFeaturesConfiguration() {
@@ -218,6 +219,7 @@ suite('Language Server', () => {
         trustedFolders: ['/trusted/test/folder'],
         insecure: 'true',
         scanningMode: 'auto',
+        isSnykCodeLsp: false,
       };
 
       deepStrictEqual(await languageServer.getInitializationOptions(), expectedInitializationOptions);

--- a/src/test/unit/common/languageServer/middleware.test.ts
+++ b/src/test/unit/common/languageServer/middleware.test.ts
@@ -34,6 +34,7 @@ suite('Language Server: Middleware', () => {
       getPreviewFeatures: () => {
         return {
           advisor: false,
+          snykCodeLsp: false,
         };
       },
       getFeaturesConfiguration() {

--- a/src/test/unit/common/languageServer/settings.test.ts
+++ b/src/test/unit/common/languageServer/settings.test.ts
@@ -14,6 +14,7 @@ suite('LanguageServerSettings', () => {
         // eslint-disable-next-line @typescript-eslint/require-await
         getToken: async () => 'snyk-token',
         getFeaturesConfiguration: () => ({}), // iacEnabled, codeSecurityEnabled, codeQualityEnabled are undefined
+        getPreviewFeatures: () => ({ snykCodeLsp: true }),
         getCliPath: () => '/path/to/cli',
         getAdditionalCliParameters: () => '--all-projects -d',
         getTrustedFolders: () => ['/trusted/path'],


### PR DESCRIPTION
### Description

- Added a new feature flag `snykCodeLsp` to enable the Snyk Code Panel Rendering via LSP.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs
