### PR TITLE
refactor: initialisation of feature flag status [IDE-346]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,12 @@
 # Snyk Security Changelog
 
-## [2.12.3]
-- update to LS protocol version 12
-
 ## [2.12.2]
-- Add CSS rules for `.light-only` and `.dark-only` to the LSP implementation. This allows the LSP to apply different styles based on the current theme.
+- update to LS protocol version 12
+- Refactors the feature flag logic into its own service.
 
 ## [2.12.1]
 - Fix applying AI fixes on Windows.
+- Add CSS rules for `.light-only` and `.dark-only` to the LSP implementation. This allows the LSP to apply different styles based on the current theme.
 
 ## [2.12.0]
 - Fix Code Suggestion rendering issue on Windows.

--- a/src/snyk/base/modules/baseSnykModule.ts
+++ b/src/snyk/base/modules/baseSnykModule.ts
@@ -5,6 +5,7 @@ import { ILanguageServer } from '../../common/languageServer/languageServer';
 import { CodeIssueData, IacIssueData } from '../../common/languageServer/types';
 import { ContextService, IContextService } from '../../common/services/contextService';
 import { DownloadService } from '../../common/services/downloadService';
+import { FeatureFlagService } from '../../common/services/featureFlagService';
 import { LearnService } from '../../common/services/learnService';
 import { INotificationService } from '../../common/services/notificationService';
 import { IOpenerService, OpenerService } from '../../common/services/openerService';
@@ -39,6 +40,7 @@ export default abstract class BaseSnykModule implements IBaseSnykModule {
   protected authService: IAuthenticationService;
   protected downloadService: DownloadService;
   protected ossService?: OssService;
+  protected featureFlagService: FeatureFlagService;
 
   protected commandController: CommandController;
   protected scanModeService: ScanModeService;

--- a/src/snyk/base/modules/interfaces.ts
+++ b/src/snyk/base/modules/interfaces.ts
@@ -22,6 +22,7 @@ export interface IBaseSnykModule {
 export interface ISnykLib {
   enableCode(): Promise<void>;
   checkAdvancedMode(): Promise<void>;
+  setupFeatureFlags(): Promise<void>;
 }
 
 export interface IExtension extends IBaseSnykModule, ISnykLib {

--- a/src/snyk/base/modules/snykLib.ts
+++ b/src/snyk/base/modules/snykLib.ts
@@ -7,6 +7,7 @@ import { Logger } from '../../common/logger/logger';
 import { vsCodeCommands } from '../../common/vscode/commands';
 import BaseSnykModule from './baseSnykModule';
 import { ISnykLib } from './interfaces';
+import { FEATURE_FLAGS } from '../../common/constants/featureFlags';
 
 export default class SnykLib extends BaseSnykModule implements ISnykLib {
   private async runFullScan_(): Promise<void> {
@@ -47,6 +48,11 @@ export default class SnykLib extends BaseSnykModule implements ISnykLib {
 
   async checkAdvancedMode(): Promise<void> {
     await this.contextService.setContext(SNYK_CONTEXT.ADVANCED, configuration.shouldShowAdvancedView);
+  }
+
+  async setupFeatureFlags(): Promise<void> {
+    const isEnabled = await this.featureFlagService.fetchFeatureFlag(FEATURE_FLAGS.consistentIgnores);
+    configuration.setFeatureFlag(FEATURE_FLAGS.consistentIgnores, isEnabled);
   }
 
   protected async setWorkspaceContext(workspacePaths: string[]): Promise<void> {

--- a/src/snyk/common/services/featureFlagService.ts
+++ b/src/snyk/common/services/featureFlagService.ts
@@ -1,0 +1,20 @@
+import { IVSCodeCommands } from '../vscode/commands';
+import { FeatureFlagStatus } from '../types';
+import { SNYK_FEATURE_FLAG_COMMAND } from '../constants/commands';
+
+export class FeatureFlagService {
+  constructor(private commandExecutor: IVSCodeCommands) {}
+
+  async fetchFeatureFlag(flagName: string): Promise<boolean> {
+    try {
+      const ffStatus = await this.commandExecutor.executeCommand<FeatureFlagStatus>(
+        SNYK_FEATURE_FLAG_COMMAND,
+        flagName,
+      );
+      return ffStatus?.ok ?? false;
+    } catch (error) {
+      console.warn(`Failed to fetch feature flag ${flagName}: ${error}`);
+      return false;
+    }
+  }
+}

--- a/src/snyk/common/watchers/configurationWatcher.ts
+++ b/src/snyk/common/watchers/configurationWatcher.ts
@@ -17,25 +17,20 @@ import {
   SEVERITY_FILTER_SETTING,
   TRUSTED_FOLDERS,
 } from '../constants/settings';
-import { FEATURE_FLAGS } from '../constants/featureFlags';
 import { ErrorHandler } from '../error/errorHandler';
 import { ILog } from '../logger/interfaces';
 import { errorsLogs } from '../messages/errors';
 import SecretStorageAdapter from '../vscode/secretStorage';
 import { IWatcher } from './interfaces';
 import { IVSCodeCommands } from '../vscode/commands';
-import { SNYK_FEATURE_FLAG_COMMAND } from '../constants/commands';
-import { FeatureFlagStatus } from '../types';
 
 class ConfigurationWatcher implements IWatcher {
-  constructor(private readonly logger: ILog, private commandExecutor: IVSCodeCommands) {}
+  constructor(private readonly logger: ILog) {}
 
   private async onChangeConfiguration(extension: IExtension, key: string): Promise<void> {
     if (key === ADVANCED_ORGANIZATION) {
-      const isEnabled = await this.fetchFeatureFlag(FEATURE_FLAGS.consistentIgnores);
-      configuration.setFeatureFlag(FEATURE_FLAGS.consistentIgnores, isEnabled);
-    }
-    if (key === ADVANCED_ADVANCED_MODE_SETTING) {
+      return extension.setupFeatureFlags();
+    } else if (key === ADVANCED_ADVANCED_MODE_SETTING) {
       return extension.checkAdvancedMode();
     } else if (key === OSS_ENABLED_SETTING) {
       extension.viewManagerService.refreshOssView();
@@ -101,19 +96,6 @@ class ConfigurationWatcher implements IWatcher {
         return extension.runScan();
       }
     });
-  }
-
-  private async fetchFeatureFlag(flagName: string): Promise<boolean> {
-    try {
-      const ffStatus = await this.commandExecutor.executeCommand<FeatureFlagStatus>(
-        SNYK_FEATURE_FLAG_COMMAND,
-        flagName,
-      );
-      return ffStatus?.ok ?? false;
-    } catch (error) {
-      console.warn(`Failed to fetch feature flag ${flagName}: ${error}`);
-      return false;
-    }
   }
 }
 

--- a/src/snyk/common/watchers/configurationWatcher.ts
+++ b/src/snyk/common/watchers/configurationWatcher.ts
@@ -22,7 +22,6 @@ import { ILog } from '../logger/interfaces';
 import { errorsLogs } from '../messages/errors';
 import SecretStorageAdapter from '../vscode/secretStorage';
 import { IWatcher } from './interfaces';
-import { IVSCodeCommands } from '../vscode/commands';
 
 class ConfigurationWatcher implements IWatcher {
   constructor(private readonly logger: ILog) {}

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -119,7 +119,6 @@ class SnykExtension extends SnykLib implements IExtension {
 
     SecretStorageAdapter.init(vscodeContext);
 
-    this.featureFlagService = new FeatureFlagService(vsCodeCommands);
     this.configurationWatcher = new ConfigurationWatcher(Logger);
     this.notificationService = new NotificationService(vsCodeWindow, vsCodeCommands, configuration, Logger);
 
@@ -367,6 +366,10 @@ class SnykExtension extends SnykLib implements IExtension {
     // Wait for LS startup to finish before updating the codeEnabled context
     // The codeEnabled context depends on an LS command
     await this.languageServer.start();
+
+    // feature flags depend on the language server
+    this.featureFlagService = new FeatureFlagService(vsCodeCommands);
+    await this.setupFeatureFlags();
 
     // Fetch feature flag to determine whether to use the new LSP-based rendering.
 

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -74,6 +74,7 @@ import { OssDetailPanelProvider } from './snykOss/providers/ossDetailPanelProvid
 import { OssVulnerabilityCountProvider } from './snykOss/providers/ossVulnerabilityCountProvider';
 import OssIssueTreeProvider from './snykOss/providers/ossVulnerabilityTreeProvider';
 import { OssVulnerabilityCountService } from './snykOss/services/vulnerabilityCount/ossVulnerabilityCountService';
+import { FeatureFlagService } from './common/services/featureFlagService';
 
 class SnykExtension extends SnykLib implements IExtension {
   public async activate(vscodeContext: vscode.ExtensionContext): Promise<void> {
@@ -118,7 +119,8 @@ class SnykExtension extends SnykLib implements IExtension {
 
     SecretStorageAdapter.init(vscodeContext);
 
-    this.configurationWatcher = new ConfigurationWatcher(Logger, vsCodeCommands);
+    this.featureFlagService = new FeatureFlagService(vsCodeCommands);
+    this.configurationWatcher = new ConfigurationWatcher(Logger);
     this.notificationService = new NotificationService(vsCodeWindow, vsCodeCommands, configuration, Logger);
 
     this.statusBarItem.show();

--- a/src/snyk/snykCode/codeSettings.ts
+++ b/src/snyk/snykCode/codeSettings.ts
@@ -1,10 +1,8 @@
 import { IConfiguration } from '../common/configuration/configuration';
-import { SNYK_FEATURE_FLAG_COMMAND, SNYK_GET_SETTINGS_SAST_ENABLED } from '../common/constants/commands';
-import { FEATURE_FLAGS } from '../common/constants/featureFlags';
+import { SNYK_GET_SETTINGS_SAST_ENABLED } from '../common/constants/commands';
 import { SNYK_CONTEXT } from '../common/constants/views';
 import { IContextService } from '../common/services/contextService';
 import { IOpenerService } from '../common/services/openerService';
-import { FeatureFlagStatus } from '../common/types';
 import { IVSCodeCommands } from '../common/vscode/commands';
 
 export interface ICodeSettings {
@@ -45,10 +43,6 @@ export class CodeSettings implements ICodeSettings {
     }
     await this.contextService.setContext(SNYK_CONTEXT.CODE_ENABLED, codeEnabled);
     await this.contextService.setContext(SNYK_CONTEXT.CODE_LOCAL_ENGINE_ENABLED, localCodeEngineEnabled);
-
-    // TODO: There is a follow-up task to refactor this to use the new feature flag service
-    const isConsistentIgnoresEnabled = await this.fetchFeatureFlag(FEATURE_FLAGS.consistentIgnores);
-    this.config.setFeatureFlag(FEATURE_FLAGS.consistentIgnores, isConsistentIgnoresEnabled);
 
     return codeEnabled;
   }
@@ -98,19 +92,4 @@ export class CodeSettings implements ICodeSettings {
   }
 
   private sleep = (duration: number) => new Promise(resolve => setTimeout(resolve, duration));
-
-  // TODO: There is a follow-up task to refactor this to use the new feature flag service
-  private async fetchFeatureFlag(flagName: string): Promise<boolean> {
-    try {
-      const ffStatus = await this.commandExecutor.executeCommand<FeatureFlagStatus>(
-        SNYK_FEATURE_FLAG_COMMAND,
-        flagName,
-      );
-      console.log('codeSettings.fetchFeatureFlag: ffStatus:', ffStatus);
-      return ffStatus?.ok ?? false;
-    } catch (error) {
-      console.warn(`Failed to fetch feature flag ${flagName}: ${error}`);
-      return false;
-    }
-  }
 }

--- a/src/test/unit/common/services/featureFlagService.test.ts
+++ b/src/test/unit/common/services/featureFlagService.test.ts
@@ -1,0 +1,28 @@
+import { strictEqual } from 'assert';
+import sinon from 'sinon';
+import { IVSCodeCommands } from '../../../../snyk/common/vscode/commands';
+import { FeatureFlagService } from '../../../../snyk/common/services/featureFlagService';
+import { SNYK_FEATURE_FLAG_COMMAND } from '../../../../snyk/common/constants/commands';
+
+suite('FeatureFlagService', () => {
+  let commands: IVSCodeCommands;
+  const executeCommandFake = sinon.fake();
+  setup(() => {
+    executeCommandFake.resetHistory();
+    commands = {
+      executeCommand: executeCommandFake,
+    } as IVSCodeCommands;
+  });
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('getCodeLesson executes correct command', async () => {
+    const featureFlagService = new FeatureFlagService(commands);
+
+    await featureFlagService.fetchFeatureFlag('test');
+    strictEqual(executeCommandFake.calledOnce, true);
+    strictEqual(executeCommandFake.calledWith(SNYK_FEATURE_FLAG_COMMAND, 'test'), true);
+  });
+});

--- a/src/test/unit/snykCode/codeSettings.test.ts
+++ b/src/test/unit/snykCode/codeSettings.test.ts
@@ -12,7 +12,6 @@ suite('Snyk Code Settings', () => {
   let setContextFake: SinonSpy;
   let setFeatureFlagFake: SinonSpy;
   let contextService: IContextService;
-  let config: IConfiguration;
 
   setup(() => {
     setContextFake = sinon.fake();
@@ -26,11 +25,7 @@ suite('Snyk Code Settings', () => {
       viewContext: {},
     };
 
-    config = {
-      setFeatureFlag: setFeatureFlagFake,
-    } as unknown as IConfiguration;
-
-    settings = new CodeSettings(contextService, config, {} as IOpenerService, {} as IVSCodeCommands);
+    settings = new CodeSettings(contextService, {} as IConfiguration, {} as IOpenerService, {} as IVSCodeCommands);
   });
 
   teardown(() => {


### PR DESCRIPTION
### Description

Refactors the logic used for initialising the feature flag status at startup.

To test, run the VSCode sandbox then:
- configure the organisation used in Snyk Settings to be one without `snykCodeConsistentIgnores`
- run a scan (Code at least) and open a vulnerability to see the existing suggestion panel
- restart VSCode
- configure the organisatio nused in Snyk Settings to be one with `snykCodeConsistentIgnores` (e.g. `ide-consistent-ignores-test`)
- run a scan (Code at least) and open a vulnerability to see the new suggestion panel

Note! We are aware of a bug where changing the organisation in Snyk Settings does not trigger an update of the organisation in LS and so the feature flag status doesn't change because the org hasn't, as far as the command in LS is aware.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing
