### PR TITLE
fix: synchronizing README from snyk/user-docs

### DIFF
--- a/.github/workflows/readme-sync.yaml
+++ b/.github/workflows/readme-sync.yaml
@@ -52,7 +52,7 @@ jobs:
             echo "No documentation changes detected, exiting."
           fi
         env:
-          SOURCE_PATH: ./docs/docs/integrations/ide-tools/visual-studio-code-extension/README.md
+          SOURCE_PATH: ./docs/docs/integrate-with-snyk/use-snyk-in-your-ide/visual-studio-code-extension/README.md
           FILE_TO_COMMIT: README.md
           DESTINATION_REPOSITORY: vscode-extension
           DESTINATION_BRANCH: docs/automatic-gitbook-update


### PR DESCRIPTION
### Description

This PR fixes synchronisation pipeline of Snyk User docs back to repository's README by fixing a folder path.
