### PR TITLE
fix: lower strictness of custom endpoint regex validation [IDE-352]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Snyk Security Changelog
-## [2.7.1]
+## [2.8.1]
+- Lower the strictness of custom endpoint regex validation so that single tenant APIs are allowed.
+
+## [2.8.0]
 - Add the Issue View Options panel to the Snyk Security Settings.
 
 ## [2.7.0]

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
             "type": "string",
             "markdownDescription": "Sets API endpoint to use for Snyk requests. Useful for custom Snyk setups. E.g. `https://api.eu.snyk.io`.",
             "scope": "window",
-            "pattern": "^(|(https?://)api.?[a-zA-Z0-9]{0,19}.(snyk|snykgov).io)$"
+            "pattern": "^(|(https?://)api.*.(snyk|snykgov).io)$"
           },
           "snyk.advanced.organization": {
             "type": "string",


### PR DESCRIPTION
### Description

Lowers the strictness of the regex validation for the custom endpoint so that it just checks that it starts with `api` and ends with `(snyk|snykgov).io`.

Can see all the single tenant endpoints [here](https://github.com/snyk/app-ui/blob/572e96a5d9dbd5502b52c6b5861007319f7b4578/docs/runbook.md?plain=1#L34). The API endpoint for this bug can be found [here](https://github.com/snyk/polaris-instances/blob/72739d6d01bee2fcd60070c8d21f749b57b5e3c0/polaris-prod-st-morganstanley-1/backstage.yaml#L11). 

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

Before:
![Screenshot 2024-05-23 at 09 06 49](https://github.com/snyk/vscode-extension/assets/81559517/69027e83-d078-445f-b93a-ca192d360327)

After:
![Screenshot 2024-05-23 at 09 09 18](https://github.com/snyk/vscode-extension/assets/81559517/0ca0c4d0-4012-4fb3-8331-747056906531)
![Screenshot 2024-05-23 at 09 09 15](https://github.com/snyk/vscode-extension/assets/81559517/c7a364c9-d453-4711-abcb-4f6b4da1ea75)
