### PR TITLE
fix: add sentry and amplitude information to github vsix [IDE-351]

### DIFF
--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -61,7 +61,14 @@ jobs:
         run: npm ci
 
       - name: Package VSIX
-        run: echo y | vsce package --no-git-tag-version --no-update-package-json ${{ needs.publish.outputs.new-version }}
+        run: |
+          run: |
+          sed -i \
+              -e 's|${env.SNYK_VSCE_AMPLITUDE_EXPERIMENT_API_KEY}|${{ secrets.SNYK_VSCE_AMPLITUDE_EXPERIMENT_API_KEY }}|g' \
+              -e 's|${env.SNYK_VSCE_SENTRY_DSN_KEY}|${{ secrets.SNYK_VSCE_SENTRY_DSN_KEY }}|g' \
+              snyk.config.json
+
+          echo y | vsce package --no-git-tag-version --no-update-package-json ${{ needs.publish.outputs.new-version }}
 
       - name: Extract release notes
         id: extract-release-notes


### PR DESCRIPTION
### Description

Previously, the sentry and amplitude api information was not added to the github release. Now it is.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
