### PR TITLE
feat: load custom VSCode styling for HTML suggestion panel [IDE-240]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Snyk Security Changelog
+
+## [2.9.2]
+- Injects custom styling for the HTML panel used by Snyk Code for consistent ignores.
+
 ## [2.8.1]
 - Lower the strictness of custom endpoint regex validation so that single tenant APIs are allowed.
 

--- a/media/views/snykCode/suggestion/suggestion_ls.scss
+++ b/media/views/snykCode/suggestion/suggestion_ls.scss
@@ -14,6 +14,7 @@
 
 .tab-item {
     color: var(--vscode-foreground);
+    border-bottom: 1px solid transparent;
 }
 
 .tab-item-icon path {
@@ -28,7 +29,18 @@
 
 .tab-content {
     background-color: var(--vscode-editor-background);
-    border: 1px solid var(--vscode-input-border);
+}
+
+.ignore-details-header,
+.data-flow-header,
+.example-fixes-header {
+  text-transform: uppercase;
+}
+
+.ignore-details-tab,
+.fix-analysis-tab,
+.vuln-overview-tab {
+  text-transform: uppercase;
 }
 
 .example-line-number,

--- a/media/views/snykCode/suggestion/suggestion_ls.scss
+++ b/media/views/snykCode/suggestion/suggestion_ls.scss
@@ -1,0 +1,76 @@
+.ignore-warning {
+    background: #FFF4ED;
+    color: #B6540B;
+    border: 1px solid #E27122;
+}
+
+.ignore-badge {
+    background: #FFF4ED;
+    color: #B6540B;
+    border: 1px solid #E27122;
+}
+
+.tabs-nav {}
+
+.tab-item {
+    color: var(--vscode-foreground);
+}
+
+.tab-item-icon path {
+    fill: var(--tab-item-github-icon-color);
+}
+
+.tab-item:hover {}
+
+.tab-item.is-selected {
+    border-bottom: 3px solid var(--vscode-focusBorder);
+}
+
+.tab-content {
+    background-color: var(--vscode-editor-background);
+    border: 1px solid var(--vscode-input-border);
+}
+
+.example-line-number,
+.example-line>code {
+    color: var(--vscode-editor-foreground);
+}
+
+.example-line.added {
+    background-color: rgb(204, 255, 216);
+}
+
+.example-line.removed {
+    background-color: rgb(255, 215, 213);
+}
+
+.vscode-dark .example-line.removed {
+    background-color: rgba(84, 36, 38, 1);
+    color: #fff;
+}
+
+.vscode-dark .example-line.added {
+    background-color: rgba(28, 68, 40, 1);
+    color: #fff;
+}
+
+.vscode-dark .example-line.added>code {
+    color: #fff;
+    background-color: transparent;
+}
+
+.vscode-dark .example-line.removed>code {
+    color: #fff;
+    background-color: transparent;
+}
+
+.vscode-high-contrast:not(.vscode-high-contrast-light) .example-line.removed {
+    background-color: #542426;
+    color: #fff;
+}
+
+.vscode-dark .added,
+.vscode-high-contrast:not(.vscode-high-contrast-light) .example-line.added {
+    background-color: #1C4428;
+    color: #fff;
+}        

--- a/media/views/snykCode/suggestion/suggestion_ls.scss
+++ b/media/views/snykCode/suggestion/suggestion_ls.scss
@@ -74,3 +74,21 @@
     background-color: #1C4428;
     color: #fff;
 }        
+
+.ignore-action-container {
+    background-color: var(--vscode-editor-background);
+    background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.075), rgba(255, 255, 255, 0.075));
+    box-shadow: 0 -1px 3px rgba(0, 0, 0, .05);
+}
+
+.ignore-button.secondary {
+    border: 1px solid var(--vscode-textLink-foreground);
+    color: var(--vscode-textLink-foreground);
+}
+
+.ignore-button.secondary:hover,
+.ignore-button.secondary:active {
+  background: var(--vscode-button-hoverBackground);
+  border-color: var(--vscode-button-hoverBackground);
+  color: var(--vscode-button-foreground);
+}

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
@@ -128,7 +128,9 @@ export class CodeSuggestionWebviewProvider
           'suggestion_ls.css',
         );
         const ideStyle = readFileSync(ideStylePath.path, 'utf8');
-        html = html.replace('${ideStyle}', ideStyle);
+        html = html.replace('${ideStyle}', '<style nonce=${nonce}>' + ideStyle + '</style>');
+        const nonce = getNonce();
+        html = html.replaceAll('${nonce}', nonce);
 
         this.panel.webview.html = html;
       } else {


### PR DESCRIPTION
### Description

Duplicates custom VSCode styling for the suggestion panel from `media/views/snykCode/suggestion/suggestion.scss` and injects it into the HTML after compiling `.scss` file to `.css`. This requires https://github.com/snyk/snyk-ls/pull/522 so that `${ideStyle}` is available.

To test:
- Run `make build-debug` in `snyk-ls` in the branch from https://github.com/snyk/snyk-ls/pull/522
- Run the sandbox using the debugger.
- Replace the LS path in the sandbox to the path for the local LS and disable automatically managing the binaries
- Make sure to use an org that has the `snykCodeConsistentIgnores` FF enabled (e.g. `ide-consistent-ignores-test`)
- Navigate to a Snyk Code vulnerability

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

https://github.com/snyk/vscode-extension/assets/81559517/9cfe6594-f997-4633-8ff2-099c3677d637

