### PR TITLE
feat: show message if no option is configured [IDE-332]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Snyk Security Changelog
+## [2.8.2]
+- Add warning messages in the Tree View for the issue view options used in consistent ignores.
+
 ## [2.8.1]
 - Lower the strictness of custom endpoint regex validation so that single tenant APIs are allowed.
 

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -38,6 +38,8 @@ export type FeaturesConfiguration = {
 export interface IssueViewOptions {
   ignoredIssues: boolean;
   openIssues: boolean;
+
+  [option: string]: boolean;
 }
 
 export interface SeverityFilter {

--- a/src/snyk/common/messages/analysisMessages.ts
+++ b/src/snyk/common/messages/analysisMessages.ts
@@ -4,6 +4,9 @@ export const messages = {
   clickToProblem: 'Click here to see the problem.',
   scanRunning: 'Scanning...',
   allSeverityFiltersDisabled: 'Please enable severity filters to see the results.',
+  allIssueViewOptionsDisabled: 'Adjust your Issue View Options to see all issues.',
+  openIssueViewOptionDisabled: 'Adjust your Issue View Options to see open issues.',
+  ignoredIssueViewOptionDisabled: 'Adjust your Issue View Options to see ignored issues.',
   duration: (time: string, day: string): string => `Analysis finished at ${time}, ${day}`,
   noWorkspaceTrustDescription:
     'None of workspace folders were trusted. If you trust the workspace, you can add it to the list of trusted folders in the extension settings, or when prompted by the extension next time.',

--- a/src/snyk/common/views/analysisTreeNodeProvider.ts
+++ b/src/snyk/common/views/analysisTreeNodeProvider.ts
@@ -7,6 +7,8 @@ import { messages } from '../messages/analysisMessages';
 import { NODE_ICONS, TreeNode } from './treeNode';
 import { TreeNodeProvider } from './treeNodeProvider';
 import { SNYK_NAME_EXTENSION, SNYK_PUBLISHER } from '../constants/general';
+import { configuration } from '../configuration/instance';
+import { FEATURE_FLAGS } from '../constants/featureFlags';
 
 export abstract class AnalysisTreeNodeProvider extends TreeNodeProvider {
   constructor(protected readonly configuration: IConfiguration, private statusProvider: AnalysisStatusProvider) {
@@ -49,6 +51,11 @@ export abstract class AnalysisTreeNodeProvider extends TreeNodeProvider {
   }
 
   protected getNoIssueViewOptionsSelectedTreeNode(numIssues: number, ignoredIssueCount: number): TreeNode | null {
+    const isIgnoresEnabled = configuration.getFeatureFlag(FEATURE_FLAGS.consistentIgnores);
+    if (!isIgnoresEnabled) {
+      return null;
+    }
+
     const anyOptionEnabled = Object.values<boolean>(this.configuration.issueViewOptions).find(enabled => !!enabled);
     if (!anyOptionEnabled) {
       return new TreeNode({

--- a/src/snyk/common/views/analysisTreeNodeProvider.ts
+++ b/src/snyk/common/views/analysisTreeNodeProvider.ts
@@ -2,10 +2,11 @@ import _ from 'lodash';
 import * as path from 'path';
 import { AnalysisStatusProvider } from '../analysis/statusProvider';
 import { IConfiguration } from '../configuration/configuration';
-import { SNYK_SHOW_LS_OUTPUT_COMMAND } from '../constants/commands';
+import { SNYK_SHOW_LS_OUTPUT_COMMAND, VSCODE_GO_TO_SETTINGS_COMMAND } from '../constants/commands';
 import { messages } from '../messages/analysisMessages';
 import { NODE_ICONS, TreeNode } from './treeNode';
 import { TreeNodeProvider } from './treeNodeProvider';
+import { SNYK_NAME_EXTENSION, SNYK_PUBLISHER } from '../constants/general';
 
 export abstract class AnalysisTreeNodeProvider extends TreeNodeProvider {
   constructor(protected readonly configuration: IConfiguration, private statusProvider: AnalysisStatusProvider) {
@@ -45,6 +46,46 @@ export abstract class AnalysisTreeNodeProvider extends TreeNodeProvider {
     return new TreeNode({
       text: messages.allSeverityFiltersDisabled,
     });
+  }
+
+  protected getNoIssueViewOptionsSelectedTreeNode(numIssues: number, ignoredIssueCount: number): TreeNode | null {
+    const anyOptionEnabled = Object.values<boolean>(this.configuration.issueViewOptions).find(enabled => !!enabled);
+    if (!anyOptionEnabled) {
+      return new TreeNode({
+        text: messages.allIssueViewOptionsDisabled,
+      });
+    }
+
+    if (numIssues === 0) {
+      return null;
+    }
+
+    // if only ignored issues are enabled, then let the customer know to adjust their settings
+    if (numIssues === ignoredIssueCount && !this.configuration.issueViewOptions.ignoredIssues) {
+      return new TreeNode({
+        text: messages.ignoredIssueViewOptionDisabled,
+        command: {
+          command: VSCODE_GO_TO_SETTINGS_COMMAND,
+          title: '',
+          arguments: [`@ext:${SNYK_PUBLISHER}.${SNYK_NAME_EXTENSION}`],
+        },
+      });
+    }
+
+    // if only open issues are enabled, then let the customer know to adjust their settings
+    if (ignoredIssueCount === 0 && !this.configuration.issueViewOptions.openIssues) {
+      return new TreeNode({
+        text: messages.openIssueViewOptionDisabled,
+        command: {
+          command: VSCODE_GO_TO_SETTINGS_COMMAND,
+          title: '',
+          arguments: [`@ext:${SNYK_PUBLISHER}.${SNYK_NAME_EXTENSION}`],
+        },
+      });
+    }
+
+    // if all options are enabled we don't want to show a warning
+    return null;
   }
 
   protected getErrorEncounteredTreeNode(scanPath?: string): TreeNode {

--- a/src/snyk/common/views/issueTreeProvider.ts
+++ b/src/snyk/common/views/issueTreeProvider.ts
@@ -85,13 +85,25 @@ export abstract class ProductIssueTreeProvider<T> extends AnalysisTreeNodeProvid
 
     nodes.sort(this.compareNodes);
 
+    const totalIssueCount = this.getTotalIssueCount();
+    const ignoredIssueCount = this.getIgnoredCount();
+
     const topNodes: (TreeNode | null)[] = [
       new TreeNode({
-        text: this.getIssueFoundText(this.getTotalIssueCount()),
+        text: this.getIssueFoundText(totalIssueCount, ignoredIssueCount),
       }),
       this.getFixableIssuesNode(this.getFixableCount()),
-      this.getNoSeverityFiltersSelectedTreeNode(),
     ];
+    const noSeverityFiltersSelectedWarning = this.getNoSeverityFiltersSelectedTreeNode();
+    if (noSeverityFiltersSelectedWarning != null) {
+      topNodes.push(noSeverityFiltersSelectedWarning);
+    } else {
+      const noIssueViewOptionSelectedWarning = this.getNoIssueViewOptionsSelectedTreeNode(
+        totalIssueCount,
+        ignoredIssueCount,
+      );
+      topNodes.push(noIssueViewOptionSelectedWarning);
+    }
 
     nodes.unshift(...topNodes.filter((n): n is TreeNode => n !== null));
     return nodes;
@@ -113,6 +125,11 @@ export abstract class ProductIssueTreeProvider<T> extends AnalysisTreeNodeProvid
 
   getFixableCount(): number {
     return this.getFilteredIssues().filter(issue => this.isFixableIssue(issue)).length;
+  }
+
+  getIgnoredCount(): number {
+    const ignoredIssues = this.getFilteredIssues().filter(issue => issue.isIgnored);
+    return ignoredIssues.length;
   }
 
   isFixableIssue(_issue: Issue<T>) {
@@ -255,7 +272,7 @@ export abstract class ProductIssueTreeProvider<T> extends AnalysisTreeNodeProvid
     return nodes;
   }
 
-  protected getIssueFoundText(nIssues: number): string {
+  protected getIssueFoundText(nIssues: number, _: number): string {
     return `Snyk found ${!nIssues ? 'no issues! ✅' : `${nIssues} issue${nIssues === 1 ? '' : 's'}`}`;
   }
 

--- a/src/snyk/common/views/issueTreeProvider.ts
+++ b/src/snyk/common/views/issueTreeProvider.ts
@@ -115,7 +115,9 @@ export abstract class ProductIssueTreeProvider<T> extends AnalysisTreeNodeProvid
 
   getFilteredIssues(): Issue<T>[] {
     const folderResults = Array.from(this.productService.result.values());
-    const successfulResults = flatten(folderResults.filter((result): result is Issue<T>[] => Array.isArray(result)));
+    const successfulResults = flatten<Issue<T>>(
+      folderResults.filter((result): result is Issue<T>[] => Array.isArray(result)),
+    );
     return this.filterIssues(successfulResults);
   }
 

--- a/src/snyk/common/views/issueTreeProvider.ts
+++ b/src/snyk/common/views/issueTreeProvider.ts
@@ -9,6 +9,8 @@ import { AnalysisTreeNodeProvider } from '../../common/views/analysisTreeNodePro
 import { INodeIcon, InternalType, NODE_ICONS, TreeNode } from '../../common/views/treeNode';
 import { IVSCodeLanguages } from '../../common/vscode/languages';
 import { Command, Range } from '../../common/vscode/types';
+import { configuration } from '../configuration/instance';
+import { FEATURE_FLAGS } from '../constants/featureFlags';
 
 interface ISeverityCounts {
   [severity: string]: number;

--- a/src/snyk/common/views/issueTreeProvider.ts
+++ b/src/snyk/common/views/issueTreeProvider.ts
@@ -9,8 +9,6 @@ import { AnalysisTreeNodeProvider } from '../../common/views/analysisTreeNodePro
 import { INodeIcon, InternalType, NODE_ICONS, TreeNode } from '../../common/views/treeNode';
 import { IVSCodeLanguages } from '../../common/vscode/languages';
 import { Command, Range } from '../../common/vscode/types';
-import { configuration } from '../configuration/instance';
-import { FEATURE_FLAGS } from '../constants/featureFlags';
 
 interface ISeverityCounts {
   [severity: string]: number;
@@ -97,7 +95,7 @@ export abstract class ProductIssueTreeProvider<T> extends AnalysisTreeNodeProvid
       this.getFixableIssuesNode(this.getFixableCount()),
     ];
     const noSeverityFiltersSelectedWarning = this.getNoSeverityFiltersSelectedTreeNode();
-    if (noSeverityFiltersSelectedWarning != null) {
+    if (noSeverityFiltersSelectedWarning !== null) {
       topNodes.push(noSeverityFiltersSelectedWarning);
     } else {
       const noIssueViewOptionSelectedWarning = this.getNoIssueViewOptionsSelectedTreeNode(

--- a/src/snyk/snykCode/views/securityIssueTreeProvider.ts
+++ b/src/snyk/snykCode/views/securityIssueTreeProvider.ts
@@ -38,9 +38,16 @@ export default class CodeSecurityIssueTreeProvider extends IssueTreeProvider {
     return `${dir} - ${issueCount} ${issueCount === 1 ? 'vulnerability' : 'vulnerabilities'}`;
   }
 
-  protected getIssueFoundText(nIssues: number): string {
+  protected getIssueFoundText(nIssues: number, ignoredIssueCount: number): string {
     if (nIssues > 0) {
-      return nIssues === 1 ? `${nIssues} vulnerability found by Snyk` : `✋ ${nIssues} vulnerabilities found by Snyk`;
+      let text;
+      if (nIssues === 1) {
+        text = `${nIssues} vulnerability found by Snyk`;
+      } else {
+        text = `✋ ${nIssues} vulnerabilities found by Snyk`;
+      }
+      text += `, ${ignoredIssueCount} ignored`;
+      return text;
     } else {
       return '✅ Congrats! No vulnerabilities found!';
     }

--- a/src/snyk/snykCode/views/securityIssueTreeProvider.ts
+++ b/src/snyk/snykCode/views/securityIssueTreeProvider.ts
@@ -8,6 +8,7 @@ import { IViewManagerService } from '../../common/services/viewManagerService';
 import { TreeNode } from '../../common/views/treeNode';
 import { IVSCodeLanguages } from '../../common/vscode/languages';
 import { IssueTreeProvider } from './issueTreeProvider';
+import { FEATURE_FLAGS } from '../../common/constants/featureFlags';
 
 export default class CodeSecurityIssueTreeProvider extends IssueTreeProvider {
   constructor(
@@ -46,7 +47,10 @@ export default class CodeSecurityIssueTreeProvider extends IssueTreeProvider {
       } else {
         text = `✋ ${nIssues} vulnerabilities found by Snyk`;
       }
-      text += `, ${ignoredIssueCount} ignored`;
+      const isIgnoresEnabled = configuration.getFeatureFlag(FEATURE_FLAGS.consistentIgnores);
+      if (isIgnoresEnabled) {
+        text += `, ${ignoredIssueCount} ignored`;
+      }
       return text;
     } else {
       return '✅ Congrats! No vulnerabilities found!';

--- a/src/snyk/snykIac/views/iacIssueTreeProvider.ts
+++ b/src/snyk/snykIac/views/iacIssueTreeProvider.ts
@@ -48,7 +48,7 @@ export default class IacIssueTreeProvider extends ProductIssueTreeProvider<IacIs
     return `${dir} - ${issueCount} ${issueCount === 1 ? 'issue' : 'issues'}`;
   }
 
-  getIssueFoundText(nIssues: number): string {
+  getIssueFoundText(nIssues: number, _: number): string {
     return `Snyk found ${!nIssues ? 'no issues! ✅' : `${nIssues} ${nIssues === 1 ? 'issue' : 'issues'}`}`;
   }
 

--- a/src/snyk/snykOss/providers/ossVulnerabilityTreeProvider.ts
+++ b/src/snyk/snykOss/providers/ossVulnerabilityTreeProvider.ts
@@ -153,7 +153,7 @@ export default class OssIssueTreeProvider extends ProductIssueTreeProvider<OssIs
     return `${dir} - ${issueCount} ${issueCount === 1 ? 'vulnerability' : 'vulnerabilities'}`;
   }
 
-  getIssueFoundText(nIssues: number): string {
+  getIssueFoundText(nIssues: number, _: number): string {
     return `Snyk found ${
       !nIssues ? 'no vulnerabilities! ✅' : `${nIssues} ${nIssues === 1 ? 'vulnerability' : 'vulnerabilities'}`
     }`;

--- a/src/test/integration/issueTreeProvider.test.ts
+++ b/src/test/integration/issueTreeProvider.test.ts
@@ -1,0 +1,194 @@
+import sinon from 'sinon';
+
+import { IConfiguration, IssueViewOptions, SeverityFilter } from '../../snyk/common/configuration/configuration';
+import { IVSCodeLanguages } from '../../snyk/common/vscode/languages';
+import { CodeIssueData } from '../../snyk/common/languageServer/types';
+import { IContextService } from '../../snyk/common/services/contextService';
+import { IProductService } from '../../snyk/common/services/productService';
+import { IssueTreeProvider } from '../../snyk/snykCode/views/issueTreeProvider';
+import { strictEqual } from 'assert';
+
+suite('Code ASecurity Issue Tree Provider', () => {
+  let contextService: IContextService;
+  let config: IConfiguration;
+  let codeService: IProductService<CodeIssueData>;
+  let languages: IVSCodeLanguages;
+
+  let issueTreeProvider: IssueTreeProvider;
+
+  setup(() => {
+    contextService = {
+      shouldShowCodeAnalysis: true,
+    } as unknown as IContextService;
+    config = {
+      issueViewOptions: {
+        ignoredIssues: true,
+        openIssues: true,
+      } as IssueViewOptions,
+      severityFilter: {
+        critical: true,
+        high: true,
+        medium: true,
+        low: true,
+      } as SeverityFilter,
+    } as unknown as IConfiguration;
+    codeService = {
+      isLsDownloadSuccessful: true,
+      isAnyWorkspaceFolderTrusted: true,
+      isAnalysisRunning: false,
+      isAnyResultAvailable: () => true,
+      result: {
+        values: () => [[]],
+      },
+    } as unknown as IProductService<CodeIssueData>;
+    languages = {} as unknown as IVSCodeLanguages;
+  });
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('getRootChildren returns no extra root children', () => {
+    const localCodeService = {
+      ...codeService,
+      result: {
+        values: () => [
+          [
+            {
+              filePath: '//folderName//test.js',
+              isIgnored: false,
+              additionalData: {
+                rule: 'some-rule',
+                hasAIFix: false,
+                isSecurityType: true,
+              },
+            } as unknown as CodeIssueData,
+          ],
+        ],
+      },
+    } as unknown as IProductService<CodeIssueData>;
+
+    issueTreeProvider = new IssueTreeProvider(contextService, localCodeService, config, languages, true);
+
+    sinon.stub(issueTreeProvider, 'getResultNodes').returns([]);
+    const rootChildren = issueTreeProvider.getRootChildren();
+    strictEqual(rootChildren.length, 2);
+    strictEqual(rootChildren[0].label, 'Snyk found 1 issue');
+    strictEqual(rootChildren[1].label, 'There are no vulnerabilities fixable by Snyk DeepCode AI');
+  });
+
+  test('getRootChildren returns a root child for no results', () => {
+    const localCodeService = {
+      ...codeService,
+      result: {
+        values: () => [[]],
+      },
+    } as unknown as IProductService<CodeIssueData>;
+
+    issueTreeProvider = new IssueTreeProvider(contextService, localCodeService, config, languages, true);
+
+    sinon.stub(issueTreeProvider, 'getResultNodes').returns([]);
+    const rootChildren = issueTreeProvider.getRootChildren();
+    strictEqual(rootChildren.length, 2);
+    strictEqual(rootChildren[0].label, 'Snyk found no issues! ✅');
+    strictEqual(rootChildren[1].label, 'There are no vulnerabilities fixable by Snyk DeepCode AI');
+  });
+
+  test('getRootChildren returns a root child for only open but not visible issues', () => {
+    const localCodeService = {
+      ...codeService,
+      result: {
+        values: () => [
+          [
+            {
+              filePath: '//folderName//test.js',
+              additionalData: {
+                rule: 'some-rule',
+                hasAIFix: false,
+                isIgnored: false,
+                isSecurityType: true,
+              },
+            } as unknown as CodeIssueData,
+          ],
+        ],
+      },
+    } as unknown as IProductService<CodeIssueData>;
+
+    config.issueViewOptions.openIssues = false;
+    issueTreeProvider = new IssueTreeProvider(contextService, localCodeService, config, languages, true);
+
+    sinon.stub(issueTreeProvider, 'getResultNodes').returns([]);
+    const rootChildren = issueTreeProvider.getRootChildren();
+    strictEqual(rootChildren.length, 3);
+    strictEqual(rootChildren[0].label, 'Snyk found 1 issue');
+    strictEqual(rootChildren[1].label, 'There are no vulnerabilities fixable by Snyk DeepCode AI');
+    strictEqual(rootChildren[2].label, 'Adjust your Issue View Options to see open issues.');
+    config.issueViewOptions.openIssues = true;
+  });
+
+  test('getRootChildren returns a root child for only ignored but not visible issues', () => {
+    const localCodeService = {
+      ...codeService,
+      result: {
+        values: () => [
+          [
+            {
+              filePath: '//folderName//test.js',
+              isIgnored: true,
+              additionalData: {
+                rule: 'some-rule',
+                hasAIFix: false,
+                isSecurityType: true,
+              },
+            } as unknown as CodeIssueData,
+          ],
+        ],
+      },
+    } as unknown as IProductService<CodeIssueData>;
+
+    config.issueViewOptions.ignoredIssues = false;
+    issueTreeProvider = new IssueTreeProvider(contextService, localCodeService, config, languages, true);
+
+    sinon.stub(issueTreeProvider, 'getResultNodes').returns([]);
+    const rootChildren = issueTreeProvider.getRootChildren();
+    strictEqual(rootChildren.length, 3);
+    strictEqual(rootChildren[0].label, 'Snyk found 1 issue');
+    strictEqual(rootChildren[1].label, 'There are no vulnerabilities fixable by Snyk DeepCode AI');
+    strictEqual(rootChildren[2].label, 'Adjust your Issue View Options to see ignored issues.');
+    config.issueViewOptions.ignoredIssues = true;
+  });
+
+  test('getRootChildren returns a root child for no visible issues', () => {
+    const localCodeService = {
+      ...codeService,
+      result: {
+        values: () => [
+          [
+            {
+              filePath: '//folderName//test.js',
+              isIgnored: false,
+              additionalData: {
+                rule: 'some-rule',
+                hasAIFix: false,
+                isSecurityType: true,
+              },
+            } as unknown as CodeIssueData,
+          ],
+        ],
+      },
+    } as unknown as IProductService<CodeIssueData>;
+
+    config.issueViewOptions.openIssues = false;
+    config.issueViewOptions.ignoredIssues = false;
+    issueTreeProvider = new IssueTreeProvider(contextService, localCodeService, config, languages, true);
+
+    sinon.stub(issueTreeProvider, 'getResultNodes').returns([]);
+    const rootChildren = issueTreeProvider.getRootChildren();
+    strictEqual(rootChildren.length, 3);
+    strictEqual(rootChildren[0].label, 'Snyk found 1 issue');
+    strictEqual(rootChildren[1].label, 'There are no vulnerabilities fixable by Snyk DeepCode AI');
+    strictEqual(rootChildren[2].label, 'Adjust your Issue View Options to see all issues.');
+    config.issueViewOptions.openIssues = true;
+    config.issueViewOptions.ignoredIssues = true;
+  });
+});

--- a/src/test/integration/issueTreeProvider.test.ts
+++ b/src/test/integration/issueTreeProvider.test.ts
@@ -1,16 +1,18 @@
 import sinon from 'sinon';
+import * as vscode from 'vscode';
 
-import { IConfiguration, IssueViewOptions, SeverityFilter } from '../../snyk/common/configuration/configuration';
 import { IVSCodeLanguages } from '../../snyk/common/vscode/languages';
 import { CodeIssueData } from '../../snyk/common/languageServer/types';
 import { IContextService } from '../../snyk/common/services/contextService';
 import { IProductService } from '../../snyk/common/services/productService';
 import { IssueTreeProvider } from '../../snyk/snykCode/views/issueTreeProvider';
 import { strictEqual } from 'assert';
+import { FEATURE_FLAGS } from '../../snyk/common/constants/featureFlags';
+import { configuration } from '../../snyk/common/configuration/instance';
+import { ISSUE_VIEW_OPTIONS_SETTING } from '../../snyk/common/constants/settings';
 
-suite('Code ASecurity Issue Tree Provider', () => {
+suite('Code Issue Tree Provider', () => {
   let contextService: IContextService;
-  let config: IConfiguration;
   let codeService: IProductService<CodeIssueData>;
   let languages: IVSCodeLanguages;
 
@@ -20,18 +22,6 @@ suite('Code ASecurity Issue Tree Provider', () => {
     contextService = {
       shouldShowCodeAnalysis: true,
     } as unknown as IContextService;
-    config = {
-      issueViewOptions: {
-        ignoredIssues: true,
-        openIssues: true,
-      } as IssueViewOptions,
-      severityFilter: {
-        critical: true,
-        high: true,
-        medium: true,
-        low: true,
-      } as SeverityFilter,
-    } as unknown as IConfiguration;
     codeService = {
       isLsDownloadSuccessful: true,
       isAnyWorkspaceFolderTrusted: true,
@@ -41,6 +31,7 @@ suite('Code ASecurity Issue Tree Provider', () => {
         values: () => [[]],
       },
     } as unknown as IProductService<CodeIssueData>;
+    configuration.setFeatureFlag(FEATURE_FLAGS.consistentIgnores, true);
     languages = {} as unknown as IVSCodeLanguages;
   });
 
@@ -68,7 +59,7 @@ suite('Code ASecurity Issue Tree Provider', () => {
       },
     } as unknown as IProductService<CodeIssueData>;
 
-    issueTreeProvider = new IssueTreeProvider(contextService, localCodeService, config, languages, true);
+    issueTreeProvider = new IssueTreeProvider(contextService, localCodeService, configuration, languages, true);
 
     sinon.stub(issueTreeProvider, 'getResultNodes').returns([]);
     const rootChildren = issueTreeProvider.getRootChildren();
@@ -85,7 +76,7 @@ suite('Code ASecurity Issue Tree Provider', () => {
       },
     } as unknown as IProductService<CodeIssueData>;
 
-    issueTreeProvider = new IssueTreeProvider(contextService, localCodeService, config, languages, true);
+    issueTreeProvider = new IssueTreeProvider(contextService, localCodeService, configuration, languages, true);
 
     sinon.stub(issueTreeProvider, 'getResultNodes').returns([]);
     const rootChildren = issueTreeProvider.getRootChildren();
@@ -94,7 +85,7 @@ suite('Code ASecurity Issue Tree Provider', () => {
     strictEqual(rootChildren[1].label, 'There are no vulnerabilities fixable by Snyk DeepCode AI');
   });
 
-  test('getRootChildren returns a root child for only open but not visible issues', () => {
+  test('getRootChildren returns a root child for only open but not visible issues', async () => {
     const localCodeService = {
       ...codeService,
       result: {
@@ -114,8 +105,12 @@ suite('Code ASecurity Issue Tree Provider', () => {
       },
     } as unknown as IProductService<CodeIssueData>;
 
-    config.issueViewOptions.openIssues = false;
-    issueTreeProvider = new IssueTreeProvider(contextService, localCodeService, config, languages, true);
+    await vscode.workspace.getConfiguration().update(ISSUE_VIEW_OPTIONS_SETTING, {
+      openIssues: false,
+      ignoredIssues: true,
+    });
+    configuration.issueViewOptions.openIssues = false;
+    issueTreeProvider = new IssueTreeProvider(contextService, localCodeService, configuration, languages, true);
 
     sinon.stub(issueTreeProvider, 'getResultNodes').returns([]);
     const rootChildren = issueTreeProvider.getRootChildren();
@@ -123,10 +118,13 @@ suite('Code ASecurity Issue Tree Provider', () => {
     strictEqual(rootChildren[0].label, 'Snyk found 1 issue');
     strictEqual(rootChildren[1].label, 'There are no vulnerabilities fixable by Snyk DeepCode AI');
     strictEqual(rootChildren[2].label, 'Adjust your Issue View Options to see open issues.');
-    config.issueViewOptions.openIssues = true;
+    await vscode.workspace.getConfiguration().update(ISSUE_VIEW_OPTIONS_SETTING, {
+      openIssues: true,
+      ignoredIssues: true,
+    });
   });
 
-  test('getRootChildren returns a root child for only ignored but not visible issues', () => {
+  test('getRootChildren returns a root child for only ignored but not visible issues', async () => {
     const localCodeService = {
       ...codeService,
       result: {
@@ -146,8 +144,11 @@ suite('Code ASecurity Issue Tree Provider', () => {
       },
     } as unknown as IProductService<CodeIssueData>;
 
-    config.issueViewOptions.ignoredIssues = false;
-    issueTreeProvider = new IssueTreeProvider(contextService, localCodeService, config, languages, true);
+    await vscode.workspace.getConfiguration().update(ISSUE_VIEW_OPTIONS_SETTING, {
+      openIssues: true,
+      ignoredIssues: false,
+    });
+    issueTreeProvider = new IssueTreeProvider(contextService, localCodeService, configuration, languages, true);
 
     sinon.stub(issueTreeProvider, 'getResultNodes').returns([]);
     const rootChildren = issueTreeProvider.getRootChildren();
@@ -155,10 +156,13 @@ suite('Code ASecurity Issue Tree Provider', () => {
     strictEqual(rootChildren[0].label, 'Snyk found 1 issue');
     strictEqual(rootChildren[1].label, 'There are no vulnerabilities fixable by Snyk DeepCode AI');
     strictEqual(rootChildren[2].label, 'Adjust your Issue View Options to see ignored issues.');
-    config.issueViewOptions.ignoredIssues = true;
+    await vscode.workspace.getConfiguration().update(ISSUE_VIEW_OPTIONS_SETTING, {
+      openIssues: true,
+      ignoredIssues: true,
+    });
   });
 
-  test('getRootChildren returns a root child for no visible issues', () => {
+  test('getRootChildren returns a root child for no visible issues', async () => {
     const localCodeService = {
       ...codeService,
       result: {
@@ -178,9 +182,11 @@ suite('Code ASecurity Issue Tree Provider', () => {
       },
     } as unknown as IProductService<CodeIssueData>;
 
-    config.issueViewOptions.openIssues = false;
-    config.issueViewOptions.ignoredIssues = false;
-    issueTreeProvider = new IssueTreeProvider(contextService, localCodeService, config, languages, true);
+    await vscode.workspace.getConfiguration().update(ISSUE_VIEW_OPTIONS_SETTING, {
+      openIssues: false,
+      ignoredIssues: false,
+    });
+    issueTreeProvider = new IssueTreeProvider(contextService, localCodeService, configuration, languages, true);
 
     sinon.stub(issueTreeProvider, 'getResultNodes').returns([]);
     const rootChildren = issueTreeProvider.getRootChildren();
@@ -188,7 +194,9 @@ suite('Code ASecurity Issue Tree Provider', () => {
     strictEqual(rootChildren[0].label, 'Snyk found 1 issue');
     strictEqual(rootChildren[1].label, 'There are no vulnerabilities fixable by Snyk DeepCode AI');
     strictEqual(rootChildren[2].label, 'Adjust your Issue View Options to see all issues.');
-    config.issueViewOptions.openIssues = true;
-    config.issueViewOptions.ignoredIssues = true;
+    await vscode.workspace.getConfiguration().update(ISSUE_VIEW_OPTIONS_SETTING, {
+      openIssues: true,
+      ignoredIssues: true,
+    });
   });
 });


### PR DESCRIPTION
### Description

This adds some warning messages in the Tree View for the following cases:
- none of the issue view options are enabled (which implies we'd show no issues)
- we find no issues and see that we only render ignores issues
- we find no issues and see that we only render open issues

It also adds info about the number of ignored issues

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

Before:
- all severities selected
![Screenshot 2024-05-29 at 15 55 44](https://github.com/snyk/vscode-extension/assets/81559517/dc3e1f59-6c0a-47ab-a9b8-d9c94f5c6072)
- some severities unselected and no vulns
![Screenshot 2024-05-29 at 15 55 51](https://github.com/snyk/vscode-extension/assets/81559517/d527943e-a51e-4565-bfcd-b38bf7d35189)
- no severities selected and no vulns
![Screenshot 2024-05-29 at 15 55 56](https://github.com/snyk/vscode-extension/assets/81559517/19207574-fcc6-44a6-bfb8-ecfaedad799e)
- no issue view options selected
![Screenshot 2024-05-29 at 15 58 53](https://github.com/snyk/vscode-extension/assets/81559517/aad2278a-dfda-473f-8797-63ab4ea3e20b)

After:
- all issues are ignored
![Screenshot 2024-05-30 at 10 23 41](https://github.com/snyk/vscode-extension/assets/81559517/ce7a9f51-6777-4d22-bfba-51b89873be13)
![Screenshot 2024-05-30 at 10 23 45](https://github.com/snyk/vscode-extension/assets/81559517/e89327fa-9382-47f6-bb55-c2432315b953)
![Screenshot 2024-05-30 at 10 23 52](https://github.com/snyk/vscode-extension/assets/81559517/e4076560-caac-4d7a-96eb-3b6e421e46e4)

- all issues are open
![Screenshot 2024-05-30 at 10 24 22](https://github.com/snyk/vscode-extension/assets/81559517/60429a69-5b29-4334-bea2-8a8f204d53dd)
![Screenshot 2024-05-30 at 10 24 27](https://github.com/snyk/vscode-extension/assets/81559517/f5f166e9-2b5b-40b3-b854-9fdf2505f471)
![Screenshot 2024-05-30 at 10 24 34](https://github.com/snyk/vscode-extension/assets/81559517/c7e9a83e-822c-47c0-be29-7028cbc9f107)

- all options are disabled
![Screenshot 2024-05-30 at 10 31 14](https://github.com/snyk/vscode-extension/assets/81559517/bb86cf9d-d456-4f1c-98a9-0bfc3fa93853)

