### PR TITLE
fix: use fspath to get correct path [IDE-398]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Snyk Security Changelog
 
+## [2.12.1]
+- Fix Code Suggestion rendering issue on Windows.
+
 ## [2.12.0]
 - Renders the AI Fix panel and adds more custom styling for VSCode.
 - Adds position line interaction.

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
@@ -127,7 +127,7 @@ export class CodeSuggestionWebviewProvider
           'suggestion',
           'suggestionLS.css',
         );
-        const ideStyle = readFileSync(ideStylePath.path, 'utf8');
+        const ideStyle = readFileSync(ideStylePath.fsPath, 'utf8');
         const ideScriptPath = vscode.Uri.joinPath(
           vscode.Uri.file(this.context.extensionPath),
           'out',
@@ -137,7 +137,7 @@ export class CodeSuggestionWebviewProvider
           'suggestion',
           'codeSuggestionWebviewScriptLS.js',
         );
-        const ideScript = readFileSync(ideScriptPath.path, 'utf8');
+        const ideScript = readFileSync(ideScriptPath.fsPath, 'utf8');
         html = html.replace('${ideStyle}', '<style nonce=${nonce}>' + ideStyle + '</style>');
         html = html.replace('${ideScript}', '<script nonce=${nonce}>' + ideScript + '</script>');
         const nonce = getNonce();


### PR DESCRIPTION
### Description
- Use uri.fspath instead of uri.path to get local files paths.
On Mac/Linux there is no difference in the result between both but on Windows:
fspath returns: 
``'c:\\Users\\user\\work\\vscode-extension\\media\\views\\snykCode\\suggestion\\suggestionLS.css'``
path returns:
``/c:/Users/shawky/work/vscode-extension/media/views/snykCode/suggestion/suggestionLS.css``

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
