### PR TITLE
fix: fix padding for vscode [IDE-382] 

### DIFF
--- a/media/views/snykCode/suggestion/suggestionLS.scss
+++ b/media/views/snykCode/suggestion/suggestionLS.scss
@@ -61,7 +61,8 @@ body {
 .data-flow-text {
     background-color: transparent;
     border-color: transparent;
-    padding: 0px;
+    padding-top: 0px;
+    padding-bottom: 0px;
 }
 
 .ignore-details-tab,


### PR DESCRIPTION
### Description

Adds a bit more padding left and right to the number in the dataflow, so it's easier to see and matches the [designs](https://www.figma.com/design/hcI2QHUtHfcIjgrpYlMqff/Holistic-Ignores?node-id=2292-63654&t=iIxZM8o3pih8EY4M-0) more.

### Checklist

- [x] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

![Screenshot 2024-06-11 at 17 02 26](https://github.com/snyk/vscode-extension/assets/81559517/ebbd8098-b744-4fac-b052-8f0623c4df20)
