### PR TITLE
fix: applying AI code fixes on Windows [IDE-395]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Snyk Security Changelog
 
+## [2.12.2]
+- Fix applying AI fixes on Windows.
+
 ## [2.12.1]
 - Fix Code Suggestion rendering issue on Windows.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Snyk Security Changelog
 
-## [2.12.2]
+## [2.12.1]
 - Fix applying AI fixes on Windows.
 
-## [2.12.1]
-- Fix Code Suggestion rendering issue on Windows.
-
 ## [2.12.0]
+- Fix Code Suggestion rendering issue on Windows.
 - Renders the AI Fix panel and adds more custom styling for VSCode.
 - Adds position line interaction.
 

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
@@ -286,14 +286,14 @@ export class CodeSuggestionWebviewProvider
           }
           const edit = new vscode.WorkspaceEdit();
 
-          const editor = vscode.window.visibleTextEditors.find(editor => editor.document.uri.path === filePath);
+          const editor = vscode.window.visibleTextEditors.find(editor => editor.document.uri.fsPath === filePath);
 
           if (!editor) {
             throw Error(`Editor with file not found: ${filePath}`);
           }
 
           const editorEndLine = editor.document.lineCount;
-          edit.replace(vscode.Uri.parse(filePath), new vscode.Range(0, 0, editorEndLine, 0), patchedContent);
+          edit.replace(vscode.Uri.file(filePath), new vscode.Range(0, 0, editorEndLine, 0), patchedContent);
 
           const success = await vscode.workspace.applyEdit(edit);
           if (!success) {


### PR DESCRIPTION
### Description
- use fspath instead of path.
- parse file path Uri using vscode.``vscode.Uri.file(filePath)`` instead of ``vscode.Uri.parse(filePath)``
Difference is 
```
vscode.Uri.file(filePath).fsPath
'c:\\Users\\user\\work\\project-with-vulns\\copy.ts'
vscode.Uri.parse(filePath).fsPath
'\\Users\\user\\work\\project-with-vulns\\copy.ts'
```

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
