### PR TITLE
chore: add `.light-only` and `.dark-only` rules to LS CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Snyk Security Changelog
 
+## [2.12.2]
+- Add CSS rules for `.light-only` and `.dark-only` to the LSP implementation. This allows the LSP to apply different styles based on the current theme.
+
 ## [2.12.1]
 - Fix applying AI fixes on Windows.
 

--- a/media/views/snykCode/suggestion/suggestionLS.scss
+++ b/media/views/snykCode/suggestion/suggestionLS.scss
@@ -117,7 +117,7 @@ body {
 .vscode-high-contrast:not(.vscode-high-contrast-light) .example-line.added {
     background-color: #1C4428;
     color: #fff;
-}        
+}
 
 .ignore-action-container {
     background-color: var(--vscode-editor-background);
@@ -139,4 +139,14 @@ body {
 
 .sn-fix-wrapper {
     background-color: var(--vscode-editor-background);
+}
+
+.vscode-dark .light-only,
+.vscode-high-contrast:not(.vscode-high-contrast-light) .light-only {
+  display: none;
+}
+
+.vscode-light .dark-only,
+.vscode-high-contrast.vscode-high-contrast-light .dark-only {
+  display: none;
 }


### PR DESCRIPTION
### Description

- Added CSS rules to toggle arrow icons based on the IDE theme.
- Ensures correct arrow icon display for dark, light, and high-contrast themes.
- Related to the migration from tab-based to arrow-based navigation in Fixed Code Examples (see PR [#540](https://github.com/snyk/snyk-ls/pull/540)).

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

|light-high-contrast|dark-high-contrast|absyss|
|-|-|-|
|<img width="1516" alt="light-high-contrast" src="https://github.com/snyk/vscode-extension/assets/1948377/fed2ae15-4b1f-4b4d-ad0e-045b37b72866">|<img width="1516" alt="dark-high-contrast" src="https://github.com/snyk/vscode-extension/assets/1948377/0411caa3-3712-4040-9225-0bbc74fa769f">|<img width="1516" alt="absyss" src="https://github.com/snyk/vscode-extension/assets/1948377/7ebb1e01-f0bb-42cc-9905-dd6f792177eb">|







