### PR TITLE
fix: dataflow links work across files [IDE-391]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Snyk Security Changelog
 
 ## [2.12.2]
-- update to LS protocol version 12
 - Refactors the feature flag logic into its own service.
+- Fix multi-file links in the DataFlow HTML panel.
 
 ## [2.12.1]
 - Fix applying AI fixes on Windows.
 - Add CSS rules for `.light-only` and `.dark-only` to the LSP implementation. This allows the LSP to apply different styles based on the current theme.
+- Update to LS protocol version 12.
 
 ## [2.12.0]
 - Fix Code Suggestion rendering issue on Windows.

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScriptLS.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScriptLS.ts
@@ -120,19 +120,10 @@
     vscode.postMessage(message);
   }
 
-  function navigateToIssue(i: number) {
+  function navigateToIssue(position?: MarkerPosition) {
     if (!suggestion) {
       return;
     }
-    const markers = suggestion.markers;
-    if (!markers) {
-      return;
-    }
-    const position = {
-      file: suggestion.filePath,
-      rows: markers[i].pos[0].rows,
-      cols: markers[i].pos[0].cols,
-    };
 
     const message: OpenLocalMessage = {
       type: 'openLocal',
@@ -175,7 +166,20 @@
   const dataFlows = document.getElementsByClassName('data-flow-clickable-row');
   for (let i = 0; i < dataFlows.length; i++) {
     dataFlows[i].addEventListener('click', () => {
-      navigateToIssue(i);
+      const rows: Point = [
+        parseInt(dataFlows[i].getAttribute('start-line')!),
+        parseInt(dataFlows[i].getAttribute('end-line')!),
+      ];
+      const cols: Point = [
+        parseInt(dataFlows[i].getAttribute('start-character')!),
+        parseInt(dataFlows[i].getAttribute('end-character')!),
+      ];
+      const position = {
+        file: dataFlows[i].getAttribute('file-path')!,
+        rows: rows,
+        cols: cols,
+      };
+      navigateToIssue(position);
     });
   }
   document.getElementById('ignore-line-issue')?.addEventListener('click', () => {
@@ -185,7 +189,7 @@
     ignoreIssue(false);
   });
   document.getElementById('position-line')!.addEventListener('click', () => {
-    navigateToIssue(0);
+    navigateToIssue();
   });
 
   function toggleElement(element: Element | null, toggle: 'hide' | 'show') {


### PR DESCRIPTION
### Description

We have to make sure to read the file-path and other attributes from the component rather than the stored `suggestion` because the suggestion doesn't have the data from the different files. 

The DataFlow section is new in VSCode so the old code didn't account for multiple files and only showed lines in the same file:
![Screenshot 2024-06-14 at 16 11 47](https://github.com/snyk/vscode-extension/assets/81559517/2e488944-0407-436d-824f-07e8650baf08)


### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs


https://github.com/snyk/vscode-extension/assets/81559517/ed5ecd48-1313-414d-9067-dbbb42594759

