### PR TITLE
fix: content within `.suggestion` is scrollable and visible [IDE-366]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Snyk Security Changelog
 
+## [2.12.4]
+- Fix `.suggestion` class to ensure it is scrollable and not overlapped by the `.suggestion-actions` fixed element. This change prevents the suggestion content from being hidden.
+
 ## [2.12.3]
 - Fix a bug in AI Applyfix on Windows.
 - Changes some of the colours used in the HTML panel so it's consistent with designs.

--- a/media/views/snykCode/suggestion/suggestion.scss
+++ b/media/views/snykCode/suggestion/suggestion.scss
@@ -38,6 +38,8 @@ body {
   height: 100%;
   margin: 0;
   font-size: 1.4rem;
+  overflow-y: auto;
+  height: calc(100vh - 80px); /* 80px is the height of the footer */
 }
 
 .suggestion-title {


### PR DESCRIPTION
### Description

This PR fixes the issue where content within the `.suggestion` class was being overlapped by the footer. The overlap caused some content to be hidden, making it inaccessible.

**Note**:
- The height calculation (`calc(100vh - 80px)`) is based on the height of the `.suggestion-actions` element.
### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

## Berore

<video src="https://github.com/snyk/vscode-extension/assets/1948377/aa2eb42e-fb3d-444a-b53f-80437fe700ca" controls="controls" style="max-width: 460px;">
</video>


## After
<video src="https://github.com/snyk/vscode-extension/assets/1948377/9ad70dc8-18d4-48a0-8335-bfac7ccacd62" controls="controls" style="max-width: 460px;">
</video>
