### PR TITLE
refactor: prepare to use the html/template version of the OSS HTML [IDE-326]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Snyk Security Changelog
 
-## [2.12.4]
+### [2.13.1]
+- Refactor the Suggestion Panel for OSS so it's more secure and will be supported in other IDEs
+
+## [2.13.0]
 - Fix `.suggestion` class to ensure it is scrollable and not overlapped by the `.suggestion-actions` fixed element. This change prevents the suggestion content from being hidden.
 - transmit required protocol version to language server
 - Remove unused stylesheet and refactor stylesheets


### PR DESCRIPTION
### Description

In https://github.com/snyk/snyk-ls/pull/564 we are refactoring the HTML for OSS to use `html/template` and also to eventually be able to inject styling for IntelliJ. JCEF only supports `<style>`styling and not linked stylesheets so refactoring this code to work the same way it does now for Snyk Code by injecting the `<style>` styling into the `${ideStyle}` variable.

We also won't need to inject the icons since they will be injected in the HTML template in LS.

We will deliver this version of VSCode for an older version of the CLI so we need to make sure it works with or without the changes in LS. So test it with and without https://github.com/snyk/snyk-ls/pull/564.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

