### PR TITLE
refactor: removes unnecessary styling and HTML code [IDE-285] 

### DIFF
--- a/media/views/oss/suggestion/suggestion.scss
+++ b/media/views/oss/suggestion/suggestion.scss
@@ -1,39 +1,11 @@
 @import '../../common/webview';
 
-.suggestion {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-}
-
 .suggestion .suggestion-text {
   padding: 0.4rem 0;
   margin-bottom: 0.8rem;
   font-size: 1.8rem;
   font-weight: 500;
   line-height: 2.4rem;
-}
-
-.severity {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 0;
-  float: left;
-  margin: 0 1rem 0 0;
-  text-align: center;
-}
-
-.severity .icon {
-  width: 32px;
-  height: 32px;
-}
-
-.icon {
-  vertical-align: middle;
-  width: 16px;
-  height: 16px;
 }
 
 .identifiers {
@@ -49,43 +21,11 @@
   display: none;
 }
 
-.clickable:hover {
-  cursor: pointer;
-}
-
 .delimiter {
-  width: 0;
-  height: 1.3rem;
-  margin: 0 0.8rem 0 0.8rem;
   border-right:1px solid var(--vscode-input-border);
-  line-height: 1rem;
-}
-
-.summary .summary-item {
-  display: flex;
-  margin: 0.3em 0 0.3em 0;
-}
-
-.summary .label {
-  width: 160px;
-}
-
-.summary .content {
-  flex: 70%;
-}
-
-.summary .remediation {
-  margin-bottom: 1.6rem
-}
-
-.summary .detailed-path:last-child .remediation {
-  margin-bottom: 0
 }
 
 .vulnerability-overview pre {
-  padding: 8px 16px;
-  overflow-x: auto;
-  border-radius: 4px;
   font-size: var(--vscode-editor-font-size);
   font-family: var(--vscode-editor-font-family);
   background-color: var(--vscode-editor-background);

--- a/media/views/snykCode/suggestion/suggestionLS.scss
+++ b/media/views/snykCode/suggestion/suggestionLS.scss
@@ -18,19 +18,6 @@ body {
     text-transform: capitalize;
 }
 
-// TODO: remove ignore styling at the end of cycle 5 2025
-.ignore-warning {
-    background: #FFF4ED;
-    color: #B6540B;
-    border: 1px solid #E27122;
-}
-
-.ignore-badge {
-    background: #FFF4ED;
-    color: #B6540B;
-    border: 1px solid #E27122;
-}
-
 .data-flow-clickable-row {
     color: var(--vscode-textLink-foreground);
 }

--- a/src/snyk/snykOss/providers/ossDetailPanelProvider.ts
+++ b/src/snyk/snykOss/providers/ossDetailPanelProvider.ts
@@ -94,15 +94,6 @@ export class OssDetailPanelProvider
       const ideStyle = readFileSync(ideStylePath.fsPath, 'utf8');
       const nonce = getNonce();
 
-      // TODO: remove after the stable CLI release at the end of cycle 5
-      const styleUri = this.getWebViewUri('media', 'views', 'oss', 'suggestion', 'suggestion.css');
-      const headerEndValue = `<link href="${styleUri}" rel="stylesheet">`;
-      const serverityIconName = `${displayMode}-${issue.severity}-severity`;
-      html = html.replace('${headerEnd}', headerEndValue);
-      html = html.replaceAll('${cspSource}', this.panel.webview.cspSource);
-      html = html.replace('${severityIcon}', images[serverityIconName]);
-      html = html.replace('${learnIcon}', images['learn-icon']);
-      // TODO: end remove
       html = html.replace('${ideStyle}', '<style nonce=${nonce}>' + ideStyle + '</style>');
       html = html.replaceAll('${nonce}', nonce);
       html = html.replaceAll(/\$\{\w+\}/g, '');


### PR DESCRIPTION
### Description

We can remove the old ignore style for consistent Snyk Code ignores and HTML setup for OSS (base styling + injecting the stylesheet). These PRs have already been merged a while ago and contain the changes for these refactorings:
- https://github.com/snyk/snyk-ls/pull/552 for the Snyk Code ignore styling
- https://github.com/snyk/snyk-ls/pull/570 for the HTML OSS styling
- https://github.com/snyk/snyk-ls/pull/564 for the HTML OSS setup 

To test, run `npm run build` to regenerate the CSS.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs
<img width="1718" alt="Screenshot 2024-07-11 at 11 02 27" src="https://github.com/snyk/vscode-extension/assets/81559517/ac492a77-da93-44be-8f5c-e51535471071">
<img width="1716" alt="Screenshot 2024-07-11 at 11 08 18" src="https://github.com/snyk/vscode-extension/assets/81559517/e0c5a882-6cb8-4039-98f8-af07b7a5d422">
