### PR TITLE
feat: toggle inline ignores button visibility based on feature flag [IDE-444]

### DIFF
--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
@@ -30,12 +30,7 @@ import { IssueUtils } from '../../utils/issueUtils';
 import { ICodeSuggestionWebviewProvider } from '../interfaces';
 import { readFileSync } from 'fs';
 import { TextDocument } from '../../../common/vscode/types';
-import {
-  GetShowInlineIgnoresButtonFeatureFlagMessage,
-  SetShowInlineIgnoresButtonMessage,
-  Suggestion,
-  SuggestionMessage,
-} from './types';
+import { Suggestion, SuggestionMessage } from './types';
 import { WebviewPanelSerializer } from '../../../snykCode/views/webviewPanelSerializer';
 import { configuration } from '../../../common/configuration/instance';
 import { FEATURE_FLAGS } from '../../../common/constants/featureFlags';
@@ -310,18 +305,7 @@ export class CodeSuggestionWebviewProvider
 
           break;
         }
-        case 'getShowInlineIgnoresButtonFeatureFlag': {
-          const enabled = configuration.getFeatureFlag(FEATURE_FLAGS.snykCodeInlineIgnore);
-          message = {
-            type: 'getShowInlineIgnoresButtonFeatureFlag',
-            args: {
-              enabled: enabled,
-            },
-          } as GetShowInlineIgnoresButtonFeatureFlagMessage;
 
-          void this.postSuggestMessage(message);
-          break;
-        }
         default: {
           throw new Error('Unknown message type');
         }

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
@@ -199,6 +199,7 @@ export class CodeSuggestionWebviewProvider
 
   private mapToModel(issue: Issue<CodeIssueData>): Suggestion {
     const parsedDetails = marked.parse(issue.additionalData.text) as string;
+    const showInlineIgnoresButton = configuration.getFeatureFlag(FEATURE_FLAGS.snykCodeInlineIgnore);
 
     return {
       id: issue.id,
@@ -208,6 +209,7 @@ export class CodeSuggestionWebviewProvider
       text: parsedDetails,
       hasAIFix: issue.additionalData.hasAIFix,
       filePath: issue.filePath,
+      showInlineIgnoresButton,
     };
   }
 

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
@@ -30,7 +30,12 @@ import { IssueUtils } from '../../utils/issueUtils';
 import { ICodeSuggestionWebviewProvider } from '../interfaces';
 import { readFileSync } from 'fs';
 import { TextDocument } from '../../../common/vscode/types';
-import { Suggestion, SuggestionMessage } from './types';
+import {
+  GetShowInlineIgnoresButtonFeatureFlagMessage,
+  SetShowInlineIgnoresButtonMessage,
+  Suggestion,
+  SuggestionMessage,
+} from './types';
 import { WebviewPanelSerializer } from '../../../snykCode/views/webviewPanelSerializer';
 import { configuration } from '../../../common/configuration/instance';
 import { FEATURE_FLAGS } from '../../../common/constants/featureFlags';
@@ -305,7 +310,18 @@ export class CodeSuggestionWebviewProvider
 
           break;
         }
+        case 'getShowInlineIgnoresButtonFeatureFlag': {
+          const enabled = configuration.getFeatureFlag(FEATURE_FLAGS.snykCodeInlineIgnore);
+          message = {
+            type: 'getShowInlineIgnoresButtonFeatureFlag',
+            args: {
+              enabled: enabled,
+            },
+          } as GetShowInlineIgnoresButtonFeatureFlagMessage;
 
+          void this.postSuggestMessage(message);
+          break;
+        }
         default: {
           throw new Error('Unknown message type');
         }

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
@@ -206,6 +206,8 @@ declare const acquireVsCodeApi: any;
     noExamplesElem: document.getElementById('info-no-examples') as HTMLElement,
     exNumElem: document.getElementById('example-number') as HTMLElement,
     exNum2Elem: document.getElementById('example-number2') as HTMLElement,
+
+    footerInlineIgnoresButtons: document.querySelector('.suggestion-actions') as HTMLElement,
   };
 
   function navigateToUrl(url: string) {
@@ -629,10 +631,13 @@ declare const acquireVsCodeApi: any;
    * @param {Suggestion} suggestion - The suggestion object containing the details to be displayed.
    */
   function showSuggestionMeta(suggestion: Suggestion) {
-    const { metaElem } = elements;
+    const { metaElem, footerInlineIgnoresButtons } = elements;
 
     // Clear previously metadata.
     metaElem.querySelectorAll('.suggestion-meta').forEach(element => element.remove());
+
+    // Hide the inline ignores button if the feature flag is disabled.
+    footerInlineIgnoresButtons.style.display = suggestion?.showInlineIgnoresButton ? 'block' : 'none';
 
     // Append issue type: 'Vulnerability' or 'Issue'.
     const issueTypeElement = document.createElement('span');

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
@@ -6,6 +6,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /// <reference lib="dom" />
 
+import { GetShowInlineIgnoresButtonFeatureFlagMessage } from './types';
+
 declare const acquireVsCodeApi: any;
 
 // This script will be run within the webview itself
@@ -57,6 +59,7 @@ declare const acquireVsCodeApi: any;
     hasAIFix: boolean;
     diffs: AutofixUnifiedDiffSuggestion[];
     filePath: string;
+    showInlineIgnoresButton: boolean;
   };
 
   type CurrentSeverity = {
@@ -148,6 +151,17 @@ declare const acquireVsCodeApi: any;
     };
   };
 
+  type GetShowInlineIgnoresButtonFeatureFlagMessage = {
+    type: 'getShowInlineIgnoresButtonFeatureFlag';
+  };
+
+  type SetShowInlineIgnoresButtonMessage = {
+    type: 'setShowInlineIgnoresButton';
+    args: {
+      enabled: boolean;
+    };
+  };
+
   type SuggestionMessage =
     | OpenLocalMessage
     | OpenBrowserMessage
@@ -159,7 +173,9 @@ declare const acquireVsCodeApi: any;
     | SetLessonMessage
     | GetLessonMessage
     | SetAutofixDiffsMessage
-    | SetAutofixErrorMessage;
+    | SetAutofixErrorMessage
+    | GetShowInlineIgnoresButtonFeatureFlagMessage
+    | SetShowInlineIgnoresButtonMessage;
 
   const vscode = acquireVsCodeApi();
 
@@ -205,6 +221,8 @@ declare const acquireVsCodeApi: any;
     noExamplesElem: document.getElementById('info-no-examples') as HTMLElement,
     exNumElem: document.getElementById('example-number') as HTMLElement,
     exNum2Elem: document.getElementById('example-number2') as HTMLElement,
+
+    inlineIgnoresButton: document.getElementById('ignore-line-issue') as HTMLElement,
   };
 
   function navigateToUrl(url: string) {
@@ -454,7 +472,7 @@ declare const acquireVsCodeApi: any;
    * numeric value. If the provided severity string is not one of the allowed values, the function
    * returns `undefined`.
    *
-   * @param {Suggestion['severity']} severity - The severity string to be mapped.
+   * @param {Suggestion["severity"]} severity - The severity string to be mapped.
    * @returns {CurrentSeverity | undefined} The mapped severity object, or undefined
    */
   function getCurrentSeverity(severity: Suggestion['severity']): CurrentSeverity | undefined {
@@ -616,6 +634,11 @@ declare const acquireVsCodeApi: any;
 
       toggleElement(exampleElem, 'hide');
     }
+
+    const message: GetShowInlineIgnoresButtonFeatureFlagMessage = {
+      type: 'getShowInlineIgnoresButtonFeatureFlag',
+    };
+    sendMessage(message);
   }
 
   /**
@@ -720,6 +743,7 @@ declare const acquireVsCodeApi: any;
     fixLoadingIndicatorElem,
     fixWrapperElem,
     fixErrorSectionElem,
+    inlineIgnoresButton,
   } = elements;
 
   generateAIFixButton?.addEventListener('click', generateAIFix);
@@ -795,6 +819,16 @@ declare const acquireVsCodeApi: any;
         }
         toggleElement(fixWrapperElem, 'hide');
         toggleElement(fixErrorSectionElem, 'show');
+        break;
+      }
+
+      case 'setShowInlineIgnoresButton': {
+        let toggle: 'hide' | 'show' = 'show';
+        if (!message.args.enabled) {
+          toggle = 'hide';
+        }
+        toggleElement(inlineIgnoresButton, toggle);
+        break;
       }
     }
   });

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
@@ -149,17 +149,6 @@ declare const acquireVsCodeApi: any;
     };
   };
 
-  type GetShowInlineIgnoresButtonFeatureFlagMessage = {
-    type: 'getShowInlineIgnoresButtonFeatureFlag';
-  };
-
-  type SetShowInlineIgnoresButtonMessage = {
-    type: 'setShowInlineIgnoresButton';
-    args: {
-      enabled: boolean;
-    };
-  };
-
   type SuggestionMessage =
     | OpenLocalMessage
     | OpenBrowserMessage
@@ -171,9 +160,7 @@ declare const acquireVsCodeApi: any;
     | SetLessonMessage
     | GetLessonMessage
     | SetAutofixDiffsMessage
-    | SetAutofixErrorMessage
-    | GetShowInlineIgnoresButtonFeatureFlagMessage
-    | SetShowInlineIgnoresButtonMessage;
+    | SetAutofixErrorMessage;
 
   const vscode = acquireVsCodeApi();
 
@@ -219,8 +206,6 @@ declare const acquireVsCodeApi: any;
     noExamplesElem: document.getElementById('info-no-examples') as HTMLElement,
     exNumElem: document.getElementById('example-number') as HTMLElement,
     exNum2Elem: document.getElementById('example-number2') as HTMLElement,
-
-    inlineIgnoresButton: document.getElementById('ignore-line-issue') as HTMLElement,
   };
 
   function navigateToUrl(url: string) {
@@ -632,11 +617,6 @@ declare const acquireVsCodeApi: any;
 
       toggleElement(exampleElem, 'hide');
     }
-
-    const message: GetShowInlineIgnoresButtonFeatureFlagMessage = {
-      type: 'getShowInlineIgnoresButtonFeatureFlag',
-    };
-    sendMessage(message);
   }
 
   /**
@@ -741,7 +721,6 @@ declare const acquireVsCodeApi: any;
     fixLoadingIndicatorElem,
     fixWrapperElem,
     fixErrorSectionElem,
-    inlineIgnoresButton,
   } = elements;
 
   generateAIFixButton?.addEventListener('click', generateAIFix);
@@ -817,15 +796,6 @@ declare const acquireVsCodeApi: any;
         }
         toggleElement(fixWrapperElem, 'hide');
         toggleElement(fixErrorSectionElem, 'show');
-        break;
-      }
-
-      case 'setShowInlineIgnoresButton': {
-        let toggle: 'hide' | 'show' = 'show';
-        if (!message.args.enabled) {
-          toggle = 'hide';
-        }
-        toggleElement(inlineIgnoresButton, toggle);
         break;
       }
     }

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScript.ts
@@ -6,8 +6,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /// <reference lib="dom" />
 
-import { GetShowInlineIgnoresButtonFeatureFlagMessage } from './types';
-
 declare const acquireVsCodeApi: any;
 
 // This script will be run within the webview itself

--- a/src/snyk/snykCode/views/suggestion/types.ts
+++ b/src/snyk/snykCode/views/suggestion/types.ts
@@ -99,17 +99,6 @@ export type SetAutofixErrorMessage = {
   };
 };
 
-export type GetShowInlineIgnoresButtonFeatureFlagMessage = {
-  type: 'getShowInlineIgnoresButtonFeatureFlag';
-};
-
-export type SetShowInlineIgnoresButtonMessage = {
-  type: 'setShowInlineIgnoresButton';
-  args: {
-    enabled: boolean;
-  };
-};
-
 export type SuggestionMessage =
   | OpenLocalMessage
   | OpenBrowserMessage
@@ -121,6 +110,4 @@ export type SuggestionMessage =
   | SetLessonMessage
   | GetLessonMessage
   | SetAutofixDiffsMessage
-  | SetAutofixErrorMessage
-  | GetShowInlineIgnoresButtonFeatureFlagMessage
-  | SetShowInlineIgnoresButtonMessage;
+  | SetAutofixErrorMessage;

--- a/src/snyk/snykCode/views/suggestion/types.ts
+++ b/src/snyk/snykCode/views/suggestion/types.ts
@@ -99,6 +99,17 @@ export type SetAutofixErrorMessage = {
   };
 };
 
+export type GetShowInlineIgnoresButtonFeatureFlagMessage = {
+  type: 'getShowInlineIgnoresButtonFeatureFlag';
+};
+
+export type SetShowInlineIgnoresButtonMessage = {
+  type: 'setShowInlineIgnoresButton';
+  args: {
+    enabled: boolean;
+  };
+};
+
 export type SuggestionMessage =
   | OpenLocalMessage
   | OpenBrowserMessage
@@ -110,4 +121,6 @@ export type SuggestionMessage =
   | SetLessonMessage
   | GetLessonMessage
   | SetAutofixDiffsMessage
-  | SetAutofixErrorMessage;
+  | SetAutofixErrorMessage
+  | GetShowInlineIgnoresButtonFeatureFlagMessage
+  | SetShowInlineIgnoresButtonMessage;

--- a/src/snyk/snykCode/views/suggestion/types.ts
+++ b/src/snyk/snykCode/views/suggestion/types.ts
@@ -18,6 +18,7 @@ export type Suggestion = {
   rows: Point;
   hasAIFix?: boolean;
   filePath: string;
+  showInlineIgnoresButton: boolean;
 };
 
 export type OpenLocalMessage = {


### PR DESCRIPTION
### Description

This PR hides the footer with the ignore line and ignore file buttons when the feature flag exists in the settings of an organisation but is selected to `false`.


### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

|ORG with FF Enabled|ORG with FF Disabled|
|-|-|
|<img width="1603" alt="ff-enabled" src="https://github.com/user-attachments/assets/9f831110-9c0c-473c-bed9-50153b2c6946">|<img width="1595" alt="ff-disabled" src="https://github.com/user-attachments/assets/3d21e0c7-3e89-4c7c-b173-8696d4b11e76">|

