### PR TITLE
chore: hide oss quickfixes behind a preview flag

### DIFF
--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -62,6 +62,7 @@ export interface SeverityFilter {
 
 export type PreviewFeatures = {
   advisor: boolean | undefined;
+  ossQuickfixes: boolean | undefined;
 };
 
 export interface IConfiguration {
@@ -449,6 +450,7 @@ export class Configuration implements IConfiguration {
   getPreviewFeatures(): PreviewFeatures {
     const defaultSetting: PreviewFeatures = {
       advisor: false,
+      ossQuickfixes: false,
     };
 
     const userSetting =

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -133,6 +133,8 @@ export interface IConfiguration {
 
   getDeltaFindingsEnabled(): boolean;
 
+  getOssQuickFixCodeActionsEnabled(): boolean;
+
   getFolderConfigs(): FolderConfig[];
 
   setFolderConfigs(folderConfig: FolderConfig[]): Promise<void>;
@@ -147,6 +149,10 @@ export class Configuration implements IConfiguration {
   private featureFlag: { [key: string]: boolean } = {};
 
   constructor(private processEnv: NodeJS.ProcessEnv = process.env, private workspace: IVSCodeWorkspace) {}
+
+  getOssQuickFixCodeActionsEnabled(): boolean {
+    return this.getPreviewFeatures().ossQuickfixes ?? false;
+  }
 
   getInsecure(): boolean {
     const strictSSL = this.workspace.getConfiguration<boolean>('http', 'proxyStrictSSL') ?? true;

--- a/src/snyk/common/languageServer/settings.ts
+++ b/src/snyk/common/languageServer/settings.ts
@@ -85,7 +85,7 @@ export class LanguageServerSettings {
       deviceId: user.anonymousId,
       requiredProtocolVersion: `${PROTOCOL_VERSION}`,
       folderConfigs: configuration.getFolderConfigs(),
-      enableSnykOSSQuickFixCodeActions: `${configuration.getPreviewFeatures().ossQuickfixes}`,
+      enableSnykOSSQuickFixCodeActions: `${configuration.getOssQuickFixCodeActionsEnabled()}`,
     };
   }
 }

--- a/src/snyk/common/languageServer/settings.ts
+++ b/src/snyk/common/languageServer/settings.ts
@@ -43,6 +43,7 @@ export type ServerSettings = {
   requiredProtocolVersion?: string;
   enableDeltaFindings?: string;
   folderConfigs: FolderConfig[];
+  enableSnykOSSQuickFixCodeActions: string;
 };
 
 export class LanguageServerSettings {
@@ -84,6 +85,7 @@ export class LanguageServerSettings {
       deviceId: user.anonymousId,
       requiredProtocolVersion: `${PROTOCOL_VERSION}`,
       folderConfigs: configuration.getFolderConfigs(),
+      enableSnykOSSQuickFixCodeActions: `${configuration.getPreviewFeatures().ossQuickfixes}`,
     };
   }
 }

--- a/src/test/unit/common/configuration.test.ts
+++ b/src/test/unit/common/configuration.test.ts
@@ -94,12 +94,14 @@ suite('Configuration', () => {
 
     deepStrictEqual(configuration.getPreviewFeatures(), {
       advisor: false,
+      ossQuickfixes: false,
     } as PreviewFeatures);
   });
 
   test('Preview features: some features enabled', () => {
     const previewFeatures = {
       advisor: false,
+      ossQuickfixes: false,
     } as PreviewFeatures;
     const workspace = stubWorkspaceConfiguration(FEATURES_PREVIEW_SETTING, previewFeatures);
 

--- a/src/test/unit/common/languageServer/languageServer.test.ts
+++ b/src/test/unit/common/languageServer/languageServer.test.ts
@@ -62,9 +62,7 @@ suite('Language Server', () => {
         return true;
       },
       getPreviewFeatures() {
-        return {
-          advisor: false,
-        };
+        return { advisor: false, ossQuickfixes: false };
       },
       getFeaturesConfiguration() {
         return defaultFeaturesConfigurationStub;

--- a/src/test/unit/common/languageServer/languageServer.test.ts
+++ b/src/test/unit/common/languageServer/languageServer.test.ts
@@ -231,6 +231,7 @@ suite('Language Server', () => {
         scanningMode: 'auto',
         folderConfigs: [],
         authenticationMethod: 'oauth',
+        enableSnykOSSQuickFixCodeActions: 'false',
       };
 
       deepStrictEqual(await languageServer.getInitializationOptions(), expectedInitializationOptions);

--- a/src/test/unit/common/languageServer/languageServer.test.ts
+++ b/src/test/unit/common/languageServer/languageServer.test.ts
@@ -61,8 +61,8 @@ suite('Language Server', () => {
       isAutomaticDependencyManagementEnabled() {
         return true;
       },
-      getPreviewFeatures() {
-        return { advisor: false, ossQuickfixes: false };
+      getOssQuickFixCodeActionsEnabled () {
+        return false;
       },
       getFeaturesConfiguration() {
         return defaultFeaturesConfigurationStub;

--- a/src/test/unit/common/languageServer/languageServer.test.ts
+++ b/src/test/unit/common/languageServer/languageServer.test.ts
@@ -67,6 +67,12 @@ suite('Language Server', () => {
       getFeaturesConfiguration() {
         return defaultFeaturesConfigurationStub;
       },
+      getPreviewFeatures() {
+        return {
+          advisor: false,
+          ossQuickfixes: false,
+        };
+      },
       severityFilter: {
         critical: true,
         high: true,

--- a/src/test/unit/common/languageServer/languageServer.test.ts
+++ b/src/test/unit/common/languageServer/languageServer.test.ts
@@ -61,7 +61,7 @@ suite('Language Server', () => {
       isAutomaticDependencyManagementEnabled() {
         return true;
       },
-      getOssQuickFixCodeActionsEnabled () {
+      getOssQuickFixCodeActionsEnabled() {
         return false;
       },
       getFeaturesConfiguration() {

--- a/src/test/unit/common/languageServer/middleware.test.ts
+++ b/src/test/unit/common/languageServer/middleware.test.ts
@@ -37,10 +37,8 @@ suite('Language Server: Middleware', () => {
       getDeltaFindingsEnabled(): boolean {
         return false;
       },
-      getPreviewFeatures: () => {
-        return {
-          advisor: false,
-        };
+      getPreviewFeatures() {
+        return { advisor: false, ossQuickfixes: false };
       },
       getFeaturesConfiguration() {
         return defaultFeaturesConfigurationStub;

--- a/src/test/unit/common/languageServer/middleware.test.ts
+++ b/src/test/unit/common/languageServer/middleware.test.ts
@@ -40,6 +40,9 @@ suite('Language Server: Middleware', () => {
       getPreviewFeatures() {
         return { advisor: false, ossQuickfixes: false };
       },
+      getOssQuickFixCodeActionsEnabled(): boolean {
+        return false;
+      },
       getFeaturesConfiguration() {
         return defaultFeaturesConfigurationStub;
       },

--- a/src/test/unit/common/languageServer/settings.test.ts
+++ b/src/test/unit/common/languageServer/settings.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { FolderConfig, IConfiguration } from '../../../../snyk/common/configuration/configuration';
+import { FolderConfig, IConfiguration, PreviewFeatures } from '../../../../snyk/common/configuration/configuration';
 import { LanguageServerSettings } from '../../../../snyk/common/languageServer/settings';
 import { User } from '../../../../snyk/common/user';
 
@@ -22,6 +22,9 @@ suite('LanguageServerSettings', () => {
         isAutomaticDependencyManagementEnabled: () => true,
         getFolderConfigs(): FolderConfig[] {
           return [];
+        },
+        getPreviewFeatures(): PreviewFeatures {
+          return { advisor: false, ossQuickfixes: false };
         },
         getAuthenticationMethod(): string {
           return 'oauth';

--- a/src/test/unit/common/languageServer/settings.test.ts
+++ b/src/test/unit/common/languageServer/settings.test.ts
@@ -26,6 +26,9 @@ suite('LanguageServerSettings', () => {
         getPreviewFeatures(): PreviewFeatures {
           return { advisor: false, ossQuickfixes: false };
         },
+        getOssQuickFixCodeActionsEnabled(): boolean {
+          return false;
+        },
         getAuthenticationMethod(): string {
           return 'oauth';
         },


### PR DESCRIPTION
### Description

Defaults to not showing quickfixes. If Preview is enabled (see screenshot), quickfixes are added and code lenses are shown.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

![image](https://github.com/user-attachments/assets/41cd65b4-8302-4c44-9f24-d03273df61e6)

