### PR TITLE
fix: improve readability of code elements in high-contrast themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Snyk Security Changelog
 
+## [2.16.3]
+- fix readability of `code` elements within the **overview** section when using high-contrast themes (both dark and light). Text color now matches the background.
+
 ## [2.16.2]
 - updated the language server protocol version to 14 to support new communication model.
 

--- a/media/views/oss/suggestion/suggestion.scss
+++ b/media/views/oss/suggestion/suggestion.scss
@@ -22,7 +22,7 @@
 }
 
 .delimiter {
-  border-right:1px solid var(--vscode-input-border);
+  border-right: 1px solid var(--vscode-input-border);
 }
 
 .vulnerability-overview pre {
@@ -36,4 +36,14 @@
   color: var(--vscode-foreground);
   font-size: var(--vscode-editor-font-size);
   font-family: var(--vscode-editor-font-family);
+}
+
+/* High-contrast dark mode */
+.vscode-high-contrast:not(.vscode-high-contrast-light) .vulnerability-overview code {
+  color: var(--vscode-editor-background);
+}
+
+/* High-contrast light mode */
+.vscode-high-contrast.vscode-high-contrast-light .vulnerability-overview code {
+  color: var(--vscode-editor-background);
 }


### PR DESCRIPTION
### Description

Improve readability of code elements in high-contrast themes

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

|Before|After|
|-|-|
|<img width="1585" alt="light-before" src="https://github.com/user-attachments/assets/d4b4e9e7-ca03-4527-835a-a706f1a70d56">|<img width="1585" alt="light-after" src="https://github.com/user-attachments/assets/432e268e-ad5b-4234-8d4f-690499ad665a">|
|<img width="1585" alt="dark-before" src="https://github.com/user-attachments/assets/003a936a-1432-42a1-aaa2-74845c74d23b">|<img width="1585" alt="dark-after" src="https://github.com/user-attachments/assets/6826cafa-c84f-4343-a105-375905f9d38e">|



