### PR TITLE
chore: add missing CHANGELOG IaC via LS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Snyk Security Changelog
 
+## [2.17.0]
+- render IaC via Language Server
+
 ## [2.16.3]
 - fix readability of `code` elements within the **overview** section when using high-contrast themes (both dark and light). Text color now matches the background.
 

--- a/src/snyk/base/services/authenticationService.ts
+++ b/src/snyk/base/services/authenticationService.ts
@@ -75,11 +75,15 @@ export class AuthenticationService implements IAuthenticationService {
         oauthToken.access_token.length > 0 &&
         Date.parse(oauthToken.expiry) > Date.now() &&
         oauthToken.refresh_token.length > 0;
-      this.logger.debug(`Token ${token} parsed`);
+      this.logger.debug(`Token ${this.maskToken(token)} parsed`);
     } catch (e) {
-      this.logger.warn(`Token ${token} is not a valid uuid or json string: ${e}`);
+      this.logger.warn(`Token ${this.maskToken(token)} is not a valid uuid or json string: ${e}`);
     }
     return valid;
+  }
+
+  private maskToken(token: string): string {
+    return `${token.slice(0, 4)}****${token.slice(-4)}`;
   }
 
   async updateToken(token: string): Promise<void> {


### PR DESCRIPTION
### Description

This PR add the missing entry in the CHANGELOG for IaC rendered via Language Server.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

