### PR TITLE
fix: oauth2 authentication method by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
         "properties": {
           "snyk.advanced.authenticationMethod": {
             "type": "string",
-            "default": "Token authentication",
-            "description": "Specifies whether to authenticate with OAuth2 or with an API token. \n\nNote: OAuth2 is currently experimental. Once it is fully supported, using OAuth2 authentication is recommended as it provides enhanced security.",
+            "default": "OAuth2 authentication",
+            "description": "Specifies whether to authenticate with OAuth2 or with an API token. \n\nNote: OAuth2 authentication is recommended as it provides enhanced security.",
             "enum": [
               "OAuth2 authentication",
               "Token authentication"
@@ -74,7 +74,7 @@
               "Uses the OAuth2 authentication",
               "Uses the legacy Snyk Token authentication."
             ],
-            "markdownDescription": "Specifies whether to authenticate with OAuth2 or with an API token. \n\nNote: OAuth2 is currently experimental. Once it is fully supported, using OAuth2 authentication is recommended as it provides enhanced security."
+            "markdownDescription": "Specifies whether to authenticate with OAuth2 or with an API token. \n\nNote: OAuth2 authentication is recommended as it provides enhanced security."
           },
           "snyk.advanced.tokenStorage": {
             "type": "string",


### PR DESCRIPTION
### Description

This PR removed all "experimental" notes about oauth2 authentication and makes it default.
Communications were done. This should go live on August 29.

<img width="540" alt="SCR-20240826-lwkh" src="https://github.com/user-attachments/assets/b1b13c41-1c68-4100-853b-6e1993464ee6">


### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
