### PR TITLE
feat: move delta preview to settings [IDE-622]

### DIFF
--- a/package.json
+++ b/package.json
@@ -256,10 +256,10 @@
             "propertyNames": true,
             "properties": {}
           },
-          "snyk.netNewVsAllIssues": {
+          "snyk.allIssuesVsNetNewIssues": {
             "type": "string",
             "default": "All issues",
-            "description": "Specifies whether to see only net new issues or all issues. Only applies to Code Security and Code Quality.",
+            "description": "Specifies whether to see all issues or only net new issues. Only applies to Code Security and Code Quality.",
             "enum": [
               "All issues",
               "Net new issues"
@@ -268,7 +268,7 @@
               "Shows all issues that have been identified, including both new and existing issues.",
               "Shows only new issues that have been introduced in the latest scan, filtering out previously known issues."
             ],
-            "markdownDescription": "Specifies whether to see only net new issues or all issues. Only applies to Code Security and Code Quality.\n\nNote: this is an experimental feature. Please reach out to [support.snyk.io](https://support.snyk.io) for more details."
+            "markdownDescription": "Specifies whether to see all issues or only net new issues. Only applies to Code Security and Code Quality.\n\nNote: this is an experimental feature. Please reach out to [support.snyk.io](https://support.snyk.io) for more details."
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -168,11 +168,26 @@
             "description": "Severity issues to display.",
             "scope": "window"
           },
+          "snyk.allIssuesVsNetNewIssues": {
+            "type": "string",
+            "default": "All issues",
+            "description": "Specifies whether to see all issues or only net new issues. Only applies to Code Security and Code Quality.",
+            "enum": [
+              "All issues",
+              "Net new issues"
+            ],
+            "enumDescriptions": [
+              "Shows all issues that have been identified, including both new and existing issues.",
+              "Shows only new issues that have been introduced in the latest scan, filtering out previously known issues."
+            ],
+            "markdownDescription": "Specifies whether to see all issues or only net new issues. Only applies to Code Security and Code Quality.\n\n",
+            "order": 6
+          },
           "snyk.advanced.additionalParameters": {
-            "order": 6,
             "type": "string",
             "description": "Parameters to pass to Snyk CLI for Open Source security tests.",
-            "scope": "window"
+            "scope": "window",
+            "order": 7
           }
         }
       },
@@ -255,20 +270,6 @@
             "description": "Preview features that are currently in development. Setting keys will be removed when features become stable.",
             "propertyNames": true,
             "properties": {}
-          },
-          "snyk.allIssuesVsNetNewIssues": {
-            "type": "string",
-            "default": "All issues",
-            "description": "Specifies whether to see all issues or only net new issues. Only applies to Code Security and Code Quality.",
-            "enum": [
-              "All issues",
-              "Net new issues"
-            ],
-            "enumDescriptions": [
-              "Shows all issues that have been identified, including both new and existing issues.",
-              "Shows only new issues that have been introduced in the latest scan, filtering out previously known issues."
-            ],
-            "markdownDescription": "Specifies whether to see all issues or only net new issues. Only applies to Code Security and Code Quality.\n\nNote: this is an experimental feature. Please reach out to [support.snyk.io](https://support.snyk.io) for more details."
           }
         }
       },

--- a/src/snyk/common/constants/settings.ts
+++ b/src/snyk/common/constants/settings.ts
@@ -28,4 +28,4 @@ export const TRUSTED_FOLDERS = `${CONFIGURATION_IDENTIFIER}.trustedFolders`;
 export const FOLDER_CONFIGS = `${CONFIGURATION_IDENTIFIER}.folderConfigs`;
 export const SCANNING_MODE = `${CONFIGURATION_IDENTIFIER}.scanningMode`;
 
-export const DELTA_FINDINGS = `${CONFIGURATION_IDENTIFIER}.netNewVsAllIssues`;
+export const DELTA_FINDINGS = `${CONFIGURATION_IDENTIFIER}.allIssuesVsNetNewIssues`;


### PR DESCRIPTION
### Description

Update the Delta settings as per Figma design.
Update and move Delta settings from the “preview“ state; removed any texts containing preview, and move setting to other  scan configuration settings in the dialog.

![image](https://github.com/user-attachments/assets/9cb8decd-0ae8-46e2-bbe9-5578e266d006)


### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
