### PR TITLE
fix: improve error log when git repo is faulty [IDE-657]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Snyk Security Changelog
 
-## [2.20.0]
-- new error message in UI when net new scan is done on an invalid repository. Net new scans only work on Git.
-
 ## [2.19.0]
 - Moved delta scan preview setting to settings page.
+- New error message in UI when net new scan is done on an invalid repository. Net new scans only work on Git.
 
 ## [2.18.2]
 - Update Language Server Protocol version to 15.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Snyk Security Changelog
 
+## [2.20.0]
+- new error message in UI when net new scan is done on an invalid repository. Net new scans only work on Git.
+
 ## [2.19.0]
 - Moved delta scan preview setting to settings page.
 

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
           "snyk.allIssuesVsNetNewIssues": {
             "type": "string",
             "default": "All issues",
-            "description": "Specifies whether to see all issues or only net new issues. \nNet new issues returns the delta issues between the selected base branch and the local files. Only works in a git repository.\n\n",
+            "description": "Specifies whether to see all issues or only net new issues. Net new issues requires a Git repository, where it compares findings with those in the base branch.",
             "enum": [
               "All issues",
               "Net new issues"
@@ -180,7 +180,7 @@
               "Shows all issues that have been identified, including both new and existing issues.",
               "Shows only new issues that have been introduced in the latest scan, filtering out previously known issues."
             ],
-            "markdownDescription": "Specifies whether to see all issues or only net new issues. \nNet new issues returns the delta issues between the selected base branch and the local files. Only works in a git repository.\n\n",
+            "markdownDescription": "Specifies whether to see all issues or only net new issues. Net new issues a Git repository, where it compares findings with those in the base branch.\n\n",
             "order": 6
           },
           "snyk.advanced.additionalParameters": {

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
           "snyk.allIssuesVsNetNewIssues": {
             "type": "string",
             "default": "All issues",
-            "description": "Specifies whether to see all issues or only net new issues. Only applies to Code Security and Code Quality.",
+            "description": "Specifies whether to see all issues or only net new issues. \nNet new issues returns the delta issues between the selected base branch and the local files. Only works in a git repository.\n\n",
             "enum": [
               "All issues",
               "Net new issues"
@@ -180,7 +180,7 @@
               "Shows all issues that have been identified, including both new and existing issues.",
               "Shows only new issues that have been introduced in the latest scan, filtering out previously known issues."
             ],
-            "markdownDescription": "Specifies whether to see all issues or only net new issues. Only applies to Code Security and Code Quality.\n\n",
+            "markdownDescription": "Specifies whether to see all issues or only net new issues. \nNet new issues returns the delta issues between the selected base branch and the local files. Only works in a git repository.\n\n",
             "order": 6
           },
           "snyk.advanced.additionalParameters": {

--- a/src/snyk/common/editor/codeActionsProvider.ts
+++ b/src/snyk/common/editor/codeActionsProvider.ts
@@ -24,9 +24,7 @@ export abstract class CodeActionsProvider<T> implements CodeActionProvider {
       return undefined;
     }
 
-    for (const result of this.issues.entries()) {
-      const folderPath = result[0];
-      const issues = result[1];
+    for (const [folderPath, issues] of this.issues.entries()) {
       if (issues instanceof Error || !issues) {
         continue;
       }
@@ -36,10 +34,11 @@ export abstract class CodeActionsProvider<T> implements CodeActionProvider {
         continue;
       }
 
-      // returns list of actions, all new actions should be added to this list
+      // If an issue is found, return the actions
       return this.getActions(folderPath, document, issue, range);
     }
 
+    // If no issues were found after checking all entries, return undefined
     return undefined;
   }
 

--- a/src/snyk/common/languageServer/types.ts
+++ b/src/snyk/common/languageServer/types.ts
@@ -11,8 +11,6 @@ export enum LsScanProduct {
   Unknown = '',
 }
 
-//export type InProgress = 'inProgress';
-
 export enum ScanStatus {
   InProgress = 'inProgress',
   Success = 'success',

--- a/src/snyk/common/languageServer/types.ts
+++ b/src/snyk/common/languageServer/types.ts
@@ -24,6 +24,7 @@ export type Scan<T> = {
   product: ScanProduct;
   status: ScanStatus;
   issues: Issue<T>[];
+  errorMessage: string;
 };
 
 export type Issue<T> = {

--- a/src/snyk/common/languageServer/types.ts
+++ b/src/snyk/common/languageServer/types.ts
@@ -11,12 +11,16 @@ export enum LsScanProduct {
   Unknown = '',
 }
 
-export type InProgress = 'inProgress';
+//export type InProgress = 'inProgress';
 
 export enum ScanStatus {
   InProgress = 'inProgress',
   Success = 'success',
   Error = 'error',
+}
+
+export enum LsErrorMessage {
+  repositoryInvalidError = 'repository does not exist',
 }
 
 export type Scan<T> = {

--- a/src/snyk/common/services/productService.ts
+++ b/src/snyk/common/services/productService.ts
@@ -171,7 +171,7 @@ export abstract class ProductService<T> extends AnalysisStatusProvider implement
       const issues = this.diagnosticsIssueProvider.getIssuesFromDiagnostics(scanMsg.product);
       this._result.set(scanMsg.folderPath, issues);
     } else {
-      this._result.set(scanMsg.folderPath, new Error('Failed to analyze.'));
+      this._result.set(scanMsg.folderPath, new Error(scanMsg.errorMessage));
     }
 
     if (this.runningScanCount <= 0) {

--- a/src/snyk/common/views/analysisTreeNodeProvider.ts
+++ b/src/snyk/common/views/analysisTreeNodeProvider.ts
@@ -110,6 +110,21 @@ export abstract class AnalysisTreeNodeProvider extends TreeNodeProvider {
     });
   }
 
+  protected getFaultyRepositoryErrorTreeNode(scanPath?: string, errorMessage?: string): TreeNode {
+    return new TreeNode({
+      icon: NODE_ICONS.error,
+      text: scanPath ? path.basename(scanPath) : messages.scanFailed,
+      description: errorMessage,
+      internal: {
+        isError: true,
+      },
+      command: {
+        command: SNYK_SHOW_LS_OUTPUT_COMMAND,
+        title: 'errorMessage',
+      },
+    });
+  }
+
   protected getNoWorkspaceTrustTreeNode(): TreeNode {
     return new TreeNode({
       text: messages.noWorkspaceTrust,

--- a/src/snyk/common/views/issueTreeProvider.ts
+++ b/src/snyk/common/views/issueTreeProvider.ts
@@ -209,6 +209,11 @@ export abstract class ProductIssueTreeProvider<T> extends AnalysisTreeNodeProvid
       const folderName = shortFolderPath.pop() || uri.path;
 
       let folderVulnCount = 0;
+      if (folderResult instanceof Error && folderResult.message === 'repository does not exist') {
+        nodes.push(this.getFaultyRepositoryErrorTreeNode(folderName, folderResult.toString()));
+        continue;
+      }
+
       if (folderResult instanceof Error) {
         nodes.push(this.getErrorEncounteredTreeNode(folderName));
         continue;

--- a/src/snyk/common/views/issueTreeProvider.ts
+++ b/src/snyk/common/views/issueTreeProvider.ts
@@ -1,7 +1,7 @@
 import _, { flatten } from 'lodash';
 import * as vscode from 'vscode'; // todo: invert dependency
 import { IConfiguration, IssueViewOptions } from '../../common/configuration/configuration';
-import { Issue, IssueSeverity, ScanProduct } from '../../common/languageServer/types';
+import { Issue, IssueSeverity, ScanProduct, LsErrorMessage } from '../../common/languageServer/types';
 import { messages as commonMessages } from '../../common/messages/analysisMessages';
 import { IContextService } from '../../common/services/contextService';
 import { IProductService, ProductService } from '../../common/services/productService';
@@ -209,7 +209,7 @@ export abstract class ProductIssueTreeProvider<T> extends AnalysisTreeNodeProvid
       const folderName = shortFolderPath.pop() || uri.path;
 
       let folderVulnCount = 0;
-      if (folderResult instanceof Error && folderResult.message === 'repository does not exist') {
+      if (folderResult instanceof Error && folderResult.message === LsErrorMessage.repositoryInvalidError) {
         nodes.push(this.getFaultyRepositoryErrorTreeNode(folderName, folderResult.toString()));
         continue;
       }

--- a/src/snyk/snykOss/providers/ossVulnerabilityTreeProvider.ts
+++ b/src/snyk/snykOss/providers/ossVulnerabilityTreeProvider.ts
@@ -52,6 +52,12 @@ export default class OssIssueTreeProvider extends ProductIssueTreeProvider<OssIs
       const folderName = shortFolderPath.pop() || uri.path;
 
       let folderVulnCount = 0;
+
+      if (folderResult instanceof Error && folderResult.message === 'repository does not exist') {
+        nodes.push(this.getFaultyRepositoryErrorTreeNode(folderName, folderResult.toString()));
+        continue;
+      }
+
       if (folderResult instanceof Error) {
         nodes.push(this.getErrorEncounteredTreeNode(folderName));
         continue;

--- a/src/snyk/snykOss/providers/ossVulnerabilityTreeProvider.ts
+++ b/src/snyk/snykOss/providers/ossVulnerabilityTreeProvider.ts
@@ -5,7 +5,7 @@ import { IConfiguration } from '../../common/configuration/configuration';
 import { configuration } from '../../common/configuration/instance';
 import { SNYK_OPEN_ISSUE_COMMAND } from '../../common/constants/commands';
 import { SNYK_ANALYSIS_STATUS } from '../../common/constants/views';
-import { Issue, IssueSeverity, OssIssueData } from '../../common/languageServer/types';
+import { Issue, IssueSeverity, OssIssueData, LsErrorMessage } from '../../common/languageServer/types';
 import { IContextService } from '../../common/services/contextService';
 import { IProductService } from '../../common/services/productService';
 import { IViewManagerService } from '../../common/services/viewManagerService';
@@ -53,7 +53,7 @@ export default class OssIssueTreeProvider extends ProductIssueTreeProvider<OssIs
 
       let folderVulnCount = 0;
 
-      if (folderResult instanceof Error && folderResult.message === 'repository does not exist') {
+      if (folderResult instanceof Error && folderResult.message === LsErrorMessage.repositoryInvalidError) {
         nodes.push(this.getFaultyRepositoryErrorTreeNode(folderName, folderResult.toString()));
         continue;
       }

--- a/src/test/unit/common/services/productService.test.ts
+++ b/src/test/unit/common/services/productService.test.ts
@@ -73,6 +73,7 @@ suite('Product Service', () => {
       folderPath: 'test/path',
       issues: [],
       status: ScanStatus.InProgress,
+      errorMessage: '',
     });
 
     strictEqual(service.isAnalysisRunning, true);
@@ -86,12 +87,14 @@ suite('Product Service', () => {
       folderPath,
       issues: [],
       status: ScanStatus.InProgress,
+      errorMessage: '',
     });
     ls.scan$.next({
       product: ScanProduct.InfrastructureAsCode,
       folderPath,
       issues: [],
       status: ScanStatus.Success,
+      errorMessage: '',
     });
 
     strictEqual(service.isAnalysisRunning, false);
@@ -105,12 +108,14 @@ suite('Product Service', () => {
       folderPath,
       issues: [],
       status: ScanStatus.InProgress,
+      errorMessage: 'Scan failed',
     });
     ls.scan$.next({
       product: ScanProduct.InfrastructureAsCode,
       folderPath,
       issues: [],
       status: ScanStatus.Error,
+      errorMessage: 'Scan failed',
     });
 
     strictEqual(service.isAnalysisRunning, false);
@@ -125,18 +130,21 @@ suite('Product Service', () => {
       folderPath: folder1Path,
       issues: [],
       status: ScanStatus.InProgress,
+      errorMessage: '',
     });
     ls.scan$.next({
       product: ScanProduct.InfrastructureAsCode,
       folderPath: folder2Path,
       issues: [],
       status: ScanStatus.InProgress,
+      errorMessage: '',
     });
     ls.scan$.next({
       product: ScanProduct.InfrastructureAsCode,
       folderPath: folder1Path,
       issues: [],
       status: ScanStatus.Success,
+      errorMessage: '',
     });
 
     strictEqual(service.isAnalysisRunning, true);
@@ -146,6 +154,7 @@ suite('Product Service', () => {
       folderPath: folder2Path,
       issues: [],
       status: ScanStatus.Success,
+      errorMessage: '',
     });
 
     strictEqual(service.isAnalysisRunning, false);

--- a/src/test/unit/snykCode/codeService.test.ts
+++ b/src/test/unit/snykCode/codeService.test.ts
@@ -59,6 +59,7 @@ suite('Code Service', () => {
       folderPath: 'test/path',
       issues: [],
       status: ScanStatus.InProgress,
+      errorMessage: '',
     });
 
     strictEqual(service.isAnalysisRunning, false);

--- a/src/test/unit/snykIac/iacService.test.ts
+++ b/src/test/unit/snykIac/iacService.test.ts
@@ -61,6 +61,7 @@ suite('IaC Service', () => {
       folderPath: 'test/path',
       issues: [],
       status: ScanStatus.InProgress,
+      errorMessage: '',
     });
 
     strictEqual(service.isAnalysisRunning, false);

--- a/src/test/unit/snykOss/ossService.test.ts
+++ b/src/test/unit/snykOss/ossService.test.ts
@@ -59,6 +59,7 @@ suite('OSS Service', () => {
       folderPath: 'test/path',
       issues: [],
       status: ScanStatus.InProgress,
+      errorMessage: '',
     });
 
     strictEqual(service.isAnalysisRunning, true);
@@ -71,6 +72,7 @@ suite('OSS Service', () => {
       folderPath: 'test/path',
       issues: [],
       status: ScanStatus.InProgress,
+      errorMessage: '',
     });
 
     strictEqual(service.isAnalysisRunning, false);


### PR DESCRIPTION
### Description

If a folder has been scanned with net new issues, and it does not contain a valid Git, then the scan returns with an error.
The change now provides a better error response indicating that the scan was done in an invalid repository. 

Old error message
![image](https://github.com/user-attachments/assets/03b893dc-2346-4ece-b102-e4e3f4ac9dfd)

New error message
![image](https://github.com/user-attachments/assets/bf5d4d54-eeec-4f85-b613-83bef6c0d13e)


### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
