### PR TITLE
fix: dissable button after applying fix [IDE-779]

### DIFF
--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScriptLS.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScriptLS.ts
@@ -209,7 +209,7 @@ declare const acquireVsCodeApi: any;
   }
 
   // different AI fix buttons
-  const applyFixButton = document.getElementById('apply-fix') as HTMLElement;
+  const applyFixButton = document.getElementById('apply-fix') as HTMLButtonElement;
   const retryGenerateFixButton = document.getElementById('retry-generate-fix') as HTMLElement;
   const generateAIFixButton = document.getElementById('generate-ai-fix') as HTMLElement;
 
@@ -248,7 +248,8 @@ declare const acquireVsCodeApi: any;
     const filePath = suggestion.filePath;
     const patch = diffSuggestion.unifiedDiffsPerFile[filePath];
     const fixId = diffSuggestion.fixId;
-
+    lastAppliedFix = diffSelectedIndex;
+    applyFixButton.disabled = true;
     const message: ApplyGitDiffMessage = {
       type: 'applyGitDiff',
       args: { filePath, patch, fixId },
@@ -281,16 +282,18 @@ declare const acquireVsCodeApi: any;
   const diffNum2Elem = document.getElementById('diff-number2') as HTMLElement;
 
   let diffSelectedIndex = 0;
-
+  let lastAppliedFix = -1;
   function nextDiff() {
     if (!suggestion || !suggestion.diffs || diffSelectedIndex >= suggestion.diffs.length - 1) return;
     ++diffSelectedIndex;
+    applyFixButton.disabled = diffSelectedIndex == lastAppliedFix
     showCurrentDiff();
   }
 
   function previousDiff() {
     if (!suggestion || !suggestion.diffs || diffSelectedIndex <= 0) return;
     --diffSelectedIndex;
+    applyFixButton.disabled = diffSelectedIndex == lastAppliedFix;
     showCurrentDiff();
   }
 

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScriptLS.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScriptLS.ts
@@ -286,7 +286,7 @@ declare const acquireVsCodeApi: any;
   function nextDiff() {
     if (!suggestion || !suggestion.diffs || diffSelectedIndex >= suggestion.diffs.length - 1) return;
     ++diffSelectedIndex;
-    applyFixButton.disabled = diffSelectedIndex == lastAppliedFix
+    applyFixButton.disabled = diffSelectedIndex == lastAppliedFix;
     showCurrentDiff();
   }
 


### PR DESCRIPTION

### Description

Setting the `applyFix`  button to disabled after applying a certain fix.

By tracking the `lastAppliedFix` we can track, style and disable only the button corresponding to the AI Fix suggestion.
Since most of the styles were pushed to Language Server, the according style for the button can be found [there](https://github.com/snyk/snyk-ls/pull/727). 

This logic disables the button **only** for the **last applied** **suggestion** 
( eg. if we have 3 suggestions and we apply _suggestion1_ ,  apply fix button for _suggestion1_ will be **disabled**, if we then apply fix of _suggestion2_, the button of _suggestion1_ will again be **available** ( enabled ), this prevents blocking the user from experimenting with multiple suggestions. )

<img width="595" alt="Screenshot 2024-12-06 at 14 20 25" src="https://github.com/user-attachments/assets/1b83a1d0-8e1c-4ef0-be21-b30ec3673eb4">


### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
