### PR TITLE
fix: use xdg dir as default cli Path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/traverse": "^7.23.9",
         "@babel/types": "^7.23.9",
         "@deepcode/dcignore": "^1.0.4",
-        "axios": "^1.7.4",
+        "axios": "^1.7.8",
         "diff": "^5.2.0",
         "glob": "^9.3.5",
         "he": "^1.2.0",
@@ -2514,9 +2514,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -10494,9 +10494,9 @@
       }
     },
     "axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -553,7 +553,7 @@
     "@babel/traverse": "^7.23.9",
     "@babel/types": "^7.23.9",
     "@deepcode/dcignore": "^1.0.4",
-    "axios": "^1.7.4",
+    "axios": "^1.7.8",
     "diff": "^5.2.0",
     "glob": "^9.3.5",
     "he": "^1.2.0",

--- a/src/snyk/cli/cliExecutable.ts
+++ b/src/snyk/cli/cliExecutable.ts
@@ -37,7 +37,7 @@ export class CliExecutable {
     windows_arm64: 'snyk-win.exe',
   };
 
-  constructor(public readonly version: string, public readonly checksum: Checksum) { }
+  constructor(public readonly version: string, public readonly checksum: Checksum) {}
 
   static async getPath(customPath?: string): Promise<string> {
     if (customPath) {

--- a/src/snyk/cli/cliExecutable.ts
+++ b/src/snyk/cli/cliExecutable.ts
@@ -5,6 +5,22 @@ import { Checksum } from './checksum';
 import { Platform } from '../common/platform';
 
 export class CliExecutable {
+  public static defaultPaths: Record<CliSupportedPlatform, string> = {
+    linux: process.env.XDG_DATA_HOME ?? '/.local/share/',
+    // eslint-disable-next-line camelcase
+    linux_arm64: process.env.XDG_DATA_HOME ?? '/.local/share/',
+    // eslint-disable-next-line camelcase
+    linux_alpine: process.env.XDG_DATA_HOME ?? '/.local/share/',
+    // eslint-disable-next-line camelcase
+    linux_alpine_arm64: process.env.XDG_DATA_HOME ?? '/.local/share/',
+    macos: process.env.XDG_DATA_HOME ?? '/Library/Application Support/',
+    // eslint-disable-next-line camelcase
+    macos_arm64: process.env.XDG_DATA_HOME ?? '/Library/Application Support/',
+    windows: process.env.XDG_DATA_HOME ?? '\\AppData\\Local\\',
+    // eslint-disable-next-line camelcase
+    windows_arm64: process.env.XDG_DATA_HOME ?? '\\AppData\\Local\\',
+  };
+
   public static filenameSuffixes: Record<CliSupportedPlatform, string> = {
     linux: 'snyk-linux',
     // eslint-disable-next-line camelcase
@@ -20,16 +36,19 @@ export class CliExecutable {
     // eslint-disable-next-line camelcase
     windows_arm64: 'snyk-win.exe',
   };
-  constructor(public readonly version: string, public readonly checksum: Checksum) {}
 
-  static async getPath(extensionDir: string, customPath?: string): Promise<string> {
+  constructor(public readonly version: string, public readonly checksum: Checksum) { }
+
+  static async getPath(customPath?: string): Promise<string> {
     if (customPath) {
       return customPath;
     }
-
     const platform = await CliExecutable.getCurrentWithArch();
+    const homeDir = Platform.getHomeDir();
+    const defaultPath = this.defaultPaths[platform];
     const fileName = CliExecutable.getFileName(platform);
-    return path.join(extensionDir, fileName);
+    const cliDir = path.join(homeDir, defaultPath, 'snyk', 'vscode-cli');
+    return path.join(cliDir, fileName);
   }
 
   static getFileName(platform: CliSupportedPlatform): string {
@@ -67,9 +86,9 @@ export class CliExecutable {
     return platform;
   }
 
-  static async exists(extensionDir: string, customPath?: string): Promise<boolean> {
+  static async exists(customPath?: string): Promise<boolean> {
     return fs
-      .access(await CliExecutable.getPath(extensionDir, customPath))
+      .access(await CliExecutable.getPath(customPath))
       .then(() => true)
       .catch(() => false);
   }

--- a/src/snyk/cli/cliExecutable.ts
+++ b/src/snyk/cli/cliExecutable.ts
@@ -86,6 +86,13 @@ export class CliExecutable {
     return platform;
   }
 
+  public static isPathInExtensionDirectory(dirPath: string, filePath: string): boolean {
+    const normalizedDir = path.resolve(dirPath) + path.sep;
+    const normalizedFile = path.resolve(filePath);
+
+    return normalizedFile.toLowerCase().startsWith(normalizedDir.toLowerCase());
+  }
+
   static async exists(customPath?: string): Promise<boolean> {
     return fs
       .access(await CliExecutable.getPath(customPath))

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -160,7 +160,7 @@ export class Configuration implements IConfiguration {
   private featureFlag: { [key: string]: boolean } = {};
   private extensionId: string;
 
-  constructor(private processEnv: NodeJS.ProcessEnv = process.env, private workspace: IVSCodeWorkspace) { }
+  constructor(private processEnv: NodeJS.ProcessEnv = process.env, private workspace: IVSCodeWorkspace) {}
 
   getExtensionId(): string {
     return this.extensionId;

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -122,7 +122,7 @@ export interface IConfiguration {
 
   isAutomaticDependencyManagementEnabled(): boolean;
 
-  getCliPath(): Promise<string | undefined>;
+  getCliPath(): Promise<string>;
   getCliReleaseChannel(): Promise<string>;
   getCliBaseDownloadUrl(): string;
   getInsecure(): boolean;
@@ -352,7 +352,7 @@ export class Configuration implements IConfiguration {
 
   async setCliPath(cliPath: string | undefined): Promise<void> {
     if (!cliPath) {
-      cliPath = await CliExecutable.getPath(extensionContext.extensionPath);
+      cliPath = await CliExecutable.getPath();
     }
     return this.workspace.updateConfiguration(
       CONFIGURATION_IDENTIFIER,
@@ -555,7 +555,7 @@ export class Configuration implements IConfiguration {
     );
   }
 
-  async getCliPath(): Promise<string | undefined> {
+  async getCliPath(): Promise<string> {
     let cliPath = this.workspace.getConfiguration<string>(
       CONFIGURATION_IDENTIFIER,
       this.getConfigName(ADVANCED_CLI_PATH),
@@ -574,7 +574,7 @@ export class Configuration implements IConfiguration {
     const isAutomaticDependencyManagementEnabled = this.isAutomaticDependencyManagementEnabled();
     const snykLsPath = this.getSnykLanguageServerPath();
     if (!isAutomaticDependencyManagementEnabled && snykLsPath) return snykLsPath;
-    const defaultPath = await CliExecutable.getPath(extensionContext.extensionPath);
+    const defaultPath = await CliExecutable.getPath();
     return defaultPath;
   }
   getTrustedFolders(): string[] {

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -33,7 +33,6 @@ import {
 import SecretStorageAdapter from '../vscode/secretStorage';
 import { IVSCodeWorkspace } from '../vscode/workspace';
 import { CliExecutable } from '../../cli/cliExecutable';
-import { extensionContext } from '../vscode/extensionContext';
 
 const NEWISSUES = 'Net new issues';
 
@@ -161,7 +160,7 @@ export class Configuration implements IConfiguration {
   private featureFlag: { [key: string]: boolean } = {};
   private extensionId: string;
 
-  constructor(private processEnv: NodeJS.ProcessEnv = process.env, private workspace: IVSCodeWorkspace) {}
+  constructor(private processEnv: NodeJS.ProcessEnv = process.env, private workspace: IVSCodeWorkspace) { }
 
   getExtensionId(): string {
     return this.extensionId;

--- a/src/snyk/common/download/downloader.ts
+++ b/src/snyk/common/download/downloader.ts
@@ -26,7 +26,7 @@ export class Downloader {
     private readonly window: IVSCodeWindow,
     private readonly logger: ILog,
     private readonly extensionContext: ExtensionContext,
-  ) {}
+  ) { }
   /**
    * Downloads CLI. Existing executable is deleted.
    */

--- a/src/snyk/common/download/downloader.ts
+++ b/src/snyk/common/download/downloader.ts
@@ -43,10 +43,7 @@ export class Downloader {
   }
 
   private async getCliExecutable(platform: CliSupportedPlatform): Promise<CliExecutable | null> {
-    const cliPath = await CliExecutable.getPath(
-      this.extensionContext.extensionPath,
-      await this.configuration.getCliPath(),
-    );
+    const cliPath = await this.configuration.getCliPath();
     if (await this.binaryExists(cliPath)) {
       await this.deleteFileAtPath(cliPath);
     }

--- a/src/snyk/common/download/downloader.ts
+++ b/src/snyk/common/download/downloader.ts
@@ -26,7 +26,7 @@ export class Downloader {
     private readonly window: IVSCodeWindow,
     private readonly logger: ILog,
     private readonly extensionContext: ExtensionContext,
-  ) { }
+  ) {}
   /**
    * Downloads CLI. Existing executable is deleted.
    */
@@ -46,7 +46,7 @@ export class Downloader {
 
   private async getCliExecutable(platform: CliSupportedPlatform): Promise<CliExecutable | null> {
     const cliPath = await this.configuration.getCliPath();
-    const cliDir = path.dirname(cliPath);;
+    const cliDir = path.dirname(cliPath);
     mkdirSync(cliDir, { recursive: true });
     if (await this.binaryExists(cliPath)) {
       await this.deleteFileAtPath(cliPath);

--- a/src/snyk/common/download/downloader.ts
+++ b/src/snyk/common/download/downloader.ts
@@ -2,6 +2,7 @@ import axios, { CancelTokenSource } from 'axios';
 import * as fs from 'fs';
 import * as fsPromises from 'fs/promises';
 import * as stream from 'stream';
+import { mkdirSync } from 'fs';
 import { Progress } from 'vscode';
 import { Checksum } from '../../cli/checksum';
 import { messages } from '../../cli/messages/messages';
@@ -44,6 +45,7 @@ export class Downloader {
 
   private async getCliExecutable(platform: CliSupportedPlatform): Promise<CliExecutable | null> {
     const cliPath = await this.configuration.getCliPath();
+    mkdirSync(cliPath, { recursive: true });
     if (await this.binaryExists(cliPath)) {
       await this.deleteFileAtPath(cliPath);
     }

--- a/src/snyk/common/download/downloader.ts
+++ b/src/snyk/common/download/downloader.ts
@@ -1,5 +1,6 @@
 import axios, { CancelTokenSource } from 'axios';
 import * as fs from 'fs';
+import * as path from 'path';
 import * as fsPromises from 'fs/promises';
 import * as stream from 'stream';
 import { mkdirSync } from 'fs';
@@ -45,7 +46,8 @@ export class Downloader {
 
   private async getCliExecutable(platform: CliSupportedPlatform): Promise<CliExecutable | null> {
     const cliPath = await this.configuration.getCliPath();
-    mkdirSync(cliPath, { recursive: true });
+    const cliDir = path.dirname(cliPath);;
+    mkdirSync(cliDir, { recursive: true });
     if (await this.binaryExists(cliPath)) {
       await this.deleteFileAtPath(cliPath);
     }

--- a/src/snyk/common/languageServer/languageServer.ts
+++ b/src/snyk/common/languageServer/languageServer.ts
@@ -78,10 +78,7 @@ export class LanguageServer implements ILanguageServer {
       };
     }
 
-    const cliBinaryPath = await CliExecutable.getPath(
-      this.extensionContext.extensionPath,
-      await this.configuration.getCliPath(),
-    );
+    const cliBinaryPath = await this.configuration.getCliPath();
 
     // log level is set to info by default
     let logLevel = 'info';
@@ -167,7 +164,6 @@ export class LanguageServer implements ILanguageServer {
     const settings = await LanguageServerSettings.fromConfiguration(
       this.configuration,
       this.user,
-      this.extensionContext,
     );
     return settings;
   }

--- a/src/snyk/common/languageServer/languageServer.ts
+++ b/src/snyk/common/languageServer/languageServer.ts
@@ -161,10 +161,7 @@ export class LanguageServer implements ILanguageServer {
   // Initialization options are not semantically equal to server settings, thus separated here
   // https://github.com/microsoft/language-server-protocol/issues/567
   async getInitializationOptions(): Promise<ServerSettings> {
-    const settings = await LanguageServerSettings.fromConfiguration(
-      this.configuration,
-      this.user,
-    );
+    const settings = await LanguageServerSettings.fromConfiguration(this.configuration, this.user);
     return settings;
   }
 

--- a/src/snyk/common/languageServer/middleware.ts
+++ b/src/snyk/common/languageServer/middleware.ts
@@ -44,7 +44,6 @@ export class LanguageClientMiddleware implements Middleware {
       const serverSettings = await LanguageServerSettings.fromConfiguration(
         this.configuration,
         this.user,
-        this.extensionContext,
       );
       return [serverSettings];
     },

--- a/src/snyk/common/languageServer/middleware.ts
+++ b/src/snyk/common/languageServer/middleware.ts
@@ -20,7 +20,7 @@ type LanguageClientWorkspaceMiddleware = Partial<WorkspaceMiddleware> & {
 };
 
 export class LanguageClientMiddleware implements Middleware {
-  constructor(private configuration: IConfiguration, private user: User, private extensionContext: ExtensionContext) {}
+  constructor(private configuration: IConfiguration, private user: User, private extensionContext: ExtensionContext) { }
 
   workspace: LanguageClientWorkspaceMiddleware = {
     configuration: async (

--- a/src/snyk/common/languageServer/middleware.ts
+++ b/src/snyk/common/languageServer/middleware.ts
@@ -20,7 +20,7 @@ type LanguageClientWorkspaceMiddleware = Partial<WorkspaceMiddleware> & {
 };
 
 export class LanguageClientMiddleware implements Middleware {
-  constructor(private configuration: IConfiguration, private user: User, private extensionContext: ExtensionContext) { }
+  constructor(private configuration: IConfiguration, private user: User, private extensionContext: ExtensionContext) {}
 
   workspace: LanguageClientWorkspaceMiddleware = {
     configuration: async (
@@ -41,10 +41,7 @@ export class LanguageClientMiddleware implements Middleware {
         return [];
       }
 
-      const serverSettings = await LanguageServerSettings.fromConfiguration(
-        this.configuration,
-        this.user,
-      );
+      const serverSettings = await LanguageServerSettings.fromConfiguration(this.configuration, this.user);
       return [serverSettings];
     },
   };

--- a/src/snyk/common/languageServer/settings.ts
+++ b/src/snyk/common/languageServer/settings.ts
@@ -3,7 +3,6 @@ import { CLI_INTEGRATION_NAME } from '../../cli/contants/integration';
 import { Configuration, FolderConfig, IConfiguration, SeverityFilter } from '../configuration/configuration';
 import { User } from '../user';
 import { PROTOCOL_VERSION } from '../constants/languageServer';
-import { ExtensionContext } from '../vscode/extensionContext';
 
 export type ServerSettings = {
   // Feature toggles

--- a/src/snyk/common/languageServer/settings.ts
+++ b/src/snyk/common/languageServer/settings.ts
@@ -3,7 +3,6 @@ import { CLI_INTEGRATION_NAME } from '../../cli/contants/integration';
 import { Configuration, FolderConfig, IConfiguration, SeverityFilter } from '../configuration/configuration';
 import { User } from '../user';
 import { PROTOCOL_VERSION } from '../constants/languageServer';
-import { CliExecutable } from '../../cli/cliExecutable';
 import { ExtensionContext } from '../vscode/extensionContext';
 
 export type ServerSettings = {
@@ -53,7 +52,6 @@ export class LanguageServerSettings {
   static async fromConfiguration(
     configuration: IConfiguration,
     user: User,
-    extensionContext: ExtensionContext,
   ): Promise<ServerSettings> {
     const featuresConfiguration = configuration.getFeaturesConfiguration();
 
@@ -74,7 +72,7 @@ export class LanguageServerSettings {
       activateSnykIac: `${iacEnabled}`,
       enableDeltaFindings: `${configuration.getDeltaFindingsEnabled()}`,
       sendErrorReports: `${configuration.shouldReportErrors}`,
-      cliPath: await CliExecutable.getPath(extensionContext.extensionPath, await configuration.getCliPath()),
+      cliPath: await configuration.getCliPath(),
       endpoint: configuration.snykApiEndpoint,
       organization: configuration.organization,
       token: await configuration.getToken(),

--- a/src/snyk/common/languageServer/settings.ts
+++ b/src/snyk/common/languageServer/settings.ts
@@ -49,10 +49,7 @@ export type ServerSettings = {
 };
 
 export class LanguageServerSettings {
-  static async fromConfiguration(
-    configuration: IConfiguration,
-    user: User,
-  ): Promise<ServerSettings> {
+  static async fromConfiguration(configuration: IConfiguration, user: User): Promise<ServerSettings> {
     const featuresConfiguration = configuration.getFeaturesConfiguration();
 
     const ossEnabled = _.isUndefined(featuresConfiguration.ossEnabled) ? true : featuresConfiguration.ossEnabled;

--- a/src/snyk/common/services/downloadService.ts
+++ b/src/snyk/common/services/downloadService.ts
@@ -91,7 +91,6 @@ export class DownloadService {
   async isCliInstalled() {
     const cliExecutableExists = await CliExecutable.exists(
       this.extensionContext.extensionPath,
-      await this.configuration.getCliPath(),
     );
     const cliChecksumWritten = !!this.getCliChecksum();
 
@@ -105,10 +104,7 @@ export class DownloadService {
       return false;
     }
     const latestChecksum = await this.cliApi.getSha256Checksum(version, platform);
-    const path = await CliExecutable.getPath(
-      this.extensionContext.extensionPath,
-      await this.configuration.getCliPath(),
-    );
+    const path = await this.configuration.getCliPath();
 
     // Update is available if fetched checksum not matching the current one
     const checksum = await Checksum.getChecksumOf(path, latestChecksum);

--- a/src/snyk/common/services/downloadService.ts
+++ b/src/snyk/common/services/downloadService.ts
@@ -90,9 +90,7 @@ export class DownloadService {
   }
 
   async isCliInstalled() {
-    const cliExecutableExists = await CliExecutable.exists(
-      this.extensionContext.extensionPath,
-    );
+    const cliExecutableExists = await CliExecutable.exists(this.extensionContext.extensionPath);
     const cliChecksumWritten = !!this.getCliChecksum();
 
     return cliExecutableExists && cliChecksumWritten;
@@ -111,6 +109,7 @@ export class DownloadService {
       try {
         await fsPromises.unlink(path);
       } catch {
+        // eslint-disable-next-line no-empty
       }
       await this.configuration.setCliPath(await CliExecutable.getPath());
       return true;

--- a/src/test/unit/cli/cliExecutable.test.ts
+++ b/src/test/unit/cli/cliExecutable.test.ts
@@ -23,7 +23,6 @@ suite('CliExecutable', () => {
     const homedirStub = sinon.stub(os, 'homedir');
     const unixExtensionDir = '/.local/share/snyk/vscode-cli';
     const macOsExtensionDir = '/Library/Application Support/snyk/vscode-cli';
-    const winExtensionDir = `\\AppData\\Local\\snyk\\vscode-cli`;
 
     const osStub = sinon.stub(Platform, 'getCurrent').returns('darwin');
     const archStub = sinon.stub(Platform, 'getArch').returns('x64');
@@ -45,17 +44,18 @@ suite('CliExecutable', () => {
 
     osStub.returns('win32');
     homedir = 'C:\\Users\\user';
-    homedirStub.returns(homedir);    
-    expectedCliPath = path.join(Platform.getHomeDir(), winExtensionDir, 'snyk-win.exe');
-    strictEqual(await CliExecutable.getPath(), expectedCliPath);
+    homedirStub.returns(homedir);
+    expectedCliPath = path.join(Platform.getHomeDir(), '\\AppData\\Local\\', 'snyk', 'vscode-cli', 'snyk-win.exe');
+    const actualPath = await CliExecutable.getPath();
+    strictEqual(actualPath, expectedCliPath);
 
     // test arm64
     archStub.returns('arm64');
 
     osStub.returns('darwin');
     homedir = '/home/user';
-    homedirStub.returns(homedir);        
-    expectedCliPath = path.join(Platform.getHomeDir(), unixExtensionDir, 'snyk-macos-arm64');
+    homedirStub.returns(homedir);
+    expectedCliPath = path.join(Platform.getHomeDir(), macOsExtensionDir, 'snyk-macos-arm64');
     strictEqual(await CliExecutable.getPath(), expectedCliPath);
 
     osStub.returns('linux');
@@ -69,8 +69,8 @@ suite('CliExecutable', () => {
 
     osStub.returns('win32');
     homedir = 'C:\\Users\\user';
-    homedirStub.returns(homedir);        
-    expectedCliPath = path.join(Platform.getHomeDir(), winExtensionDir, 'snyk-win.exe');
+    homedirStub.returns(homedir);
+    expectedCliPath = path.join(Platform.getHomeDir(), '\\AppData\\Local\\', 'snyk', 'vscode-cli', 'snyk-win.exe');
     strictEqual(await CliExecutable.getPath(), expectedCliPath);
   });
 

--- a/src/test/unit/common/configuration.test.ts
+++ b/src/test/unit/common/configuration.test.ts
@@ -149,7 +149,7 @@ suite('Configuration', () => {
 
       const cliPath = await configuration.getCliPath();
 
-      const expectedCliPath = path.join('path/to/extension/', 'snyk-linux');
+      const expectedCliPath = path.join(Platform.getHomeDir(), '.local/share/snyk/vscode-cli', 'snyk-linux');
       strictEqual(cliPath, expectedCliPath);
     });
 

--- a/src/test/unit/common/languageServer/middleware.test.ts
+++ b/src/test/unit/common/languageServer/middleware.test.ts
@@ -110,10 +110,7 @@ suite('Language Server: Middleware', () => {
       serverResult.manageBinariesAutomatically,
       `${configuration.isAutomaticDependencyManagementEnabled()}`,
     );
-    assert.strictEqual(
-      serverResult.cliPath,
-      await configuration.getCliPath(),
-    );
+    assert.strictEqual(serverResult.cliPath, await configuration.getCliPath());
     assert.strictEqual(serverResult.enableTrustedFoldersFeature, 'true');
     assert.deepStrictEqual(serverResult.trustedFolders, configuration.getTrustedFolders());
   });

--- a/src/test/unit/common/languageServer/middleware.test.ts
+++ b/src/test/unit/common/languageServer/middleware.test.ts
@@ -112,7 +112,7 @@ suite('Language Server: Middleware', () => {
     );
     assert.strictEqual(
       serverResult.cliPath,
-      await CliExecutable.getPath(extensionContextMock.extensionPath, await configuration.getCliPath()),
+      await configuration.getCliPath(),
     );
     assert.strictEqual(serverResult.enableTrustedFoldersFeature, 'true');
     assert.deepStrictEqual(serverResult.trustedFolders, configuration.getTrustedFolders());

--- a/src/test/unit/common/languageServer/settings.test.ts
+++ b/src/test/unit/common/languageServer/settings.test.ts
@@ -49,7 +49,6 @@ suite('LanguageServerSettings', () => {
       const serverSettings = await LanguageServerSettings.fromConfiguration(
         mockConfiguration,
         mockUser,
-        extensionContextMock,
       );
 
       assert.strictEqual(serverSettings.activateSnykCodeSecurity, 'true');

--- a/src/test/unit/common/languageServer/settings.test.ts
+++ b/src/test/unit/common/languageServer/settings.test.ts
@@ -46,10 +46,7 @@ suite('LanguageServerSettings', () => {
         scanningMode: 'scan-mode',
       } as unknown as IConfiguration;
 
-      const serverSettings = await LanguageServerSettings.fromConfiguration(
-        mockConfiguration,
-        mockUser,
-      );
+      const serverSettings = await LanguageServerSettings.fromConfiguration(mockConfiguration, mockUser);
 
       assert.strictEqual(serverSettings.activateSnykCodeSecurity, 'true');
       assert.strictEqual(serverSettings.activateSnykCodeQuality, 'true');


### PR DESCRIPTION
### Description
- Change default CLI download path to use XDG dirs.
- Migrate existing config for CLI path if it's in extension folder.
- revert back logic to ensure creation of CLI dir.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
