### PR TITLE
fix: force cli download if checksum fails

### DIFF
--- a/src/snyk/common/services/downloadService.ts
+++ b/src/snyk/common/services/downloadService.ts
@@ -115,10 +115,15 @@ export class DownloadService {
       return true;
     }
     // Update is available if fetched checksum not matching the current one
-    const checksum = await Checksum.getChecksumOf(path, latestChecksum);
-    if (checksum.verify()) {
-      this.logger.info(messages.isLatest);
-      return false;
+    try {
+      const checksum = await Checksum.getChecksumOf(path, latestChecksum);
+      if (checksum.verify()) {
+        this.logger.info(messages.isLatest);
+        return false;
+      }
+    } catch {
+      // if checksum check fails; force an update
+      return true;
     }
 
     return true;


### PR DESCRIPTION
### Description

When the path to the CLI binary doesn't exists the checksum would fail and throw an error, not downloading the CLI, if the checksum fails we will force a download.
### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
