### PR TITLE
Fix: Change text for help and feedback to not refer to FAQs

### DIFF
--- a/src/snyk/base/views/supportProvider.ts
+++ b/src/snyk/base/views/supportProvider.ts
@@ -12,38 +12,32 @@ export class SupportProvider extends TreeNodeProvider {
         link: 'https://snyk.io/contact-us/?utm_source=vsc',
       }),
       new TreeNode({
-        text: 'Top 3 FAQ',
+        text: 'Get the most out of the Snyk extension',
+        icon: new ThemeIcon('file-text'),
+        link: 'https://docs.snyk.io/ide-tools/visual-studio-code-extension',
+      }),
+      new TreeNode({
+        text: 'Ignore files and directories',
+        icon: new ThemeIcon('file-text'),
         collapsed: TreeItemCollapsibleState.Expanded,
         children: [
           new TreeNode({
-            text: '1. How to get the most out of Snyk’s extension?',
-            icon: new ThemeIcon('file-text'),
-            link: 'https://docs.snyk.io/ide-tools/visual-studio-code-extension',
+            text: 'Add a pre-filled .dcignore file',
+            icon: new ThemeIcon('new-file'),
+            command: {
+              command: SNYK_DCIGNORE_COMMAND,
+              title: '',
+              arguments: [],
+            },
           }),
           new TreeNode({
-            text: '2. How to ignore files and directories?',
-            icon: new ThemeIcon('file-text'),
-            collapsed: TreeItemCollapsibleState.Expanded,
-            children: [
-              new TreeNode({
-                text: 'Add default .dcignore file to your workspace',
-                icon: new ThemeIcon('new-file'),
-                command: {
-                  command: SNYK_DCIGNORE_COMMAND,
-                  title: '',
-                  arguments: [],
-                },
-              }),
-              new TreeNode({
-                text: 'Add a custom .dcignore file to your workspace',
-                icon: new ThemeIcon('new-file'),
-                command: {
-                  command: SNYK_DCIGNORE_COMMAND,
-                  title: '',
-                  arguments: [true],
-                },
-              }),
-            ],
+            text: 'Add a blank .dcignore file',
+            icon: new ThemeIcon('new-file'),
+            command: {
+              command: SNYK_DCIGNORE_COMMAND,
+              title: '',
+              arguments: [true],
+            },
           }),
         ],
       }),


### PR DESCRIPTION
### Description

Just a change in the Help and Feedback box to be a little more internally consistent.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [x] README.md updated, if user-facing

### Screenshots / GIFs

FROM:
![CleanShot 2025-02-12 at 14 41 53@2x](https://github.com/user-attachments/assets/f5a1386e-c4d4-46d5-8acd-6254357a40f8)

TO:

![CleanShot 2025-02-13 at 15 47 48@2x](https://github.com/user-attachments/assets/2ffe5f85-2b34-4898-b997-ab6946e5be80)

