### PR TITLE
feat: snyk uri handler [IDE-955] [IDE-975]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Snyk Security Changelog
 
+## [2.22.0]
+- Using Code Actions to view an AI Fix now shows the affected issue in a details pane.
+
 ## [2.21.0]
 - add scan summary
 - add ability to enter PATs as Tokens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Snyk Security Changelog
 
 ## [2.22.0]
-- Using Code Actions to view an AI Fix now shows the affected issue in a details pane.
+- Using Code Actions to view an AI Fix now shows the affected issue in the tree view and details pane.
 
 ## [2.21.0]
 - add scan summary

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@babel/types": "^7.23.9",
         "@deepcode/dcignore": "^1.0.4",
         "axios": "^1.7.8",
-        "diff": "^5.2.0",
         "glob": "^9.3.5",
         "he": "^1.2.0",
         "htmlparser2": "^7.2.0",
@@ -3443,6 +3442,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
       "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -11181,7 +11181,8 @@
     "diff": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A=="
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -561,7 +561,6 @@
     "@babel/types": "^7.23.9",
     "@deepcode/dcignore": "^1.0.4",
     "axios": "^1.7.8",
-    "diff": "^5.2.0",
     "glob": "^9.3.5",
     "he": "^1.2.0",
     "htmlparser2": "^7.2.0",

--- a/src/snyk/common/commands/commandController.ts
+++ b/src/snyk/common/commands/commandController.ts
@@ -119,7 +119,7 @@ export class CommandController {
       await this.openLocalFile(issue.filePath, issueArgs.range);
 
       try {
-        this.snykCode.showSuggestionProvider(issueArgs.folderPath, issueArgs.id);
+        await this.snykCode.showSuggestionProvider(issueArgs.folderPath, issueArgs.id);
       } catch (e) {
         ErrorHandler.handle(e, this.logger);
       }
@@ -151,7 +151,7 @@ export class CommandController {
       await this.openLocalFile(issue.filePath, issueArgs.range);
 
       try {
-        this.iacService.showSuggestionProvider(issueArgs.folderPath, issueArgs.id);
+        await this.iacService.showSuggestionProvider(issueArgs.folderPath, issueArgs.id);
       } catch (e) {
         ErrorHandler.handle(e, this.logger);
       }

--- a/src/snyk/common/constants/commands.ts
+++ b/src/snyk/common/constants/commands.ts
@@ -26,6 +26,7 @@ export const SNYK_WORKSPACE_SCAN_COMMAND = 'snyk.workspace.scan';
 export const SNYK_TRUST_WORKSPACE_FOLDERS_COMMAND = 'snyk.trustWorkspaceFolders';
 export const SNYK_GET_ACTIVE_USER = 'snyk.getActiveUser';
 export const SNYK_CODE_FIX_DIFFS_COMMAND = 'snyk.code.fixDiffs';
+export const SNYK_CODE_FIX_APPLY_EDIT_COMMAND = 'snyk.code.fixApplyEdit';
 export const SNYK_CODE_SUBMIT_FIX_FEEDBACK = 'snyk.code.submitFixFeedback';
 export const SNYK_FEATURE_FLAG_COMMAND = 'snyk.getFeatureFlagStatus';
 export const SNYK_CLEAR_CACHE_COMMAND = 'snyk.clearCache';

--- a/src/snyk/common/languageServer/languageServer.ts
+++ b/src/snyk/common/languageServer/languageServer.ts
@@ -22,7 +22,7 @@ import { IVSCodeWindow } from '../vscode/window';
 import { IVSCodeWorkspace } from '../vscode/workspace';
 import { LanguageClientMiddleware } from './middleware';
 import { LanguageServerSettings, ServerSettings } from './settings';
-import { CodeIssueData, IacIssueData, OssIssueData, Scan } from './types';
+import { ShowIssueDetailTopicParams, CodeIssueData, IacIssueData, OssIssueData, Scan } from './types';
 import { ExtensionContext } from '../vscode/extensionContext';
 import { ISummaryProviderService } from '../../base/summary/summaryProviderService';
 
@@ -35,12 +35,14 @@ export interface ILanguageServer {
 
   cliReady$: ReplaySubject<string>;
   scan$: Subject<Scan<CodeIssueData | OssIssueData | IacIssueData>>;
+  showIssueDetailTopic$: Subject<ShowIssueDetailTopicParams>;
 }
 
 export class LanguageServer implements ILanguageServer {
   private client: LanguageClient;
   readonly cliReady$ = new ReplaySubject<string>(1);
   readonly scan$ = new Subject<Scan<CodeIssueData | OssIssueData | IacIssueData>>();
+  readonly showIssueDetailTopic$ = new Subject<ShowIssueDetailTopicParams>();
 
   constructor(
     private user: User,
@@ -113,7 +115,7 @@ export class LanguageServer implements ILanguageServer {
       synchronize: {
         configurationSection: CONFIGURATION_IDENTIFIER,
       },
-      middleware: new LanguageClientMiddleware(this.configuration, this.user, this.extensionContext),
+      middleware: new LanguageClientMiddleware(this.logger, this.configuration, this.user, this.showIssueDetailTopic$),
       /**
        * We reuse the output channel here as it's not properly disposed of by the language client (vscode-languageclient@8.0.0-next.2)
        * See: https://github.com/microsoft/vscode-languageserver-node/blob/cdf4d6fdaefe329ce417621cf0f8b14e0b9bb39d/client/src/common/client.ts#L2789

--- a/src/snyk/common/languageServer/middleware.ts
+++ b/src/snyk/common/languageServer/middleware.ts
@@ -54,6 +54,10 @@ export class LanguageClientMiddleware implements Middleware {
     ) => {
       if (params.uri.startsWith('snyk:')) {
         console.log(`Intercepted window/showDocument request: ${params.uri}`);
+        // 'snyk://filePath?product=Snyk+Code&issueId=f657804e7d3e7ca96968c8d707641217&action=showInDetailPanel'
+        // Implement a handler for the action param
+        // TODO: select issue that matches product + issueId in the tree and maybe refresh it
+        // don't continue processing
       }
       const result = await next(params, CancellationToken.None);
 

--- a/src/snyk/common/languageServer/middleware.ts
+++ b/src/snyk/common/languageServer/middleware.ts
@@ -11,9 +11,7 @@ import type {
   ShowDocumentResult,
   WindowMiddleware,
 } from '../vscode/types';
-import {
-  CancellationToken,
-} from '../vscode/types';
+import { CancellationToken } from '../vscode/types';
 import { LanguageServerSettings, ServerSettings } from './settings';
 import { ShowIssueDetailTopicParams, LsScanProduct, SnykURIAction } from './types';
 import { Subject } from 'rxjs';
@@ -31,7 +29,7 @@ export class LanguageClientMiddleware implements Middleware {
     private readonly logger: ILog,
     private configuration: IConfiguration,
     private user: User,
-    private showIssueDetailTopic$: Subject<ShowIssueDetailTopicParams>
+    private showIssueDetailTopic$: Subject<ShowIssueDetailTopicParams>,
   ) {}
 
   workspace: LanguageClientWorkspaceMiddleware = {
@@ -58,10 +56,7 @@ export class LanguageClientMiddleware implements Middleware {
     },
   };
   window: WindowMiddleware = {
-    showDocument: async (
-      params: ShowDocumentParams,
-      next,
-    ) => {
+    showDocument: async (params: ShowDocumentParams, next) => {
       let uri;
       try {
         uri = new URL(params.uri);
@@ -72,15 +67,17 @@ export class LanguageClientMiddleware implements Middleware {
         // 'snyk://filePath?product=Snyk+Code&issueId=123abc456&action=showInDetailPanel'
         const action = uri.searchParams.get('action');
         if (action === SnykURIAction.ShowInDetailPanel) {
-          this.logger.info(`Intercepted window/showDocument request (action=${SnykURIAction.ShowInDetailPanel}): ${params.uri}`);
-          const filePath = uri.pathname;
+          this.logger.info(
+            `Intercepted window/showDocument request (action=${SnykURIAction.ShowInDetailPanel}): ${params.uri}`,
+          );
+          const _filePath = uri.pathname;
           const product = uri.searchParams.get('product');
           if (product !== LsScanProduct.Code) {
-            throw new Error(`Currently only able to handle showing issues for "${LsScanProduct.Code}"`)
+            throw new Error(`Currently only able to handle showing issues for "${LsScanProduct.Code}"`);
           }
           const issueId = uri.searchParams.get('issueId');
           if (issueId === null || issueId === '') {
-            throw new Error(`Invalid "snyk:" URI recieved (bad issueId)! ${params.uri}`)
+            throw new Error(`Invalid "snyk:" URI recieved (bad issueId)! ${params.uri}`);
           }
 
           this.showIssueDetailTopic$.next({
@@ -91,10 +88,10 @@ export class LanguageClientMiddleware implements Middleware {
           // TODO: select issue that matches product + issueId in the tree and maybe refresh it
           // don't continue processing
 
-          return {success: true};
+          return { success: true };
         }
       }
-      return await next(params, CancellationToken.None) as ShowDocumentResult;
+      return (await next(params, CancellationToken.None)) as ShowDocumentResult;
     },
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/snyk/common/languageServer/middleware.ts
+++ b/src/snyk/common/languageServer/middleware.ts
@@ -1,13 +1,15 @@
+import { CancellationToken, RequestHandler, ShowDocumentRequest, WindowMiddleware } from 'vscode-languageclient';
 import { IConfiguration } from '../../common/configuration/configuration';
 import { User } from '../user';
 import { ExtensionContext } from '../vscode/extensionContext';
 import type {
-  CancellationToken,
   ConfigurationParams,
   ConfigurationRequestHandlerSignature,
   Middleware,
   ResponseError,
   WorkspaceMiddleware,
+  ShowDocumentParams,
+  ShowDocumentResult,
 } from '../vscode/types';
 import { LanguageServerSettings, ServerSettings } from './settings';
 
@@ -45,10 +47,26 @@ export class LanguageClientMiddleware implements Middleware {
       return [serverSettings];
     },
   };
+  window: WindowMiddleware = {
+    showDocument: async (
+      params: ShowDocumentParams,
+      next,
+    ) => {
+      if (params.uri.startsWith('snyk:')) {
+        console.log(`Intercepted window/showDocument request: ${params.uri}`);
+      }
+      const result = await next(params, CancellationToken.None);
 
+      return result as ShowDocumentResult;
+    },
+  };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   isThenable<T>(v: any): v is Thenable<T> {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     return typeof v?.then === 'function';
   }
 }
+function isResponseError(result: import("vscode-languageclient").ResponseError<void> | import("vscode-languageclient").ShowDocumentResult) {
+  throw new Error('Function not implemented.');
+}
+

--- a/src/snyk/common/languageServer/middleware.ts
+++ b/src/snyk/common/languageServer/middleware.ts
@@ -85,9 +85,6 @@ export class LanguageClientMiddleware implements Middleware {
             issueId,
           });
 
-          // TODO: select issue that matches product + issueId in the tree and maybe refresh it
-          // don't continue processing
-
           return { success: true };
         }
       }

--- a/src/snyk/common/languageServer/types.ts
+++ b/src/snyk/common/languageServer/types.ts
@@ -146,3 +146,12 @@ export type SummaryMessage = {
     summary: Summary;
   };
 };
+
+export enum SnykURIAction {
+  ShowInDetailPanel = 'showInDetailPanel',
+}
+
+export type ShowIssueDetailTopicParams = {
+  issueId: string;
+  product: LsScanProduct;
+}

--- a/src/snyk/common/languageServer/types.ts
+++ b/src/snyk/common/languageServer/types.ts
@@ -154,4 +154,4 @@ export enum SnykURIAction {
 export type ShowIssueDetailTopicParams = {
   issueId: string;
   product: LsScanProduct;
-}
+};

--- a/src/snyk/common/services/productService.ts
+++ b/src/snyk/common/services/productService.ts
@@ -41,7 +41,7 @@ export abstract class ProductService<T> extends AnalysisStatusProvider implement
   private runningScanCount = 0;
 
   protected lsScanSubscription: Subscription;
-  protected lsAiFixSubscription: Subscription;
+  protected lsShowIssueDetailSubscription: Subscription;
 
   protected disposables: Disposable[] = [];
 
@@ -61,7 +61,7 @@ export abstract class ProductService<T> extends AnalysisStatusProvider implement
     super();
     this._result = new Map<string, WorkspaceFolderResult<T>>();
     this.lsScanSubscription = this.subscribeToLsScanMessages();
-    this.lsAiFixSubscription = this.subscribeToLsAiFixMessages();
+    this.lsShowIssueDetailSubscription = this.subscribeToShowIssueDetailMessages();
   }
 
   abstract subscribeToLsScanMessages(): Subscription;
@@ -158,7 +158,7 @@ export abstract class ProductService<T> extends AnalysisStatusProvider implement
 
   dispose(): void {
     this.lsScanSubscription.unsubscribe();
-    this.lsAiFixSubscription.unsubscribe();
+    this.lsShowIssueDetailSubscription.unsubscribe();
   }
 
   // Must be called from the child class to listen on scan messages
@@ -180,13 +180,13 @@ export abstract class ProductService<T> extends AnalysisStatusProvider implement
     }
   }
 
-  private subscribeToLsAiFixMessages(): Subscription {
-    return this.languageServer.showIssueDetailTopic$.subscribe((aiFix) => {
-      if (aiFix.product !== this.lsScanProduct) {
+  private subscribeToShowIssueDetailMessages(): Subscription {
+    return this.languageServer.showIssueDetailTopic$.subscribe(params => {
+      if (params.product !== this.lsScanProduct) {
         return;
       }
 
-      this.showSuggestionProviderById(aiFix.issueId);
+      void this.showSuggestionProviderById(params.issueId);
     });
   }
 

--- a/src/snyk/common/services/productTreeViewService.ts
+++ b/src/snyk/common/services/productTreeViewService.ts
@@ -1,0 +1,33 @@
+import * as vscode from 'vscode';
+import { ProductIssueTreeProvider } from '../views/issueTreeProvider';
+import { TreeNode } from '../views/treeNode';
+import { ILanguageServer } from '../languageServer/languageServer';
+import { LsScanProduct } from '../languageServer/types';
+import { Subscription } from 'rxjs';
+import { Disposable } from '../vscode/types';
+
+export class ProductTreeViewService<T> implements Disposable {
+  protected lsShowIssueDetailSubscription: Subscription;
+
+  constructor(
+    private readonly treeView: vscode.TreeView<TreeNode>,
+    private readonly productIssueTreeProvider: ProductIssueTreeProvider<T>,
+    private readonly languageServer: ILanguageServer,
+    readonly lsScanProduct: LsScanProduct,
+  ) {
+    this.lsShowIssueDetailSubscription = this.subscribeToShowIssueDetailMessages();
+  }
+
+  dispose(): void {
+    this.lsShowIssueDetailSubscription.unsubscribe();
+  }
+
+  private subscribeToShowIssueDetailMessages(): Subscription {
+    return this.languageServer.showIssueDetailTopic$.subscribe(params => {
+      if (params.product !== this.lsScanProduct) {
+        return;
+      }
+      void this.productIssueTreeProvider.revealIssueById(this.treeView, params.issueId);
+    });
+  }
+}

--- a/src/snyk/common/tsUtil.ts
+++ b/src/snyk/common/tsUtil.ts
@@ -1,0 +1,6 @@
+export function isEnumStringValueOf<E extends { [key: string]: string }>(
+  enumObj: E,
+  value: string,
+): value is E[keyof E] {
+  return Object.values(enumObj).includes(value);
+}

--- a/src/snyk/common/views/summaryWebviewScript.ts
+++ b/src/snyk/common/views/summaryWebviewScript.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
 type SummaryMessage = {
   type: 'sendSummaryParams';
@@ -14,7 +15,7 @@ type SummaryMessage = {
 type Summary = {
   toggleDelta: boolean;
 };
-let vscode = acquireVsCodeApi();
+const vscode = acquireVsCodeApi();
 
 const summary: Summary = {
   // @ts-expect-error this will be injected in a func coming from LS that has isEnabled as arg.

--- a/src/snyk/common/views/treeNode.ts
+++ b/src/snyk/common/views/treeNode.ts
@@ -46,30 +46,34 @@ export type InternalType = {
   isError?: boolean;
 };
 
-interface INodeOptions {
+type TreeNodeIssueType = {
+  id: string;
+  uri: Uri;
+  filePath: string;
+  range?: Range;
+};
+
+export interface INodeOptions {
   text: string;
   description?: string;
   descriptionTail?: string;
-  issue?: {
-    uri: Uri;
-    filePath: string;
-    range?: Range;
-  };
+  issue?: TreeNodeIssueType;
   link?: string;
   icon?: INodeIcon | ThemeIcon;
   command?: Command;
   collapsed?: TreeItemCollapsibleState;
-  parent?: TreeNode;
   children?: TreeNode[];
   internal?: InternalType;
 }
 
 type INode = TreeItem & {
   readonly internal: InternalType;
+  readonly issue: TreeNodeIssueType | undefined;
 };
 
 export class TreeNode extends TreeItem implements INode {
   readonly internal: InternalType;
+  readonly issue: TreeNodeIssueType | undefined;
   private parent: TreeNode | undefined;
   private children: TreeNode[] | undefined;
 
@@ -104,9 +108,11 @@ export class TreeNode extends TreeItem implements INode {
     // However, as of August 2020, there is still no way to manually decorate tree items
     // https://github.com/microsoft/vscode/issues/47502
     // this.resourceUri = options.link ? Uri.parse(options.link) : (options.issue && options.issue.uri);
-    this.parent = options.parent;
     this.children = options.children;
     this.internal = options.internal || {};
+    this.issue = options.issue;
+
+    this.children?.forEach(childNode => (childNode.parent = this));
   }
 
   getParent(): TreeNode | undefined {

--- a/src/snyk/common/vscode/types.ts
+++ b/src/snyk/common/vscode/types.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-namespace */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import * as vscode from 'vscode';
 import * as lsc from 'vscode-languageclient/node';
 import * as lst from 'vscode-languageserver-textdocument';
@@ -62,10 +65,11 @@ export type WindowMiddleware = lsc.WindowMiddleware;
 
 // Language client namespace mappings
 /*
-* TODO - Look into how to map without re-declaring.
-* You can't `export const NS = parent.NS;` as that breaks unit tests, as it causes an import of vscode.
-*/
+ * TODO - Look into how to map without re-declaring.
+ * You can't `export const NS = parent.NS;` as that breaks unit tests, as it causes an import of vscode.
+ */
 export declare namespace CancellationToken {
+  // map of lsc.CancellationToken
   const None: CancellationToken;
   const Cancelled: CancellationToken;
   function is(value: any): value is CancellationToken;

--- a/src/snyk/common/vscode/types.ts
+++ b/src/snyk/common/vscode/types.ts
@@ -58,3 +58,15 @@ export type LSPTextDocument = lst.TextDocument;
 export type ShowDocumentParams = lsc.ShowDocumentParams;
 export type ShowDocumentRequestHandlerSignature = lsc.ShowDocumentRequest.HandlerSignature;
 export type ShowDocumentResult = lsc.ShowDocumentResult;
+export type WindowMiddleware = lsc.WindowMiddleware;
+
+// Language client namespace mappings
+/*
+* TODO - Look into how to map without re-declaring.
+* You can't `export const NS = parent.NS;` as that breaks unit tests, as it causes an import of vscode.
+*/
+export declare namespace CancellationToken {
+  const None: CancellationToken;
+  const Cancelled: CancellationToken;
+  function is(value: any): value is CancellationToken;
+}

--- a/src/snyk/common/vscode/types.ts
+++ b/src/snyk/common/vscode/types.ts
@@ -55,3 +55,6 @@ export type ConfigurationRequestHandlerSignature = lsc.ConfigurationRequest.Hand
 export type ResponseError<D = void> = lsc.ResponseError<D>;
 export type InlineValueText = lsc.InlineValueText;
 export type LSPTextDocument = lst.TextDocument;
+export type ShowDocumentParams = lsc.ShowDocumentParams;
+export type ShowDocumentRequestHandlerSignature = lsc.ShowDocumentRequest.HandlerSignature;
+export type ShowDocumentResult = lsc.ShowDocumentResult;

--- a/src/snyk/snykCode/codeService.ts
+++ b/src/snyk/snykCode/codeService.ts
@@ -2,7 +2,7 @@ import { Subscription } from 'rxjs';
 import { IConfiguration } from '../common/configuration/configuration';
 import { IWorkspaceTrust } from '../common/configuration/trustedFolders';
 import { ILanguageServer } from '../common/languageServer/languageServer';
-import { CodeIssueData, Scan, ScanProduct } from '../common/languageServer/types';
+import { CodeIssueData, LsScanProduct, Scan, ScanProduct } from '../common/languageServer/types';
 import { ILog } from '../common/logger/interfaces';
 import { ProductService } from '../common/services/productService';
 import { IViewManagerService } from '../common/services/viewManagerService';
@@ -42,6 +42,7 @@ export class SnykCodeService extends ProductService<CodeIssueData> {
       languages,
       diagnosticsIssueProvider,
       logger,
+      LsScanProduct.Code,
     );
 
     this.registerCodeActionsProvider(

--- a/src/snyk/snykCode/views/issueTreeProvider.ts
+++ b/src/snyk/snykCode/views/issueTreeProvider.ts
@@ -12,9 +12,11 @@ import { IssueUtils } from '../utils/issueUtils';
 import { CodeIssueCommandArg } from './interfaces';
 import { TreeNode } from '../../common/views/treeNode';
 import { IFolderConfigs } from '../../common/configuration/folderConfigs';
+import { ILog } from '../../common/logger/interfaces';
 
 export class IssueTreeProvider extends ProductIssueTreeProvider<CodeIssueData> {
   constructor(
+    protected readonly logger: ILog,
     protected contextService: IContextService,
     protected codeService: IProductService<CodeIssueData>,
     protected configuration: IConfiguration,
@@ -22,7 +24,7 @@ export class IssueTreeProvider extends ProductIssueTreeProvider<CodeIssueData> {
     protected readonly isSecurityType: boolean,
     protected readonly folderConfigs: IFolderConfigs,
   ) {
-    super(contextService, codeService, configuration, languages, folderConfigs);
+    super(logger, contextService, codeService, configuration, languages, folderConfigs);
   }
 
   shouldShowTree(): boolean {

--- a/src/snyk/snykCode/views/qualityIssueTreeProvider.ts
+++ b/src/snyk/snykCode/views/qualityIssueTreeProvider.ts
@@ -3,6 +3,7 @@ import { IFolderConfigs } from '../../common/configuration/folderConfigs';
 import { configuration } from '../../common/configuration/instance';
 import { SNYK_ANALYSIS_STATUS } from '../../common/constants/views';
 import { CodeIssueData } from '../../common/languageServer/types';
+import { ILog } from '../../common/logger/interfaces';
 import { IContextService } from '../../common/services/contextService';
 import { IProductService } from '../../common/services/productService';
 import { IViewManagerService } from '../../common/services/viewManagerService';
@@ -12,6 +13,7 @@ import { IssueTreeProvider } from './issueTreeProvider';
 
 export class CodeQualityIssueTreeProvider extends IssueTreeProvider {
   constructor(
+    protected readonly logger: ILog,
     protected viewManagerService: IViewManagerService,
     protected contextService: IContextService,
     protected codeService: IProductService<CodeIssueData>,
@@ -19,7 +21,7 @@ export class CodeQualityIssueTreeProvider extends IssueTreeProvider {
     protected languages: IVSCodeLanguages,
     protected readonly folderConfigs: IFolderConfigs,
   ) {
-    super(contextService, codeService, configuration, languages, false, folderConfigs);
+    super(logger, contextService, codeService, configuration, languages, false, folderConfigs);
   }
 
   getRootChildren(): TreeNode[] {

--- a/src/snyk/snykCode/views/securityIssueTreeProvider.ts
+++ b/src/snyk/snykCode/views/securityIssueTreeProvider.ts
@@ -10,9 +10,11 @@ import { IVSCodeLanguages } from '../../common/vscode/languages';
 import { IssueTreeProvider } from './issueTreeProvider';
 import { FEATURE_FLAGS } from '../../common/constants/featureFlags';
 import { IFolderConfigs } from '../../common/configuration/folderConfigs';
+import { ILog } from '../../common/logger/interfaces';
 
 export default class CodeSecurityIssueTreeProvider extends IssueTreeProvider {
   constructor(
+    protected readonly logger: ILog,
     protected viewManagerService: IViewManagerService,
     protected contextService: IContextService,
     protected codeService: IProductService<CodeIssueData>,
@@ -20,7 +22,7 @@ export default class CodeSecurityIssueTreeProvider extends IssueTreeProvider {
     protected languages: IVSCodeLanguages,
     protected readonly folderConfigs: IFolderConfigs,
   ) {
-    super(contextService, codeService, configuration, languages, true, folderConfigs);
+    super(logger, contextService, codeService, configuration, languages, true, folderConfigs);
   }
 
   getRootChildren(): TreeNode[] {

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewProvider.ts
@@ -1,15 +1,14 @@
 import _ from 'lodash';
 import { relative } from 'path';
-import { applyPatch } from 'diff';
 import { marked } from 'marked';
 import * as vscode from 'vscode';
 import {
   SNYK_CODE_FIX_DIFFS_COMMAND,
   SNYK_GENERATE_ISSUE_DESCRIPTION,
-  SNYK_CODE_SUBMIT_FIX_FEEDBACK,
   SNYK_IGNORE_ISSUE_COMMAND,
   SNYK_OPEN_BROWSER_COMMAND,
   SNYK_OPEN_LOCAL_COMMAND,
+  SNYK_CODE_FIX_APPLY_EDIT_COMMAND,
 } from '../../../common/constants/commands';
 import { SNYK_VIEW_SUGGESTION_CODE } from '../../../common/constants/views';
 import { ErrorHandler } from '../../../common/error/errorHandler';
@@ -26,11 +25,9 @@ import { IVSCodeWorkspace } from '../../../common/vscode/workspace';
 import { WEBVIEW_PANEL_SECURITY_TITLE } from '../../constants/analysis';
 import { messages as errorMessages } from '../../messages/error';
 import { getAbsoluteMarkerFilePath } from '../../utils/analysisUtils';
-import { generateDecorationOptions } from '../../utils/patchUtils';
 import { IssueUtils } from '../../utils/issueUtils';
 import { ICodeSuggestionWebviewProvider } from '../interfaces';
 import { readFileSync } from 'fs';
-import { TextDocument } from '../../../common/vscode/types';
 import { Suggestion, SuggestionMessage } from './types';
 import { WebviewPanelSerializer } from '../../../snykCode/views/webviewPanelSerializer';
 import { configuration } from '../../../common/configuration/instance';
@@ -293,39 +290,9 @@ export class CodeSuggestionWebviewProvider
           break;
         }
 
-        case 'applyGitDiff': {
-          const { patch, filePath, fixId } = message.args;
-
-          const fileContent = readFileSync(filePath, 'utf8');
-          const patchedContent = applyPatch(fileContent, patch);
-
-          if (!patchedContent) {
-            throw Error('Failed to apply patch');
-          }
-          const edit = new vscode.WorkspaceEdit();
-
-          const editor = vscode.window.visibleTextEditors.find(editor => editor.document.uri.fsPath === filePath);
-
-          if (!editor) {
-            throw Error(`Editor with file not found: ${filePath}`);
-          }
-
-          const editorEndLine = editor.document.lineCount;
-          edit.replace(vscode.Uri.file(filePath), new vscode.Range(0, 0, editorEndLine, 0), patchedContent);
-
-          const success = await vscode.workspace.applyEdit(edit);
-          if (!success) {
-            throw Error('Failed to apply edit to workspace');
-          }
-
-          this.highlightAddedCode(filePath, patch);
-          this.setupCloseOnSave(filePath);
-
-          try {
-            await vscode.commands.executeCommand(SNYK_CODE_SUBMIT_FIX_FEEDBACK, fixId, 'FIX_APPLIED');
-          } catch (e) {
-            throw new Error('Error in submit fix feedback');
-          }
+        case 'fixApplyEdit': {
+          const { fixId } = message.args;
+          await vscode.commands.executeCommand(SNYK_CODE_FIX_APPLY_EDIT_COMMAND, fixId);
           break;
         }
 
@@ -336,65 +303,6 @@ export class CodeSuggestionWebviewProvider
     } catch (e) {
       ErrorHandler.handle(e, this.logger, errorMessages.suggestionViewMessageHandlingFailed(JSON.stringify(message)));
     }
-  }
-
-  private setupCloseOnSave(filePath: string) {
-    vscode.workspace.onDidSaveTextDocument((e: TextDocument) => {
-      if (e.uri.fsPath == filePath) {
-        this.panel?.dispose();
-      }
-    });
-  }
-
-  private highlightAddedCode(filePath: string, diffData: string) {
-    const highlightDecoration = vscode.window.createTextEditorDecorationType({
-      // seems to work well with both dark and light backgrounds
-      backgroundColor: 'rgba(0,255,0,0.3)',
-    });
-
-    const editor = vscode.window.visibleTextEditors.find(editor => editor.document.uri.fsPath === filePath);
-    if (!editor) {
-      return; // No open editor found with the target file
-    }
-
-    const decorationOptions = generateDecorationOptions(diffData, this.languages);
-    if (decorationOptions.length === 0) {
-      return;
-    }
-
-    editor.setDecorations(highlightDecoration, decorationOptions);
-
-    const firstLine = decorationOptions[0].range.start.line;
-
-    // scroll to first added line
-    const line = editor.document.lineAt(firstLine);
-    const range = line.range;
-    editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
-
-    // remove highlight on any of:
-    // - user types
-    // - saves the doc
-    // - after an amount of time
-
-    const removeHighlights = () => {
-      editor.setDecorations(highlightDecoration, []);
-      listeners.forEach(listener => {
-        if (listener instanceof vscode.Disposable) listener.dispose();
-        else clearTimeout(listener);
-      });
-    };
-
-    const documentEventHandler = (document: TextDocument) => {
-      if (document.uri.fsPath == filePath) {
-        removeHighlights();
-      }
-    };
-
-    const listeners = [
-      setTimeout(removeHighlights, 30000),
-      vscode.workspace.onDidSaveTextDocument(documentEventHandler),
-      vscode.workspace.onDidChangeTextDocument(e => documentEventHandler(e.document)),
-    ];
   }
 
   private getTitle(): string {

--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScriptLS.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScriptLS.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /// <reference lib="dom" />
@@ -74,11 +75,9 @@ type GetSuggestionMessage = {
   type: 'get';
 };
 
-type ApplyGitDiffMessage = {
-  type: 'applyGitDiff';
+type FixApplyEditMessage = {
+  type: 'fixApplyEdit';
   args: {
-    patch: string;
-    filePath: string;
     fixId: string;
   };
 };
@@ -104,7 +103,7 @@ type SuggestionMessage =
   | SetSuggestionMessage
   | GetSuggestionMessage
   | GetAutofixDiffsMesssage
-  | ApplyGitDiffMessage
+  | FixApplyEditMessage
   | SetAutofixDiffsMessage
   | SetAutofixErrorMessage;
 

--- a/src/snyk/snykCode/views/suggestion/ideFuncs/ideApplyAiFix.ts
+++ b/src/snyk/snykCode/views/suggestion/ideFuncs/ideApplyAiFix.ts
@@ -3,11 +3,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
-const applyFixMessage: ApplyGitDiffMessage = {
-  type: 'applyGitDiff',
+const fixApplyEditMessage: FixApplyEditMessage = {
+  type: 'fixApplyEdit',
   //@ts-expect-error these will be injected from a func coming from LS
-  args: { filePath, patch, fixId },
+  args: { fixId },
 };
 
-vscode.postMessage(applyFixMessage);
+vscode.postMessage(fixApplyEditMessage);

--- a/src/snyk/snykCode/views/suggestion/ideFuncs/ideGenerateAiFix.ts
+++ b/src/snyk/snykCode/views/suggestion/ideFuncs/ideGenerateAiFix.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
 type GetAutofixDiffsMesssage = {
   type: 'getAutofixDiffs';

--- a/src/snyk/snykCode/views/suggestion/types.ts
+++ b/src/snyk/snykCode/views/suggestion/types.ts
@@ -59,11 +59,9 @@ export type GetAutofixDiffsMesssage = {
   };
 };
 
-export type ApplyGitDiffMessage = {
-  type: 'applyGitDiff';
+export type FixApplyEditMessage = {
+  type: 'fixApplyEdit';
   args: {
-    patch: string;
-    filePath: string;
     fixId: string;
   };
 };
@@ -106,7 +104,7 @@ export type SuggestionMessage =
   | OpenBrowserMessage
   | IgnoreIssueMessage
   | GetAutofixDiffsMesssage
-  | ApplyGitDiffMessage
+  | FixApplyEditMessage
   | SetSuggestionMessage
   | GetSuggestionMessage
   | SetLessonMessage

--- a/src/snyk/snykIac/iacService.ts
+++ b/src/snyk/snykIac/iacService.ts
@@ -2,7 +2,7 @@ import { Subscription } from 'rxjs';
 import { IConfiguration } from '../common/configuration/configuration';
 import { IWorkspaceTrust } from '../common/configuration/trustedFolders';
 import { ILanguageServer } from '../common/languageServer/languageServer';
-import { IacIssueData, Scan, ScanProduct } from '../common/languageServer/types';
+import { IacIssueData, LsScanProduct, Scan, ScanProduct } from '../common/languageServer/types';
 import { ILog } from '../common/logger/interfaces';
 import { ProductService } from '../common/services/productService';
 import { IViewManagerService } from '../common/services/viewManagerService';
@@ -42,6 +42,7 @@ export class IacService extends ProductService<IacIssueData> {
       languages,
       diagnosticsIssueProvider,
       logger,
+      LsScanProduct.InfrastructureAsCode,
     );
 
     this.registerCodeActionsProvider(

--- a/src/snyk/snykIac/views/iacIssueTreeProvider.ts
+++ b/src/snyk/snykIac/views/iacIssueTreeProvider.ts
@@ -15,9 +15,11 @@ import { IacIssue } from '../issue';
 import { messages } from '../messages/analysis';
 import { IacIssueCommandArg } from './interfaces';
 import { IFolderConfigs } from '../../common/configuration/folderConfigs';
+import { ILog } from '../../common/logger/interfaces';
 
 export default class IacIssueTreeProvider extends ProductIssueTreeProvider<IacIssueData> {
   constructor(
+    protected readonly logger: ILog,
     protected viewManagerService: IViewManagerService,
     protected contextService: IContextService,
     protected iacService: IProductService<IacIssueData>,
@@ -25,7 +27,7 @@ export default class IacIssueTreeProvider extends ProductIssueTreeProvider<IacIs
     protected languages: IVSCodeLanguages,
     protected readonly folderConfigs: IFolderConfigs,
   ) {
-    super(contextService, iacService, configuration, languages, folderConfigs);
+    super(logger, contextService, iacService, configuration, languages, folderConfigs);
   }
 
   getRootChildren(): TreeNode[] {

--- a/src/snyk/snykOss/ossService.ts
+++ b/src/snyk/snykOss/ossService.ts
@@ -42,7 +42,7 @@ export class OssService extends ProductService<OssIssueData> {
       languages,
       diagnosticsIssueProvider,
       logger,
-      LsScanProduct.OpenSource
+      LsScanProduct.OpenSource,
     );
 
     this.registerCodeActionsProvider(

--- a/src/snyk/snykOss/ossService.ts
+++ b/src/snyk/snykOss/ossService.ts
@@ -2,7 +2,7 @@ import { Subscription } from 'rxjs';
 import { IConfiguration } from '../common/configuration/configuration';
 import { IWorkspaceTrust } from '../common/configuration/trustedFolders';
 import { ILanguageServer } from '../common/languageServer/languageServer';
-import { OssIssueData, Scan, ScanProduct } from '../common/languageServer/types';
+import { LsScanProduct, OssIssueData, Scan, ScanProduct } from '../common/languageServer/types';
 import { ILog } from '../common/logger/interfaces';
 import { ProductService } from '../common/services/productService';
 import { IViewManagerService } from '../common/services/viewManagerService';
@@ -42,6 +42,7 @@ export class OssService extends ProductService<OssIssueData> {
       languages,
       diagnosticsIssueProvider,
       logger,
+      LsScanProduct.OpenSource
     );
 
     this.registerCodeActionsProvider(

--- a/src/snyk/snykOss/providers/ossVulnerabilityTreeProvider.ts
+++ b/src/snyk/snykOss/providers/ossVulnerabilityTreeProvider.ts
@@ -15,9 +15,11 @@ import { IVSCodeLanguages } from '../../common/vscode/languages';
 import { messages } from '../constants/messages';
 import { getOssIssueCommandArg } from './ossIssueCommandHelper';
 import { IFolderConfigs } from '../../common/configuration/folderConfigs';
+import { ILog } from '../../common/logger/interfaces';
 
 export default class OssIssueTreeProvider extends ProductIssueTreeProvider<OssIssueData> {
   constructor(
+    protected readonly logger: ILog,
     protected viewManagerService: IViewManagerService,
     protected contextService: IContextService,
     protected ossService: IProductService<OssIssueData>,
@@ -25,7 +27,7 @@ export default class OssIssueTreeProvider extends ProductIssueTreeProvider<OssIs
     protected languages: IVSCodeLanguages,
     protected readonly folderConfigs: IFolderConfigs,
   ) {
-    super(contextService, ossService, configuration, languages, folderConfigs);
+    super(logger, contextService, ossService, configuration, languages, folderConfigs);
   }
 
   getRootChildren(): TreeNode[] {

--- a/src/test/integration/issueTreeProvider.test.ts
+++ b/src/test/integration/issueTreeProvider.test.ts
@@ -11,6 +11,7 @@ import { FEATURE_FLAGS } from '../../snyk/common/constants/featureFlags';
 import { configuration } from '../../snyk/common/configuration/instance';
 import { ISSUE_VIEW_OPTIONS_SETTING } from '../../snyk/common/constants/settings';
 import { IFolderConfigs } from '../../snyk/common/configuration/folderConfigs';
+import { LoggerMockFailOnErrors } from '../unit/mocks/logger.mock';
 
 suite('Code Issue Tree Provider', () => {
   let contextService: IContextService;
@@ -64,6 +65,7 @@ suite('Code Issue Tree Provider', () => {
     } as unknown as IProductService<CodeIssueData>;
 
     issueTreeProvider = new IssueTreeProvider(
+      new LoggerMockFailOnErrors(),
       contextService,
       localCodeService,
       configuration,
@@ -88,6 +90,7 @@ suite('Code Issue Tree Provider', () => {
     } as unknown as IProductService<CodeIssueData>;
 
     issueTreeProvider = new IssueTreeProvider(
+      new LoggerMockFailOnErrors(),
       contextService,
       localCodeService,
       configuration,
@@ -128,6 +131,7 @@ suite('Code Issue Tree Provider', () => {
     });
     configuration.issueViewOptions.openIssues = false;
     issueTreeProvider = new IssueTreeProvider(
+      new LoggerMockFailOnErrors(),
       contextService,
       localCodeService,
       configuration,
@@ -173,6 +177,7 @@ suite('Code Issue Tree Provider', () => {
       ignoredIssues: false,
     });
     issueTreeProvider = new IssueTreeProvider(
+      new LoggerMockFailOnErrors(),
       contextService,
       localCodeService,
       configuration,
@@ -218,6 +223,7 @@ suite('Code Issue Tree Provider', () => {
       ignoredIssues: false,
     });
     issueTreeProvider = new IssueTreeProvider(
+      new LoggerMockFailOnErrors(),
       contextService,
       localCodeService,
       configuration,

--- a/src/test/unit/common/languageServer/languageServer.test.ts
+++ b/src/test/unit/common/languageServer/languageServer.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import assert, { deepStrictEqual, fail, strictEqual } from 'assert';
+import assert, { deepStrictEqual, strictEqual } from 'assert';
 import { ReplaySubject } from 'rxjs';
 import sinon from 'sinon';
 import { v4 } from 'uuid';

--- a/src/test/unit/common/languageServer/languageServer.test.ts
+++ b/src/test/unit/common/languageServer/languageServer.test.ts
@@ -13,7 +13,7 @@ import { ILanguageClientAdapter } from '../../../../snyk/common/vscode/languageC
 import { LanguageClient, LanguageClientOptions, ServerOptions } from '../../../../snyk/common/vscode/types';
 import { IVSCodeWorkspace } from '../../../../snyk/common/vscode/workspace';
 import { defaultFeaturesConfigurationStub } from '../../mocks/configuration.mock';
-import { LoggerMock } from '../../mocks/logger.mock';
+import { LoggerMock, LoggerMockFailOnErrors } from '../../mocks/logger.mock';
 import { windowMock } from '../../mocks/window.mock';
 import { stubWorkspaceConfiguration } from '../../mocks/workspace.mock';
 import { PROTOCOL_VERSION } from '../../../../snyk/common/constants/languageServer';
@@ -29,16 +29,7 @@ suite('Language Server', () => {
   let downloadServiceMock: DownloadService;
   let extensionContextMock: ExtensionContext;
   const path = 'testPath';
-  const logger = {
-    info(_msg: string) {},
-    warn(_msg: string) {},
-    log(_msg: string) {},
-    error(msg: string) {
-      fail(msg);
-    },
-  } as unknown as LoggerMock;
-
-  let contextGetGlobalStateValue: sinon.SinonStub;
+  const logger = new LoggerMockFailOnErrors();
 
   setup(() => {
     configurationMock = {
@@ -90,7 +81,7 @@ suite('Language Server', () => {
 
     extensionContextMock = {
       extensionPath: 'test/path',
-      getGlobalStateValue: contextGetGlobalStateValue,
+      getGlobalStateValue: sinon.fake(),
       updateGlobalStateValue: sinon.fake(),
       setContext: sinon.fake(),
       subscriptions: [],

--- a/src/test/unit/common/languageServer/middleware.test.ts
+++ b/src/test/unit/common/languageServer/middleware.test.ts
@@ -1,6 +1,5 @@
 import assert from 'assert';
 import sinon from 'sinon';
-import { CliExecutable } from '../../../../snyk/cli/cliExecutable';
 import { FolderConfig, IConfiguration } from '../../../../snyk/common/configuration/configuration';
 import { LanguageClientMiddleware } from '../../../../snyk/common/languageServer/middleware';
 import { ServerSettings } from '../../../../snyk/common/languageServer/settings';
@@ -10,15 +9,19 @@ import type {
   ConfigurationParams,
   ConfigurationRequestHandlerSignature,
   ResponseError,
+  ShowDocumentParams,
+  ShowDocumentRequestHandlerSignature,
 } from '../../../../snyk/common/vscode/types';
 import { defaultFeaturesConfigurationStub } from '../../mocks/configuration.mock';
 import { ExtensionContext } from '../../../../snyk/common/vscode/extensionContext';
+import { ShowIssueDetailTopicParams, LsScanProduct, SnykURIAction } from '../../../../snyk/common/languageServer/types';
+import { Subject } from 'rxjs';
+import { LoggerMockFailOnErrors } from '../../mocks/logger.mock';
 
 suite('Language Server: Middleware', () => {
   let configuration: IConfiguration;
   let user: User;
   let extensionContextMock: ExtensionContext;
-  let contextGetGlobalStateValue: sinon.SinonStub;
 
   setup(() => {
     user = { anonymousId: 'anonymous-id' } as User;
@@ -61,7 +64,7 @@ suite('Language Server: Middleware', () => {
     } as IConfiguration;
     extensionContextMock = {
       extensionPath: 'test/path',
-      getGlobalStateValue: contextGetGlobalStateValue,
+      getGlobalStateValue: sinon.fake(),
       updateGlobalStateValue: sinon.fake(),
       setContext: sinon.fake(),
       subscriptions: [],
@@ -75,7 +78,7 @@ suite('Language Server: Middleware', () => {
   });
 
   test('Configuration request should translate settings', async () => {
-    const middleware = new LanguageClientMiddleware(configuration, user, extensionContextMock);
+    const middleware = new LanguageClientMiddleware(new LoggerMockFailOnErrors(), configuration, user, new Subject<ShowIssueDetailTopicParams>());
     const params: ConfigurationParams = {
       items: [
         {
@@ -116,7 +119,7 @@ suite('Language Server: Middleware', () => {
   });
 
   test('Configuration request should return an error', async () => {
-    const middleware = new LanguageClientMiddleware(configuration, user, extensionContextMock);
+    const middleware = new LanguageClientMiddleware(new LoggerMockFailOnErrors(), configuration, user, new Subject<ShowIssueDetailTopicParams>());
     const params: ConfigurationParams = {
       items: [
         {
@@ -138,5 +141,43 @@ suite('Language Server: Middleware', () => {
       console.log(res);
       assert.fail("Handler didn't return an error");
     }
+  });
+
+  test(`Snyk URI for action=${SnykURIAction.ShowInDetailPanel} should trigger show issue detail topic publish`, async () => {
+    const product = LsScanProduct.Code;
+    const issueId = '123abc456';
+
+    const showIssueDetailTopic$ = new Subject<ShowIssueDetailTopicParams>();
+    const subscribedTopicMessageRecieved = new Promise<ShowIssueDetailTopicParams>((resolve) => {
+      let calledAlready = false;
+      showIssueDetailTopic$.subscribe((showIssueDetailTopicParams) => {
+        assert.strictEqual(calledAlready, false, 'Show issue detail topic published to multiple times');
+        calledAlready = true;
+        resolve(showIssueDetailTopicParams);
+      });
+    });
+
+    const middleware = new LanguageClientMiddleware(new LoggerMockFailOnErrors(), sinon.fake() as unknown as IConfiguration, sinon.fake() as unknown as User, showIssueDetailTopic$);
+    const params: ShowDocumentParams = {
+      uri: `snyk:///fake/file/path?product=${product.replaceAll(' ', '+')}&issueId=${issueId}&action=${SnykURIAction.ShowInDetailPanel}`
+    }
+    const failOnNextHandler: ShowDocumentRequestHandlerSignature = (_params, _token) => {
+      return {success: false};
+    };
+
+    const res = await middleware.window.showDocument?.(params, failOnNextHandler);
+    if (res === undefined) {
+      assert.fail('Failed to call showDocument');
+    }
+    if (res instanceof Error) {
+      assert.fail('Handler returned an error');
+    }
+    assert.deepStrictEqual(res, {success: true});
+
+    const showIssueDetailTopicParams = await subscribedTopicMessageRecieved;
+    assert.deepStrictEqual(showIssueDetailTopicParams, {
+      product,
+      issueId,
+    });
   });
 });

--- a/src/test/unit/common/languageServer/middleware.test.ts
+++ b/src/test/unit/common/languageServer/middleware.test.ts
@@ -158,8 +158,8 @@ suite('Language Server: Middleware', () => {
 
     const middleware = new LanguageClientMiddleware(
       new LoggerMockFailOnErrors(),
-      sinon.fake() as unknown as IConfiguration,
-      sinon.fake() as unknown as User,
+      {} as IConfiguration,
+      {} as User,
       showIssueDetailTopic$,
     );
     const params: ShowDocumentParams = {

--- a/src/test/unit/common/services/productService.test.ts
+++ b/src/test/unit/common/services/productService.test.ts
@@ -4,8 +4,8 @@ import sinon from 'sinon';
 import { IConfiguration } from '../../../../snyk/common/configuration/configuration';
 import { WorkspaceTrust } from '../../../../snyk/common/configuration/trustedFolders';
 import { ILanguageServer } from '../../../../snyk/common/languageServer/languageServer';
-import { Issue, Scan, ScanProduct, ScanStatus } from '../../../../snyk/common/languageServer/types';
-import { IProductService, ProductService } from '../../../../snyk/common/services/productService';
+import { Issue, LsScanProduct, Scan, ScanProduct, ScanStatus } from '../../../../snyk/common/languageServer/types';
+import { ProductService } from '../../../../snyk/common/services/productService';
 import { IViewManagerService } from '../../../../snyk/common/services/viewManagerService';
 import { IProductWebviewProvider } from '../../../../snyk/common/views/webviewProvider';
 import { ExtensionContext } from '../../../../snyk/common/vscode/extensionContext';
@@ -15,15 +15,17 @@ import { LanguageServerMock } from '../../mocks/languageServer.mock';
 import { LoggerMock } from '../../mocks/logger.mock';
 import { IDiagnosticsIssueProvider } from '../../../../snyk/common/services/diagnosticsService';
 
-type ProductData = {
+type MockProductData = {
   productName: string;
 };
-class MockProductService extends ProductService<ProductData> {
+class MockProductService extends ProductService<MockProductData> {
   productType: ScanProduct;
+
+  showSuggestionProviderById = sinon.fake();
 
   subscribeToLsScanMessages(): Subscription {
     return this.languageServer.scan$.subscribe((scan: Scan<unknown>) => {
-      super.handleLsScanMessage(scan as Scan<ProductData>);
+      super.handleLsScanMessage(scan as Scan<MockProductData>);
     });
   }
 
@@ -34,7 +36,7 @@ class MockProductService extends ProductService<ProductData> {
 
 suite('Product Service', () => {
   let ls: ILanguageServer;
-  let service: IProductService<ProductData>;
+  let service: MockProductService;
   let refreshViewFake: sinon.SinonSpy;
 
   setup(() => {
@@ -48,7 +50,7 @@ suite('Product Service', () => {
     service = new MockProductService(
       {} as ExtensionContext,
       {} as IConfiguration,
-      {} as unknown as IProductWebviewProvider<Issue<ProductData>>,
+      {} as unknown as IProductWebviewProvider<Issue<MockProductData>>,
       viewManagerService,
       {
         getWorkspaceFolders: () => [''],
@@ -58,8 +60,9 @@ suite('Product Service', () => {
       {} as IVSCodeLanguages,
       {
         getIssuesFromDiagnostics: () => [],
-      } as IDiagnosticsIssueProvider<ProductData>,
+      } as IDiagnosticsIssueProvider<MockProductData>,
       new LoggerMock(),
+      LsScanProduct.Code,
     );
   });
 
@@ -160,4 +163,15 @@ suite('Product Service', () => {
     strictEqual(service.isAnalysisRunning, false);
     sinon.assert.calledTwice(refreshViewFake);
   });
+
+  test('Show issue detail topic message shows issue detail pane', () => {
+    const issueId = '123abc456';
+
+    ls.showIssueDetailTopic$.next({
+      product: service.lsScanProduct,
+      issueId,
+    });
+
+    sinon.assert.calledOnceWithExactly(service.showSuggestionProviderById, issueId);
+  })
 });

--- a/src/test/unit/common/services/productService.test.ts
+++ b/src/test/unit/common/services/productService.test.ts
@@ -173,5 +173,5 @@ suite('Product Service', () => {
     });
 
     sinon.assert.calledOnceWithExactly(service.showSuggestionProviderById, issueId);
-  })
+  });
 });

--- a/src/test/unit/mocks/languageServer.mock.ts
+++ b/src/test/unit/mocks/languageServer.mock.ts
@@ -1,7 +1,13 @@
 import { ReplaySubject, Subject } from 'rxjs';
 import sinon from 'sinon';
 import { ILanguageServer } from '../../../snyk/common/languageServer/languageServer';
-import { ShowIssueDetailTopicParams, CodeIssueData, IacIssueData, OssIssueData, Scan } from '../../../snyk/common/languageServer/types';
+import {
+  ShowIssueDetailTopicParams,
+  CodeIssueData,
+  IacIssueData,
+  OssIssueData,
+  Scan,
+} from '../../../snyk/common/languageServer/types';
 
 export class LanguageServerMock implements ILanguageServer {
   start = sinon.fake();

--- a/src/test/unit/mocks/languageServer.mock.ts
+++ b/src/test/unit/mocks/languageServer.mock.ts
@@ -1,7 +1,7 @@
 import { ReplaySubject, Subject } from 'rxjs';
 import sinon from 'sinon';
 import { ILanguageServer } from '../../../snyk/common/languageServer/languageServer';
-import { CodeIssueData, IacIssueData, OssIssueData, Scan } from '../../../snyk/common/languageServer/types';
+import { ShowIssueDetailTopicParams, CodeIssueData, IacIssueData, OssIssueData, Scan } from '../../../snyk/common/languageServer/types';
 
 export class LanguageServerMock implements ILanguageServer {
   start = sinon.fake();
@@ -10,4 +10,5 @@ export class LanguageServerMock implements ILanguageServer {
 
   cliReady$ = new ReplaySubject<string>(1);
   scan$ = new Subject<Scan<CodeIssueData | OssIssueData | IacIssueData>>();
+  showIssueDetailTopic$ = new Subject<ShowIssueDetailTopicParams>();
 }

--- a/src/test/unit/mocks/logger.mock.ts
+++ b/src/test/unit/mocks/logger.mock.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import assert from 'assert';
 import { ILog, LogLevel } from '../../../snyk/common/logger/interfaces';
 
 export class LoggerMock implements ILog {
@@ -9,4 +10,8 @@ export class LoggerMock implements ILog {
   debug = (_message: string): void => undefined;
 
   showOutput = (): void => undefined;
+}
+
+export class LoggerMockFailOnErrors extends LoggerMock {
+  error = (message: string) => assert.fail(message);
 }


### PR DESCRIPTION
### Description

Added handler for showDocument callbacks from Language server.

If a snyk:// URI is received with the correct action, issueId and product query parameters, we:

- Navigate to the issue in the tree
- Show the details panel for the issue

Plus when the fix is applied the IDE now calls the language server.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_

### Reviewing

For the reviewer, it might be easier to review this PR split in 2 parts:
 - snyk: URI commits: https://github.com/snyk/vscode-extension/pull/580/files/3d57aff35c4fe05a0bf410cf81baacbcea0227d6
 - Fix applying calling the LS commit: https://github.com/snyk/vscode-extension/pull/580/commits/6367f566bd1dcfd055b2b5bf5556c819b3fb2783
