### PR TITLE
fix: update custom endpoint description [IDE-1057]

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
           },
           "snyk.advanced.customEndpoint": {
             "type": "string",
-            "markdownDescription": "Sets API endpoint to use for Snyk requests. Useful for custom Snyk setups. E.g. `https://api.eu.snyk.io`.",
+            "markdownDescription": "If you're using SSO(OAuth2), Custom Endpoint configuration is automatic. \n\nOtherwise, for public regional instances, see the [docs](https://docs.snyk.io/working-with-snyk/regional-hosting-and-data-residency#available-snyk-regions). \n\nFor private instances, contact your team or account manager.",
             "scope": "window",
             "pattern": "^(|(https?://)api.*.(snyk|snykgov).io)$"
           },

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
           },
           "snyk.advanced.customEndpoint": {
             "type": "string",
-            "markdownDescription": "If you're using SSO(OAuth2), Custom Endpoint configuration is automatic. \n\nOtherwise, for public regional instances, see the [docs](https://docs.snyk.io/working-with-snyk/regional-hosting-and-data-residency#available-snyk-regions). \n\nFor private instances, contact your team or account manager.",
+            "markdownDescription": "If you're using SSO with Snyk and OAuth2 the custom endpoint configuration is automatically populated. \n\nOtherwise, for public regional instances, see the [docs](https://docs.snyk.io/working-with-snyk/regional-hosting-and-data-residency#available-snyk-regions). \n\nFor private instances, contact your team or account manager.",
             "scope": "window",
             "pattern": "^(|(https?://)api.*.(snyk|snykgov).io)$"
           },

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
           },
           "snyk.advanced.customEndpoint": {
             "type": "string",
-            "markdownDescription": "If you're using SSO with Snyk and OAuth2 the custom endpoint configuration is automatically populated. \n\nOtherwise, for public regional instances, see the [docs](https://docs.snyk.io/working-with-snyk/regional-hosting-and-data-residency#available-snyk-regions). \n\nFor private instances, contact your team or account manager.",
+            "markdownDescription": "If you're using SSO with Snyk and OAuth2, the custom endpoint configuration is automatically populated. \n\nOtherwise, for public regional instances, see our [documentation](https://docs.snyk.io/working-with-snyk/regional-hosting-and-data-residency#available-snyk-regions). \n\nFor private instances, contact your team or account manager.",
             "scope": "window",
             "pattern": "^(|(https?://)api.*.(snyk|snykgov).io)$"
           },


### PR DESCRIPTION
### Description


In IDEs, you can configure a custom endpoint in order to target a custom region (e.g EU). The current description for this option is "Sets API endpoint to use for Snyk requests. Useful for custom Snyk setups. E.g. https://api.eu.snyk.io/.". With the recent platform changes, on OAuth using SSO, we automatically redirect to the right instance and that field does not need to be configured anymore.


Update
`If you're using SSO (OAuth2), API endpoint configuration is automatic. Otherwise, for public regional instances, see the docs. For private instances, contact your team or account manager.`


### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
