### PR TITLE
fix: preserve default CAs and append custom certs to Axios CA options [IDE-1098]

### DIFF
--- a/src/snyk/common/proxy.ts
+++ b/src/snyk/common/proxy.ts
@@ -17,7 +17,14 @@ export async function getHttpsProxyAgent(
   const proxyOptions = await getProxyOptions(workspace, configuration, logger, processEnv);
   if (proxyOptions == undefined) return undefined;
 
-  return new HttpsProxyAgent(proxyOptions);
+  const agent = new HttpsProxyAgent(proxyOptions);
+
+  // Extract CA certificates from proxy agent options and add them at the top level
+  if (proxyOptions.ca) {
+    (agent as any).ca = proxyOptions.ca;
+  }
+
+  return agent;
 }
 
 export async function getProxyOptions(

--- a/src/snyk/common/proxy.ts
+++ b/src/snyk/common/proxy.ts
@@ -116,12 +116,14 @@ async function getDefaultAgentOptions(
     // use custom certs if provided
     if (processEnv.NODE_EXTRA_CA_CERTS) {
       try {
-        const allCerts = [...tls.rootCertificates];
+        logger.debug('NODE_EXTRA_CA_CERTS env var is set');
         await fs.access(processEnv.NODE_EXTRA_CA_CERTS);
         const extraCerts = await fs.readFile(processEnv.NODE_EXTRA_CA_CERTS, 'utf-8');
-        if (extraCerts) {
-          allCerts.push(extraCerts);
+        if (!extraCerts) {
+          return;
         }
+        logger.debug('found certs in NODE_EXTRA_CA_CERTS');
+        const allCerts = [...tls.rootCertificates, extraCerts];
         defaultOptions = { ca: allCerts };
         globalAgent.options.ca = allCerts;
       } catch (error) {

--- a/src/snyk/common/proxy.ts
+++ b/src/snyk/common/proxy.ts
@@ -21,6 +21,7 @@ export async function getHttpsProxyAgent(
 
   // Extract CA certificates from proxy agent options and add them at the top level
   if (proxyOptions.ca) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     (agent as any).ca = proxyOptions.ca;
   }
 

--- a/src/test/unit/common/proxy.test.ts
+++ b/src/test/unit/common/proxy.test.ts
@@ -42,7 +42,6 @@ suite('Proxy', () => {
 
     // should still set rejectUnauthorized flag
     // @ts-ignore: cannot test options otherwise
-    assert.deepStrictEqual(configOptions.httpAgent?.options.rejectUnauthorized, proxyStrictSSL);
     assert.deepStrictEqual(configOptions.httpsAgent?.options.rejectUnauthorized, proxyStrictSSL);
   });
 
@@ -62,7 +61,7 @@ suite('Proxy', () => {
 
       test('should return rejectUnauthorized true', async () => {
         const config = await getAxiosConfig(workspace, configuration, logger);
-        assert.deepStrictEqual(config.httpAgent?.options.rejectUnauthorized, true);
+        assert.deepStrictEqual(config.httpsAgent?.options.rejectUnauthorized, true);
       });
     });
 


### PR DESCRIPTION
### Description
### Changes:
* Preserve default CAs and append custom CA to it.
* Set `ca` property at the top level of the proxy type to be recognized by axios.

### Tested on Mac and Win with MITM proxy with following use cases and it worked:

- No Proxy config.
- Proxy CA is included in node env var but not trusted.
- Proxy CA is included in node env var and trusted.
- Node env var is not set but but Proxy CA is trusted.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
