### PR TITLE
fix: event origin check

### DIFF
--- a/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScriptLS.ts
+++ b/src/snyk/snykCode/views/suggestion/codeSuggestionWebviewScriptLS.ts
@@ -187,7 +187,7 @@ document.getElementById('position-line')!.addEventListener('click', () => {
 window.addEventListener('message', event => {
   // SAFE: Validate the origin strictly - in VSCode this should be vscode-webview://
   // This exactly matches Snyk's recommended pattern in their documentation
-  if (event.origin !== 'vscode-webview://') {
+  if (!event.origin.startsWith('vscode-webview://')) {
     console.error('Security: Message rejected from untrusted origin:', event.origin);
     return;
   }


### PR DESCRIPTION
### Description

In some cases, `event.origin` contains a URI not just the `vscode-webview://` so this caused some events such as `generateAiFix` to not be triggered, this PR handles this edge case by checking if the `event.origin` starts with `vscode-webview://`
### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
