### PR TITLE
fix: remove blank template replacements

### DIFF
--- a/src/snyk/common/views/summaryWebviewProvider.ts
+++ b/src/snyk/common/views/summaryWebviewProvider.ts
@@ -64,7 +64,9 @@ export class SummaryWebviewViewProvider implements vscode.WebviewViewProvider {
 
       html = html.replace('${ideStyle}', `<style nonce=${nonce}>` + '' + '</style>');
       html = html.replace('${ideFunc}', ideScript);
-      html = html.replace('${ideScript}', '');
+      // Must not have blank template replacements, as they could be used to skip the "${nonce}" injection check
+      // and still end up with the nonce injected, e.g. "${nonce${resolvesToEmpty}}" becomes "${nonce}" - See IDE-1050.
+      html = html.replace('${ideScript}', ' ');
       html = html.replace(/\${nonce}/g, nonce);
 
       this.webviewView.webview.html = html;

--- a/src/snyk/snykIac/views/suggestion/iacSuggestionWebviewProvider.ts
+++ b/src/snyk/snykIac/views/suggestion/iacSuggestionWebviewProvider.ts
@@ -104,7 +104,9 @@ export class IacSuggestionWebviewProvider
     // data-ide-style is a placeholder defined in the Language Server
     // to be replaced with the custom IDE styles.
     html = html.replace('${ideStyle}', `<style nonce="${nonce}">${ideStyle}</style>`);
-    html = html.replace('${ideScript}', '');
+    // Must not have blank template replacements, as they could be used to skip the "${nonce}" injection check
+    // and still end up with the nonce injected, e.g. "${nonce${resolvesToEmpty}}" becomes "${nonce}" - See IDE-1050.
+    html = html.replace('${ideScript}', ' ');
     return html;
   }
 


### PR DESCRIPTION
### Description

This PR, aims to fix a potential cross-site scripting (XSS) vulnerability in the HTML reports.
By using a space for replacements, the attacker cannot use a bypass using "${nonce${resolvesToEmpty}}".

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
