### PR TITLE
fix: avoid writing default autoSelectOrganization to workspace config [IDE-1738]

### DIFF
--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -170,9 +170,12 @@ export interface IConfiguration {
   /**
    * Sets the auto organization setting at the workspace folder level.
    * @param workspaceFolder - The workspace folder to set the setting for
-   * @param autoSelectOrganization - Whether auto organization should be enabled
+   * @param autoSelectOrganization - Whether auto organization should be enabled, or undefined to clear the folder-level override
    */
-  setAutoSelectOrganization(workspaceFolder: WorkspaceFolder, autoSelectOrganization: boolean): Promise<void>;
+  setAutoSelectOrganization(
+    workspaceFolder: WorkspaceFolder,
+    autoSelectOrganization: boolean | undefined,
+  ): Promise<void>;
 
   /**
    * Gets the organization setting for a workspace folder, considering all levels (folder, workspace, global, default).
@@ -618,7 +621,10 @@ export class Configuration implements IConfiguration {
     );
   }
 
-  async setAutoSelectOrganization(workspaceFolder: WorkspaceFolder, autoSelectOrganization: boolean): Promise<void> {
+  async setAutoSelectOrganization(
+    workspaceFolder: WorkspaceFolder,
+    autoSelectOrganization: boolean | undefined,
+  ): Promise<void> {
     const { configurationId, section } = Configuration.getConfigName(ADVANCED_AUTO_SELECT_ORGANIZATION);
     await this.workspace.updateConfiguration(configurationId, section, autoSelectOrganization, workspaceFolder);
   }


### PR DESCRIPTION
### **User description**
### Description

Fixes user-reported issue where the `snyk.advanced.autoSelectOrganization` setting was always written into the workspace configuration file (`.vscode/settings.json`), even when the value was `true` (the default). This polluted workspace configs unnecessarily and was unwanted by users.

**Root cause:** In `handleOrgSettingsFromFolderConfigs`, the condition `desiredAutoOrg !== currentAutoOrg || desiredAutoOrg` always evaluated to `true` when `desiredAutoOrg` was `true` (the common default case where the user hasn't manually set an org).

**Fix:**
- Changed the condition to `desiredAutoOrg !== currentAutoOrg` — only write when there's an actual change
- When clearing a folder-level override back to default, write `undefined` instead of `true` to remove the setting entirely from workspace config
- Updated `setAutoSelectOrganization` to accept `boolean | undefined`

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/vscode-extension/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/vscode-extension/blob/main/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

N/A — no UI changes.


___

### **PR Type**
Bug fix


___

### **Description**
- Avoid writing default auto-select-organization to workspace config.

- Only write folder config if value differs from effective config.

- Clear folder-level override when falling back to default.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Old Logic: Always Write Default] --> B{Check If Desired Matches Current};
  B -- True --> C[Write Value];
  B -- False --> D[Skip Write];
  E[New Logic: Write Only if Different] --> F{Desired != Current?};
  F -- True --> G{Is Desired True?};
  G -- True --> H[Write Undefined (Clear Override)];
  G -- False --> I[Write False];
  F -- False --> D;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.ts</strong><dd><code>Update setAutoSelectOrganization signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/snyk/common/configuration/configuration.ts

<ul><li>Modified <code>setAutoSelectOrganization</code> to accept <code>boolean | undefined</code>.<br> <li> Updated the method signature to reflect the new parameter type.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/vscode-extension/pull/715/changes#diff-ea516e6da03ef31b513852a7029ea1873e6672eab75b939bc6465f90dc24c69f">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>languageServer.ts</strong><dd><code>Refine auto-organization setting logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/snyk/common/languageServer/languageServer.ts

<ul><li>Changed logic to only write <code>autoSelectOrganization</code> if the desired <br>value differs from the current effective value.<br> <li> When clearing a folder-level override back to default, it now writes <br><code>undefined</code> instead of <code>true</code>.<br> <li> Updated log messages to reflect the new behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/vscode-extension/pull/715/changes#diff-3b2a43f4595d28491fa3a90fcf03f78603ecced8084c2aa57fc972717ced9710">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>languageServer.test.ts</strong><dd><code>Update language server tests for auto-org settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/unit/common/languageServer/languageServer.test.ts

<ul><li>Added a test case to verify that <code>autoSelectOrganization</code> is not written <br>when <code>orgSetByUser</code> is false and <code>currentAutoOrg</code> is already true.<br> <li> Added a test case to verify that the folder-level <br><code>autoSelectOrganization</code> override is cleared by writing <code>undefined</code> when <br><code>orgSetByUser</code> is false and <code>currentAutoOrg</code> is false.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/vscode-extension/pull/715/changes#diff-dabd42c22eb5aec2ac82d2a44197da9adfad285ed79bebb0ba4769bf679b98f3">+31/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

