### PR TITLE
fix(deps): upgrade lodash to ^4.18.1 (SNYK-JS-LODASH-15869625)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "he": "^1.2.0",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
-        "lodash": "^4.17.23",
+        "lodash": "^4.18.1",
         "marked": "^11.2.0",
         "needle": "^3.3.1",
         "open": "^7.4.2",
@@ -5829,9 +5829,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.get": {

--- a/package.json
+++ b/package.json
@@ -629,7 +629,7 @@
     "he": "^1.2.0",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.0",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "marked": "^11.2.0",
     "needle": "^3.3.1",
     "open": "^7.4.2",


### PR DESCRIPTION
### Description

Upgrades direct `lodash` dependency from `^4.17.23` to `^4.18.1` to remediate [SNYK-JS-LODASH-15869625](https://security.snyk.io/vuln/SNYK-JS-LODASH-15869625) (arbitrary code injection, high severity).

No application code changes.

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/vscode-extension/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/vscode-extension/blob/main/CONTRIBUTING.md).
- [x] Tests added and all succeed — dependency-only change; `npm run test:unit` run successfully before commit.
- [x] Linted — pre-commit / eslint as part of workflow.
- [ ] CHANGELOG.md updated — file only links to GitHub releases; no versioned entries to edit (see CONTRIBUTING).
- [ ] README.md updated, if user-facing — not applicable.

### Screenshots / GIFs

N/A (no UI changes).

Made with [Cursor](https://cursor.com)