### PR TITLE
feat: implement CLI protocol version verification [IDE-1978]

### DIFF
--- a/src/snyk/common/languageServer/languageServer.ts
+++ b/src/snyk/common/languageServer/languageServer.ts
@@ -1,8 +1,10 @@
+import { execFile } from 'child_process';
 import _ from 'lodash';
 import { firstValueFrom, ReplaySubject, Subject } from 'rxjs';
 import { IAuthenticationService } from '../../base/services/authenticationService';
 import { Configuration, IConfiguration } from '../configuration/configuration';
 import { CLI_INTEGRATION_NAME } from '../../cli/contants/integration';
+import { SNYK_SETTINGS_COMMAND } from '../constants/commands';
 import {
   PROTOCOL_VERSION,
   SNYK_ADD_TRUSTED_FOLDERS,
@@ -136,6 +138,10 @@ export class LanguageServer implements ILanguageServer {
     }
 
     const cliBinaryPath = await this.configuration.getCliPath();
+
+    if (!(await this.verifyCliProtocolVersion(cliBinaryPath))) {
+      return;
+    }
 
     // log level is set to info by default
     let logLevel = 'info';
@@ -328,6 +334,65 @@ export class LanguageServer implements ILanguageServer {
           this.suppressConfigFeedbackFromInboundPersistence = false;
         }
       });
+  }
+
+  /**
+   * Probes the CLI's reported protocol version and aborts startup with a user-visible
+   * error notification when it cannot be determined or doesn't match {@link PROTOCOL_VERSION}.
+   * Does not trigger any download/repair: recovery is the user's choice via the action button.
+   */
+  private async verifyCliProtocolVersion(cliBinaryPath: string | undefined): Promise<boolean> {
+    if (!cliBinaryPath) {
+      await this.notifyProtocolVersionFailure(
+        `Snyk CLI path is not configured. The Snyk Language Server will not start.`,
+      );
+      return false;
+    }
+
+    const cliProtocolVersion = await this.getCliProtocolVersion(cliBinaryPath);
+    if (cliProtocolVersion === PROTOCOL_VERSION) {
+      return true;
+    }
+
+    const message =
+      cliProtocolVersion === undefined
+        ? `Failed to verify the Snyk CLI protocol version. Expected ${PROTOCOL_VERSION}. The Snyk Language Server will not start.`
+        : `Snyk CLI protocol version mismatch (expected ${PROTOCOL_VERSION}, got ${cliProtocolVersion}). The Snyk Language Server will not start.`;
+    await this.notifyProtocolVersionFailure(message);
+    return false;
+  }
+
+  private async notifyProtocolVersionFailure(message: string): Promise<void> {
+    this.logger.error(message);
+    const openSettings = 'Open Settings';
+    const choice = await this.window.showErrorMessage(message, openSettings);
+    if (choice === openSettings) {
+      await this.codeCommands.executeCommand(SNYK_SETTINGS_COMMAND);
+    }
+  }
+
+  /**
+   * Runs `<cliBinaryPath> language-server --protocolVersion` and parses the trimmed integer output.
+   * Returns `undefined` when the binary cannot be executed or the output is not a parseable integer.
+   */
+  protected getCliProtocolVersion(cliBinaryPath: string): Promise<number | undefined> {
+    return new Promise(resolve => {
+      execFile(cliBinaryPath, ['language-server', '--protocolVersion'], (error, stdout) => {
+        if (error) {
+          this.logger.error(`Failed to invoke Snyk CLI for protocol version probe: ${error.message}`);
+          resolve(undefined);
+          return;
+        }
+        const trimmed = stdout.trim();
+        const parsed = parseInt(trimmed, 10);
+        if (!Number.isFinite(parsed) || `${parsed}` !== trimmed) {
+          this.logger.error(`Unable to parse Snyk CLI protocol version output: "${trimmed}"`);
+          resolve(undefined);
+          return;
+        }
+        resolve(parsed);
+      });
+    });
   }
 
   // Initialization options are not semantically equal to server settings, thus separated here

--- a/src/test/unit/common/languageServer/languageServer.test.ts
+++ b/src/test/unit/common/languageServer/languageServer.test.ts
@@ -40,6 +40,7 @@ suite('Language Server', () => {
   let configurationMock: IConfiguration;
   let languageServer: LanguageServer;
   let downloadServiceMock: DownloadService;
+  let protocolVersionStub: sinon.SinonStub;
 
   const logger = new LoggerMockFailOnErrors();
 
@@ -175,6 +176,11 @@ suite('Language Server', () => {
       downloadReady$: new ReplaySubject<void>(1),
       verifyAndRepairCli: sinon.fake.resolves(true),
     } as unknown as DownloadService;
+
+    // Stub the protocol-version probe to a matching version so existing tests can start the LS.
+    protocolVersionStub = sinon
+      .stub(LanguageServer.prototype, 'getCliProtocolVersion' as keyof LanguageServer)
+      .resolves(PROTOCOL_VERSION);
   });
 
   teardown(() => {
@@ -504,6 +510,132 @@ suite('Language Server', () => {
 
       sinon.assert.calledOnceWithExactly(debugSpy, 'Received $/snyk.configuration notification');
       debugSpy.restore();
+    });
+  });
+
+  suite('CLI protocol version guard', () => {
+    function createTrackingAdapter(): {
+      adapter: ILanguageClientAdapter;
+      createSpy: sinon.SinonSpy;
+      startStub: sinon.SinonStub;
+    } {
+      const startStub = sinon.stub().resolves();
+      const create = sinon.spy(
+        (): LanguageClient =>
+          ({
+            start: startStub,
+            onNotification: sinon.stub(),
+            onReady: sinon.stub().resolves(),
+            sendNotification: sinon.stub().resolves(),
+          } as unknown as LanguageClient),
+      );
+      const adapter = { create } as unknown as ILanguageClientAdapter;
+      return { adapter, createSpy: create, startStub };
+    }
+
+    test('does not start the LanguageClient when CLI protocol version mismatches', async () => {
+      protocolVersionStub.resolves(PROTOCOL_VERSION + 1);
+      const { adapter, createSpy, startStub } = createTrackingAdapter();
+      const window = new WindowMock();
+      window.showErrorMessage.resolves(undefined);
+
+      languageServer = new LanguageServer(
+        user,
+        configurationMock,
+        adapter,
+        stubWorkspaceConfiguration('snyk.loglevel', 'trace'),
+        window,
+        authServiceMock,
+        new LoggerMock(),
+        downloadServiceMock,
+        {} as IMcpProvider,
+        {} as IExtensionRetriever,
+        {} as ISummaryProviderService,
+        {} as IUriAdapter,
+        {} as IMarkdownStringAdapter,
+        new CommandsMock(),
+        {} as IDiagnosticsIssueProvider<unknown>,
+        explicitLspConfigurationChangeTracker,
+      );
+      downloadServiceMock.downloadReady$.next();
+
+      await languageServer.start();
+
+      sinon.assert.notCalled(createSpy);
+      sinon.assert.notCalled(startStub);
+      sinon.assert.calledOnce(window.showErrorMessage);
+      assert.match(
+        window.showErrorMessage.firstCall.args[0] as string,
+        new RegExp(`expected ${PROTOCOL_VERSION}, got ${PROTOCOL_VERSION + 1}`),
+      );
+      assert.strictEqual(window.showErrorMessage.firstCall.args[1], 'Open Settings');
+    });
+
+    test('does not start the LanguageClient when CLI protocol version probe fails', async () => {
+      protocolVersionStub.resolves(undefined);
+      const { adapter, createSpy, startStub } = createTrackingAdapter();
+      const window = new WindowMock();
+      window.showErrorMessage.resolves(undefined);
+
+      languageServer = new LanguageServer(
+        user,
+        configurationMock,
+        adapter,
+        stubWorkspaceConfiguration('snyk.loglevel', 'trace'),
+        window,
+        authServiceMock,
+        new LoggerMock(),
+        downloadServiceMock,
+        {} as IMcpProvider,
+        {} as IExtensionRetriever,
+        {} as ISummaryProviderService,
+        {} as IUriAdapter,
+        {} as IMarkdownStringAdapter,
+        new CommandsMock(),
+        {} as IDiagnosticsIssueProvider<unknown>,
+        explicitLspConfigurationChangeTracker,
+      );
+      downloadServiceMock.downloadReady$.next();
+
+      await languageServer.start();
+
+      sinon.assert.notCalled(createSpy);
+      sinon.assert.notCalled(startStub);
+      sinon.assert.calledOnce(window.showErrorMessage);
+      assert.match(window.showErrorMessage.firstCall.args[0] as string, /Failed to verify/);
+    });
+
+    test('opens Snyk HTML settings panel when user clicks Open Settings', async () => {
+      protocolVersionStub.resolves(PROTOCOL_VERSION + 1);
+      const { adapter } = createTrackingAdapter();
+      const window = new WindowMock();
+      window.showErrorMessage.resolves('Open Settings');
+      const commands = new CommandsMock();
+      commands.executeCommand.resolves(undefined);
+
+      languageServer = new LanguageServer(
+        user,
+        configurationMock,
+        adapter,
+        stubWorkspaceConfiguration('snyk.loglevel', 'trace'),
+        window,
+        authServiceMock,
+        new LoggerMock(),
+        downloadServiceMock,
+        {} as IMcpProvider,
+        {} as IExtensionRetriever,
+        {} as ISummaryProviderService,
+        {} as IUriAdapter,
+        {} as IMarkdownStringAdapter,
+        commands,
+        {} as IDiagnosticsIssueProvider<unknown>,
+        explicitLspConfigurationChangeTracker,
+      );
+      downloadServiceMock.downloadReady$.next();
+
+      await languageServer.start();
+
+      sinon.assert.calledOnceWithExactly(commands.executeCommand, 'snyk.settings');
     });
   });
 });


### PR DESCRIPTION
### **User description**
### Description

Adds a startup guard that verifies the Snyk CLI's reported protocol version matches the version the extension expects (`PROTOCOL_VERSION`) before launching the Language Server. This prevents the extension from connecting to a CLI that speaks a different protocol than what the extension is built against, which previously caused confusing downstream failures (missing notifications, malformed configuration, scans never completing, etc.).

[IDE-1978]

#### Behavior

In `LanguageServer.start()`, after `downloadReady$` resolves and the CLI binary path is known, but before the language client is created:

1. Spawn `<cliBinaryPath> language-server --protocolVersion` via `child_process.execFile`.
2. Trim whitespace from stdout and parse the result as an integer.
3. Compare against the extension's `PROTOCOL_VERSION` constant.
4. On match → continue to existing client creation/start.
5. On mismatch / parse failure / exec failure / missing CLI path:
   - Log an error to the LS output channel.
   - Show an error notification to the user with an `Open Settings` action button.
   - If the user clicks `Open Settings`, execute `snyk.settings`, which opens the Snyk HTML workspace configuration panel (where the user can update the CLI path, change the release channel, or enable automatic dependency management).
   - Return early — **no client is created and no download/repair is attempted**. Recovery is the user's choice via the action button.

The guard intentionally does not call `verifyAndRepairCli` on failure: a protocol-version mismatch typically means the CLI was installed/pinned by the user, and silently re-downloading would be surprising. The user is given the information and the controls to fix it themselves.

#### Implementation notes

- The probe (`getCliProtocolVersion`) is a `protected` method so it can be stubbed in tests via the prototype.
- All existing tests in `languageServer.test.ts` get a default prototype stub returning `PROTOCOL_VERSION` (added in `setup()`), so no existing test needed to change.
- Three new unit tests cover: mismatching version, probe failure (unparseable / exec error), and the `Open Settings` action invoking `snyk.settings`.

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/vscode-extension/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/vscode-extension/blob/main/CONTRIBUTING.md).
- [x] Tests added and all succeed (`npm run test:unit` — 243 passing, 15 in the LanguageServer suite incl. 3 new)
- [x] Linted (`npm run lint:fix` — no new errors)
- [x] CHANGELOG.md updated
- [ ] README.md updated, if user-facing — N/A (notification-only behavior)

### Screenshots / GIFs

_TODO: add a screenshot of the error notification with the `Open Settings` action button._


[IDE-1978]: https://snyksec.atlassian.net/browse/IDE-1978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
enhancement


___

### **Description**
- Verify Snyk CLI protocol version.

- Prevent LS startup on mismatch.

- Notify user on failure.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Language Server Startup] --> B{Verify CLI Protocol Version}
  B -->|Match| C[Start Language Client]
  B -->|Mismatch or Error| D[Notify User of Failure]
  D --> E[Abort LS Startup]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>languageServer.ts</strong><dd><code>Implement CLI protocol version verification logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/snyk/common/languageServer/languageServer.ts

<ul><li>Added logic to probe CLI protocol version using <code>execFile</code>.<br> <li> Integrated a protocol version check into the LS startup flow.<br> <li> Implemented error logging, user notifications, and a command to open <br>settings on failure.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/vscode-extension/pull/742/changes#diff-3b2a43f4595d28491fa3a90fcf03f78603ecced8084c2aa57fc972717ced9710">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>languageServer.test.ts</strong><dd><code>Add tests for CLI protocol version verification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/unit/common/languageServer/languageServer.test.ts

<ul><li>Added a new test suite for the CLI protocol version guard.<br> <li> Included tests for version mismatch, probe failure, and user <br>interaction.<br> <li> Stubbed the <code>getCliProtocolVersion</code> method for existing tests.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/vscode-extension/pull/742/changes#diff-dabd42c22eb5aec2ac82d2a44197da9adfad285ed79bebb0ba4769bf679b98f3">+132/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

