### PR TITLE
fix: honour workspace-scope organization in single-folder workspaces [IDE-2032]

### DIFF
--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -654,15 +654,7 @@ export class Configuration implements IConfiguration {
 
   get organization(): string {
     const { configurationId, section } = Configuration.getConfigName(ADVANCED_ORGANIZATION);
-    const workspaceFolders = this.workspace.getWorkspaceFolders();
     const inspection = this.workspace.inspectConfiguration<string>(configurationId, section);
-
-    // If only 1 folder in workspace, return user (global) scope only
-    if (workspaceFolders.length === 1) {
-      return inspection?.globalValue ?? '';
-    }
-
-    // If multiple folders, return workspace scope, falling back to user (global) scope
     return inspection?.workspaceValue ?? inspection?.globalValue ?? '';
   }
 

--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -653,6 +653,10 @@ export class Configuration implements IConfiguration {
   }
 
   get organization(): string {
+    // VS Code window-scope precedence: workspaceValue beats globalValue. Honour the
+    // workspace-scope override even in single-folder workspaces — a workspace-scope
+    // clear (`''`) must reach LS, and the writer no longer special-cases single-folder
+    // either (IDE-1638 removed the matching branch from applySettingsMap).
     const { configurationId, section } = Configuration.getConfigName(ADVANCED_ORGANIZATION);
     const inspection = this.workspace.inspectConfiguration<string>(configurationId, section);
     return inspection?.workspaceValue ?? inspection?.globalValue ?? '';

--- a/src/test/unit/common/configuration.test.ts
+++ b/src/test/unit/common/configuration.test.ts
@@ -242,68 +242,64 @@ suite('Configuration', () => {
   });
 
   suite('Organization Configuration - Critical Paths', () => {
-    suite('Single-Folder Workspace', () => {
-      test('organization getter returns ONLY global value in single-folder workspace', () => {
-        const workspace = createWorkspaceMockWithInspection<string>(
-          ADVANCED_ORGANIZATION,
-          {
-            globalValue: 'global-org',
-            workspaceValue: 'workspace-org',
-          },
-          1, // single folder
-        );
+    test('organization getter prioritises workspace value over global', () => {
+      const workspace = createWorkspaceMockWithInspection<string>(
+        ADVANCED_ORGANIZATION,
+        {
+          globalValue: 'global-org',
+          workspaceValue: 'workspace-org',
+        },
+        1,
+      );
 
-        const configuration = new Configuration({}, workspace);
+      const configuration = new Configuration({}, workspace);
 
-        strictEqual(configuration.organization, 'global-org');
-      });
-
-      test('organization getter ignores workspace value even if set in single-folder workspace', () => {
-        const workspace = createWorkspaceMockWithInspection<string>(
-          ADVANCED_ORGANIZATION,
-          {
-            globalValue: undefined,
-            workspaceValue: 'workspace-org',
-          },
-          1, // single folder
-        );
-
-        const configuration = new Configuration({}, workspace);
-
-        strictEqual(configuration.organization, '');
-      });
+      strictEqual(configuration.organization, 'workspace-org');
     });
 
-    suite('Multi-Folder Workspace', () => {
-      test('organization getter prioritizes workspace value over global in multi-folder workspace', () => {
-        const workspace = createWorkspaceMockWithInspection<string>(
-          ADVANCED_ORGANIZATION,
-          {
-            globalValue: 'global-org',
-            workspaceValue: 'workspace-org',
-          },
-          2, // multi folder
-        );
+    test('organization getter honours a workspace-scope clear (empty string) over a non-empty global', () => {
+      const workspace = createWorkspaceMockWithInspection<string>(
+        ADVANCED_ORGANIZATION,
+        {
+          globalValue: 'global-org',
+          workspaceValue: '',
+        },
+        1,
+      );
 
-        const configuration = new Configuration({}, workspace);
+      const configuration = new Configuration({}, workspace);
 
-        strictEqual(configuration.organization, 'workspace-org');
-      });
+      strictEqual(configuration.organization, '');
+    });
 
-      test('organization getter falls back to global when no workspace value in multi-folder', () => {
-        const workspace = createWorkspaceMockWithInspection<string>(
-          ADVANCED_ORGANIZATION,
-          {
-            globalValue: 'global-org',
-            workspaceValue: undefined,
-          },
-          2, // multi folder
-        );
+    test('organization getter falls back to global when workspace value is undefined', () => {
+      const workspace = createWorkspaceMockWithInspection<string>(
+        ADVANCED_ORGANIZATION,
+        {
+          globalValue: 'global-org',
+          workspaceValue: undefined,
+        },
+        1,
+      );
 
-        const configuration = new Configuration({}, workspace);
+      const configuration = new Configuration({}, workspace);
 
-        strictEqual(configuration.organization, 'global-org');
-      });
+      strictEqual(configuration.organization, 'global-org');
+    });
+
+    test('organization getter returns empty string when neither scope is set', () => {
+      const workspace = createWorkspaceMockWithInspection<string>(
+        ADVANCED_ORGANIZATION,
+        {
+          globalValue: undefined,
+          workspaceValue: undefined,
+        },
+        1,
+      );
+
+      const configuration = new Configuration({}, workspace);
+
+      strictEqual(configuration.organization, '');
     });
   });
 


### PR DESCRIPTION
## Summary

The `Configuration.organization` getter had a single-folder branch that returned only `globalValue`, ignoring `workspaceValue`. This was added in [IDE-1661](https://github.com/snyk/vscode-extension/pull/706) alongside a matching writer-side special case in the settings page that forced user-scope writes in single-folder workspaces. The writer-side special case was removed in [IDE-1638](https://github.com/snyk/vscode-extension/pull/733) ("support Central Config API") when `applySettingsMap` was unified, but the reader-side branch was left behind.

The asymmetry: in a single-folder workspace with `globalValue` = some UUID and `workspaceValue` = `''`, the writer puts `''` in workspace scope (because `getSettingScope` returns `'workspace'` whenever `workspaceValue !== undefined`), but the reader ignores `workspaceValue` and returns the global UUID. End result: blanking the org at workspace scope silently has no effect on the LS payload — the IDE keeps sending the global UUID.

This PR drops the single-folder branch so the reader follows VS Code's standard window-scope precedence (`workspaceValue ?? globalValue`), matching the writer.

## Relationship to PR #750

This is the second half of the org-clearing fix originally chased in #750:
- **#750 (IDE-2032)** — LS rejects `null` for string settings, so the outbound payload now emits `''` instead of `null` when an explicitly-changed string is cleared.
- **This PR** — makes the reader actually return `''` in the workspace-scope-clear case so the #750 path engages.

The two PRs are independent and either can ship first; together they close out the "blank org textbox should clear the org sent to LS" user-facing behaviour.

## Test plan

- [x] Unit tests pass (`configuration.test.ts` — 4 rewritten/added cases covering workspace-precedence, workspace-empty-clear, global-fallback, both-undefined)
- [ ] Manual: single-folder workspace, set `snyk.advanced.organization` in user settings to a UUID, then clear it via the Snyk settings page; verify the outbound `\$/snyk.didChangeConfiguration` (or `workspace/configuration` pull) carries `organization: { value: '', changed: true }`.
- [ ] Manual: multi-folder workspace — verify workspace-scope override still wins over global (unchanged behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IDE-1661]: https://snyksec.atlassian.net/browse/IDE-1661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1638]: https://snyksec.atlassian.net/browse/IDE-1638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ