### PR TITLE
fix: don't override user-set settings with default values on ls start [IDE-2107]

### DIFF
--- a/media/views/common/configuration/settings-fallback.html
+++ b/media/views/common/configuration/settings-fallback.html
@@ -355,6 +355,8 @@
 </form>
 
 <script>
+  // Mirrors the save-on-close logic in infrastructure/configuration/template/js/features/auto-save.js.
+  // Keep both in sync when changing the visibilitychange handler or re-entrance guard.
   (function() {
     if (typeof window.__IS_IDE_AUTOSAVE_ENABLED__ === 'undefined') {
       window.__IS_IDE_AUTOSAVE_ENABLED__ = false;
@@ -362,6 +364,8 @@
 
     var FIELDS = ['cli_path', 'automatic_download', 'binary_base_url', 'cli_release_channel', 'proxy_insecure'];
     var initialState = null;
+    // Guard against re-entrance when blur() triggers getAndSaveIdeConfig
+    var _isSaving = false;
 
     function get(id) {
       return document.getElementById(id);
@@ -461,21 +465,40 @@
     }
 
     window.getAndSaveIdeConfig = function() {
-      if (!validateCliVersion()) {
-        if (typeof window.__ideSaveAttemptFinished__ === 'function') {
-          window.__ideSaveAttemptFinished__('validation_error');
-        }
-        return;
-      }
-      var data = collectChangedData();
+      if (_isSaving) return;
+      _isSaving = true;
+
       try {
-        if (typeof window.__saveIdeConfig__ === 'function') {
-          window.__saveIdeConfig__(JSON.stringify(data));
-          captureInitialState();
-          notifyDirty(false);
+        // Commit any focused text input or select value before collecting.
+        // Closing the panel without blurring silently discards uncommitted changes
+        // because blur never fires. The _isSaving guard prevents recursion.
+        var active = document.activeElement;
+        if (active && typeof active.blur === 'function' &&
+            (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.tagName === 'SELECT') &&
+            active.type !== 'checkbox' && active.type !== 'radio' && active.type !== 'button' && active.type !== 'hidden' &&
+            !active.readOnly && !active.disabled) {
+          active.blur();
         }
-      } catch (e) {
-        console.error('Error saving configuration:', e);
+
+        if (!validateCliVersion()) {
+          if (typeof window.__ideSaveAttemptFinished__ === 'function') {
+            window.__ideSaveAttemptFinished__('validation_error');
+          }
+          return;
+        }
+
+        var data = collectChangedData();
+        try {
+          if (typeof window.__saveIdeConfig__ === 'function') {
+            window.__saveIdeConfig__(JSON.stringify(data));
+            captureInitialState();
+            notifyDirty(false);
+          }
+        } catch (e) {
+          console.error('Error saving configuration:', e);
+        }
+      } finally {
+        _isSaving = false;
       }
     };
 
@@ -553,6 +576,16 @@
       toggleCustomVersionInput();
       validateCliVersion();
       captureInitialState();
+
+      // Save when the panel becomes hidden (e.g. closed in VS Code) without a prior blur.
+      // Closing a webview does not fire blur on the focused element, so text field changes
+      // typed but not yet blurred would otherwise be silently discarded.
+      // Only fires for auto-save IDEs; non-auto-save IDEs use an explicit OK/Cancel flow.
+      document.addEventListener('visibilitychange', function() {
+        if (document.visibilityState === 'hidden' && window.__IS_IDE_AUTOSAVE_ENABLED__) {
+          window.getAndSaveIdeConfig();
+        }
+      });
     });
   })();
 </script>

--- a/src/snyk/base/modules/interfaces.ts
+++ b/src/snyk/base/modules/interfaces.ts
@@ -31,5 +31,6 @@ export interface IExtension extends IBaseSnykModule, ISnykLib {
   activate(context: VSCodeExtensionContext): void;
   stopLanguageServer(): Promise<void>;
   restartLanguageServer(): Promise<void>;
+  restartLanguageServerWithDependencyDownload(): Promise<void>;
   initDependencyDownload(): DownloadService;
 }

--- a/src/snyk/common/constants/languageServer.ts
+++ b/src/snyk/common/constants/languageServer.ts
@@ -3,6 +3,10 @@
 export const SNYK_LANGUAGE_SERVER_NAME = 'Snyk Language Server';
 // The internal language server protocol version for custom messages and configuration
 export const PROTOCOL_VERSION = 25;
+// Sentinel reported by locally-built (non-release) snyk-ls binaries via `--protocolVersion`.
+// snyk-ls treats this as always-compatible (see application/server/server.go handleProtocolVersion),
+// so the IDE must too — otherwise local development binaries can never start.
+export const DEVELOPMENT_PROTOCOL_VERSION = 'development';
 
 // LS protocol methods (needed for not having to rely on vscode dependencies in testing)
 export const DID_CHANGE_CONFIGURATION_METHOD = 'workspace/didChangeConfiguration';

--- a/src/snyk/common/languageServer/languageServer.ts
+++ b/src/snyk/common/languageServer/languageServer.ts
@@ -6,6 +6,7 @@ import { Configuration, IConfiguration } from '../configuration/configuration';
 import { CLI_INTEGRATION_NAME } from '../../cli/contants/integration';
 import { SNYK_SETTINGS_COMMAND } from '../constants/commands';
 import {
+  DEVELOPMENT_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
   SNYK_ADD_TRUSTED_FOLDERS,
   SNYK_CONFIGURATION,
@@ -45,6 +46,15 @@ export interface ILanguageServer {
   start(): Promise<void>;
 
   stop(): Promise<void>;
+
+  /**
+   * Registers the (idempotent, session-long) listener that records user-driven `snyk.*`
+   * settings changes for outbound `changed: true`. Call at activation so changes made
+   * while the LS is down are still tracked. Returns the listener's {@link Disposable} on first
+   * registration (so the caller can tie it to the extension lifetime), or `undefined` if already
+   * registered.
+   */
+  registerExplicitKeyMarkingListener(): Disposable | undefined;
 
   showOutputChannel(): void;
 
@@ -279,11 +289,21 @@ export class LanguageServer implements ILanguageServer {
   }
 
   /**
-   * Marks which LS keys the user explicitly changed via native VS Code settings,
-   * so the middleware can set `changed: true` on the next `workspace/configuration` pull response.
+   * Marks which LS keys the user explicitly changed via native VS Code settings, so the
+   * middleware sets `changed: true` on the next `workspace/configuration` pull and on
+   * `initializationOptions` at the next LS start.
+   *
+   * Registered once at extension activation — independently of the LS lifecycle — and kept
+   * alive across restarts and while the LS is down. This is essential when the CLI hasn't
+   * downloaded yet and the fallback settings page is shown: changes made then (e.g. unchecking
+   * "manage binaries automatically") must still be recorded, otherwise the LS never learns the
+   * override and echoes back its own default. Idempotent: subsequent calls are no-ops and return
+   * `undefined`; the first call returns the listener's Disposable for the caller to own.
    */
-  private registerExplicitKeyMarkingListener(): void {
-    this.configurationChangeDisposable?.dispose();
+  registerExplicitKeyMarkingListener(): Disposable | undefined {
+    if (this.configurationChangeDisposable) {
+      return undefined;
+    }
 
     this.configurationChangeDisposable = this.workspace.onDidChangeConfiguration(e => {
       if (this.suppressConfigFeedbackFromInboundPersistence) {
@@ -291,6 +311,7 @@ export class LanguageServer implements ILanguageServer {
       }
       markExplicitLsKeysFromConfigurationChangeEvent(e, this.explicitLspConfigurationChangeTracker);
     });
+    return this.configurationChangeDisposable;
   }
 
   private handleSnykConfigurationNotification(params: LspConfigurationParam): void {
@@ -331,6 +352,17 @@ export class LanguageServer implements ILanguageServer {
     }
 
     const cliProtocolVersion = await this.getCliProtocolVersion(cliBinaryPath);
+
+    // Locally-built (non-release) snyk-ls binaries report the "development" sentinel and are
+    // always compatible — mirror snyk-ls' own handleProtocolVersion behaviour so local
+    // development binaries can start.
+    if (cliProtocolVersion === DEVELOPMENT_PROTOCOL_VERSION) {
+      this.logger.warn(
+        `Snyk CLI reports a "${DEVELOPMENT_PROTOCOL_VERSION}" protocol version (local build); skipping the protocol version check.`,
+      );
+      return true;
+    }
+
     if (cliProtocolVersion === PROTOCOL_VERSION) {
       return true;
     }
@@ -353,25 +385,62 @@ export class LanguageServer implements ILanguageServer {
   }
 
   /**
-   * Runs `<cliBinaryPath> language-server --protocolVersion` and parses the trimmed integer output.
-   * Returns `undefined` when the binary cannot be executed or the output is not a parseable integer.
+   * Parses the trimmed `--protocolVersion` output into the {@link DEVELOPMENT_PROTOCOL_VERSION}
+   * sentinel (local builds), a release integer, or `undefined` when it's neither.
    */
-  protected getCliProtocolVersion(cliBinaryPath: string): Promise<number | undefined> {
+  protected parseProtocolVersionOutput(stdout: string): number | typeof DEVELOPMENT_PROTOCOL_VERSION | undefined {
+    const trimmed = stdout.trim();
+    if (trimmed === DEVELOPMENT_PROTOCOL_VERSION) {
+      return DEVELOPMENT_PROTOCOL_VERSION;
+    }
+    const parsed = parseInt(trimmed, 10);
+    if (!Number.isFinite(parsed) || `${parsed}` !== trimmed) {
+      return undefined;
+    }
+    return parsed;
+  }
+
+  /**
+   * Runs `<cliBinaryPath> language-server --protocolVersion` and parses the output.
+   * Returns the {@link DEVELOPMENT_PROTOCOL_VERSION} sentinel for local builds that report it,
+   * the parsed integer for release binaries, or `undefined` when the binary cannot be executed
+   * or the output is neither the sentinel nor a parseable integer.
+   *
+   * Debug builds (`make build-debug`) pause ~10s and exit non-zero after printing the version, so we
+   * parse stdout even when execFile reports an error and only treat it as a failure when no valid
+   * version was printed.
+   */
+  protected getCliProtocolVersion(
+    cliBinaryPath: string,
+  ): Promise<number | typeof DEVELOPMENT_PROTOCOL_VERSION | undefined> {
     return new Promise(resolve => {
-      execFile(cliBinaryPath, ['language-server', '--protocolVersion'], (error, stdout) => {
+      execFile(cliBinaryPath, ['language-server', '--protocolVersion'], (error, stdout, stderr) => {
+        const version = this.parseProtocolVersionOutput(stdout ?? '');
+
+        if (version !== undefined) {
+          if (error) {
+            this.logger.warn(
+              `Snyk CLI protocol version probe exited with an error but reported a version ("${version}"); using it. ` +
+                `Error: ${error.message}`,
+            );
+          }
+          resolve(version);
+          return;
+        }
+
         if (error) {
-          this.logger.error(`Failed to invoke Snyk CLI for protocol version probe: ${error.message}`);
+          const { code, signal } = error as NodeJS.ErrnoException & { signal?: NodeJS.Signals };
+          this.logger.error(
+            `Failed to invoke Snyk CLI for protocol version probe (exit code: ${code ?? 'n/a'}, signal: ${
+              signal ?? 'n/a'
+            }): ${error.message}. stdout: "${(stdout ?? '').trim()}", stderr: "${(stderr ?? '').trim()}"`,
+          );
           resolve(undefined);
           return;
         }
-        const trimmed = stdout.trim();
-        const parsed = parseInt(trimmed, 10);
-        if (!Number.isFinite(parsed) || `${parsed}` !== trimmed) {
-          this.logger.error(`Unable to parse Snyk CLI protocol version output: "${trimmed}"`);
-          resolve(undefined);
-          return;
-        }
-        resolve(parsed);
+
+        this.logger.error(`Unable to parse Snyk CLI protocol version output: "${(stdout ?? '').trim()}"`);
+        resolve(undefined);
       });
     });
   }
@@ -406,8 +475,9 @@ export class LanguageServer implements ILanguageServer {
   async stop(): Promise<void> {
     this.logger.info('Stopping Snyk Language Server...');
 
-    this.configurationChangeDisposable?.dispose();
-    this.configurationChangeDisposable = undefined;
+    // Intentionally keep `configurationChangeDisposable` alive across stop/restart and while the LS
+    // is down — see registerExplicitKeyMarkingListener. Its lifetime is owned by the extension
+    // context (registered into subscriptions at activation), so it's disposed on deactivation.
 
     if (!this.client) {
       return Promise.resolve();

--- a/src/snyk/common/languageServer/lsKeyToVscodeKeyMap.ts
+++ b/src/snyk/common/languageServer/lsKeyToVscodeKeyMap.ts
@@ -274,18 +274,10 @@ export function mapConfigToSettings(config: HtmlSettingsData): Record<string, un
  * Maps inbound LS global settings directly to VS Code settings.
  * Entries without a vscodeKey (token, sendErrorReports, etc.) are skipped.
  *
- * Settings the LS reports with `source: 'default'` are skipped: a default is the
- * LS's fallback value (not an authoritative one), and persisting it would clobber
- * the IDE-owned setting. The LS does not set `changed` in the LS→IDE direction, so
- * `source` is the discriminator here. This prevents the LS's default-derived snapshot
- * (e.g. `automatic_download: { value: true, source: 'default' }`) from reverting a
- * user's explicit choice.
- *
- * Follow-up: when the LS reports `source: 'default'` AND the IDE currently has a
- * stored value, that signals a reset of a previously-authoritative value (e.g. a
- * remote/LDX-sync override was cleared server-side). Correct handling is to *clear*
- * the IDE setting key, not write the default value. That needs an unset path in
- * applySettingsMap and is out of scope here.
+ * The LS is the source of truth: every reported value is persisted. The IDE keeps the
+ * LS's view authoritative by sending user overrides as `changed: true` (tracked from
+ * activation onward, even while the LS is down), so the LS resolves and echoes the
+ * user's value rather than its own default.
  */
 export function mapLspSettingsToVscodeSettings(
   globalSettings: Record<string, LspConfigSetting>,
@@ -295,9 +287,7 @@ export function mapLspSettingsToVscodeSettings(
   for (const [lsKey, entry] of Object.entries(SETTINGS_REGISTRY)) {
     if (!entry.vscodeKey) continue;
 
-    const setting = globalSettings[lsKey];
-    if (setting?.source === 'default') continue;
-    const value = setting?.value;
+    const value = globalSettings[lsKey]?.value;
     if (value === undefined) continue;
 
     setOrMerge(result, entry.vscodeKey, entry.toVscodeValue ? entry.toVscodeValue(value) : value);

--- a/src/snyk/common/languageServer/lsKeyToVscodeKeyMap.ts
+++ b/src/snyk/common/languageServer/lsKeyToVscodeKeyMap.ts
@@ -273,6 +273,19 @@ export function mapConfigToSettings(config: HtmlSettingsData): Record<string, un
 /**
  * Maps inbound LS global settings directly to VS Code settings.
  * Entries without a vscodeKey (token, sendErrorReports, etc.) are skipped.
+ *
+ * Settings the LS reports with `source: 'default'` are skipped: a default is the
+ * LS's fallback value (not an authoritative one), and persisting it would clobber
+ * the IDE-owned setting. The LS does not set `changed` in the LS→IDE direction, so
+ * `source` is the discriminator here. This prevents the LS's default-derived snapshot
+ * (e.g. `automatic_download: { value: true, source: 'default' }`) from reverting a
+ * user's explicit choice.
+ *
+ * Follow-up: when the LS reports `source: 'default'` AND the IDE currently has a
+ * stored value, that signals a reset of a previously-authoritative value (e.g. a
+ * remote/LDX-sync override was cleared server-side). Correct handling is to *clear*
+ * the IDE setting key, not write the default value. That needs an unset path in
+ * applySettingsMap and is out of scope here.
  */
 export function mapLspSettingsToVscodeSettings(
   globalSettings: Record<string, LspConfigSetting>,
@@ -282,7 +295,9 @@ export function mapLspSettingsToVscodeSettings(
   for (const [lsKey, entry] of Object.entries(SETTINGS_REGISTRY)) {
     if (!entry.vscodeKey) continue;
 
-    const value = globalSettings[lsKey]?.value;
+    const setting = globalSettings[lsKey];
+    if (setting?.source === 'default') continue;
+    const value = setting?.value;
     if (value === undefined) continue;
 
     setOrMerge(result, entry.vscodeKey, entry.toVscodeValue ? entry.toVscodeValue(value) : value);

--- a/src/snyk/common/views/workspaceConfiguration/services/configurationPersistenceService.ts
+++ b/src/snyk/common/views/workspaceConfiguration/services/configurationPersistenceService.ts
@@ -56,8 +56,17 @@ export class ConfigurationPersistenceService implements IConfigurationPersistenc
         }
       }
 
-      // Notify the LS once after all settings (including token) have been written
-      await this.clientAdapter.getLanguageClient().sendNotification(DID_CHANGE_CONFIGURATION_METHOD, {});
+      // Notify the LS once after all settings (including token) have been written.
+      // The client is undefined until the LS has started — e.g. when saving from the fallback
+      // settings page while the CLI is still downloading. Settings are already persisted above,
+      // and the LS reads them from initializationOptions at its next start, so skipping the
+      // notification here is safe.
+      const languageClient = this.clientAdapter.getLanguageClient();
+      if (languageClient) {
+        await languageClient.sendNotification(DID_CHANGE_CONFIGURATION_METHOD, {});
+      } else {
+        this.logger.debug('Language Server is not running; skipping didChangeConfiguration notification.');
+      }
 
       this.logger.info('Workspace configuration saved successfully');
     } catch (e) {

--- a/src/snyk/common/watchers/configurationWatcher.ts
+++ b/src/snyk/common/watchers/configurationWatcher.ts
@@ -13,6 +13,7 @@ import {
   TRUSTED_FOLDERS,
   DELTA_FINDINGS,
   ADVANCED_AUTHENTICATION_METHOD,
+  ADVANCED_AUTOMATIC_DEPENDENCY_MANAGEMENT,
   ADVANCED_CLI_PATH,
   ADVANCED_CLI_RELEASE_CHANNEL,
   CODE_SECURITY_ENABLED_SETTING,
@@ -59,6 +60,19 @@ class ConfigurationWatcher implements IWatcher {
     } else if (key === ADVANCED_CLI_PATH) {
       // Language Server client must sync config changes before we can restart
       return _.debounce(() => extension.restartLanguageServer(), DEFAULT_LS_DEBOUNCE_INTERVAL)();
+    } else if (key === ADVANCED_AUTOMATIC_DEPENDENCY_MANAGEMENT) {
+      // Re-evaluate binary management and restart so the toggle takes effect without an IDE reload:
+      // enabling downloads the managed binary, disabling falls back to the configured cliPath.
+      // The debounced call detaches from this method's promise, so log failures explicitly.
+      return _.debounce(
+        () =>
+          extension
+            .restartLanguageServerWithDependencyDownload()
+            .catch(err =>
+              ErrorHandler.handle(err, this.logger, `${errorsLogs.configWatcher}. Configuration key: ${key}`),
+            ),
+        DEFAULT_LS_DEBOUNCE_INTERVAL,
+      )();
     } else if (key === ADVANCED_CLI_RELEASE_CHANNEL) {
       if (configuration.isAutomaticDependencyManagementEnabled()) {
         await extension.stopLanguageServer();
@@ -96,6 +110,7 @@ class ConfigurationWatcher implements IWatcher {
         CODE_SECURITY_ENABLED_SETTING,
         IAC_ENABLED_SETTING,
         ADVANCED_CUSTOM_ENDPOINT,
+        ADVANCED_AUTOMATIC_DEPENDENCY_MANAGEMENT,
         ADVANCED_CLI_PATH,
         ADVANCED_CLI_RELEASE_CHANNEL,
         ADVANCED_AUTHENTICATION_METHOD,

--- a/src/snyk/common/watchers/configurationWatcher.ts
+++ b/src/snyk/common/watchers/configurationWatcher.ts
@@ -36,6 +36,28 @@ class ConfigurationWatcher implements IWatcher {
     private readonly vscodeContext: vscode.ExtensionContext,
   ) {}
 
+  // Persistent debounced restarts so rapid config changes collapse into a single LS restart cycle
+  // (a fresh `_.debounce(...)()` per event would never share a timer and so never debounce).
+  private readonly debouncedRestartLanguageServer = _.debounce((extension: IExtension) => {
+    extension
+      .restartLanguageServer()
+      .catch(err =>
+        ErrorHandler.handle(err, this.logger, `${errorsLogs.configWatcher}. Configuration key: ${ADVANCED_CLI_PATH}`),
+      );
+  }, DEFAULT_LS_DEBOUNCE_INTERVAL);
+
+  private readonly debouncedRestartWithDependencyDownload = _.debounce((extension: IExtension) => {
+    extension
+      .restartLanguageServerWithDependencyDownload()
+      .catch(err =>
+        ErrorHandler.handle(
+          err,
+          this.logger,
+          `${errorsLogs.configWatcher}. Configuration key: ${ADVANCED_AUTOMATIC_DEPENDENCY_MANAGEMENT}`,
+        ),
+      );
+  }, DEFAULT_LS_DEBOUNCE_INTERVAL);
+
   private async onChangeConfiguration(
     extension: IExtension,
     key: string,
@@ -59,20 +81,13 @@ class ConfigurationWatcher implements IWatcher {
       return extension.viewManagerService.refreshAllViews();
     } else if (key === ADVANCED_CLI_PATH) {
       // Language Server client must sync config changes before we can restart
-      return _.debounce(() => extension.restartLanguageServer(), DEFAULT_LS_DEBOUNCE_INTERVAL)();
+      this.debouncedRestartLanguageServer(extension);
+      return;
     } else if (key === ADVANCED_AUTOMATIC_DEPENDENCY_MANAGEMENT) {
       // Re-evaluate binary management and restart so the toggle takes effect without an IDE reload:
       // enabling downloads the managed binary, disabling falls back to the configured cliPath.
-      // The debounced call detaches from this method's promise, so log failures explicitly.
-      return _.debounce(
-        () =>
-          extension
-            .restartLanguageServerWithDependencyDownload()
-            .catch(err =>
-              ErrorHandler.handle(err, this.logger, `${errorsLogs.configWatcher}. Configuration key: ${key}`),
-            ),
-        DEFAULT_LS_DEBOUNCE_INTERVAL,
-      )();
+      this.debouncedRestartWithDependencyDownload(extension);
+      return;
     } else if (key === ADVANCED_CLI_RELEASE_CHANNEL) {
       if (configuration.isAutomaticDependencyManagementEnabled()) {
         await extension.stopLanguageServer();

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -539,6 +539,15 @@ class SnykExtension extends SnykLib implements IExtension {
     // Skip LS initialization during integration tests to prevent LS interferening with tests
     if (process.env.SNYK_INTEGRATION_TEST_MODE === 'true') return;
 
+    // Track user-driven `snyk.*` settings changes from now on — even before the LS starts — so
+    // overrides made while the CLI is still downloading (fallback settings page) are sent as
+    // `changed: true` at the next LS start instead of being lost and echoed back as defaults.
+    // Owned by the extension context so it's disposed on deactivation.
+    const explicitKeyMarkingDisposable = this.languageServer.registerExplicitKeyMarkingListener();
+    if (explicitKeyMarkingDisposable) {
+      vscodeContext.subscriptions.push(explicitKeyMarkingDisposable);
+    }
+
     this.initDependencyDownload();
 
     this.ossVulnerabilityCountService = new OssVulnerabilityCountService(
@@ -654,16 +663,36 @@ class SnykExtension extends SnykLib implements IExtension {
     await this.languageServer.start();
   }
 
+  /**
+   * Re-evaluates dependency management and restarts the LS so a change to
+   * `automaticDependencyManagement` takes effect without an IDE reload: enabling downloads the
+   * managed binary, disabling falls back to the configured `cliPath`.
+   *
+   * The download is awaited *before* starting so the LS does not probe the binary while a download
+   * is still in flight (`start()` resolves immediately on the replayed `downloadReady$`).
+   */
+  public async restartLanguageServerWithDependencyDownload(): Promise<void> {
+    await this.languageServer.stop();
+    await this.downloadDependencies();
+    await this.languageServer.start();
+  }
+
   public initDependencyDownload(): DownloadService {
-    this.downloadService.downloadOrUpdate().catch(err => {
+    void this.downloadDependencies();
+    return this.downloadService;
+  }
+
+  private async downloadDependencies(): Promise<void> {
+    try {
+      await this.downloadService.downloadOrUpdate();
+    } catch (err) {
       if (err instanceof TransientNetworkError || isNetworkConnectivityError(err)) {
         Logger.info(`CLI download skipped due to no network connectivity. Will retry on next startup.`);
         return;
       }
       void ErrorHandler.handleGlobal(err, Logger, this.contextService, this.loadingBadge);
       void this.notificationService.showErrorNotification((err as Error).message);
-    });
-    return this.downloadService;
+    }
   }
 
   private registerCommands(context: vscode.ExtensionContext): void {

--- a/src/test/unit/common/languageServer/languageServer.test.ts
+++ b/src/test/unit/common/languageServer/languageServer.test.ts
@@ -380,6 +380,100 @@ suite('Language Server', () => {
     sinon.assert.notCalled(markStub);
   });
 
+  test('tracks explicit LS keys while the LS is down (listener registered without start)', () => {
+    const markStub = sinon.stub();
+    const tracker: IExplicitLspConfigurationChangeTracker = {
+      markExplicitlyChanged: markStub,
+      unmarkExplicitlyChanged: sinon.stub(),
+      isExplicitlyChanged: () => true,
+    };
+    let configListener: (e: { affectsConfiguration: (s: string) => boolean }) => void = () => {};
+    const onDidChangeConfigurationStub = sinon.stub().callsFake((fn: typeof configListener) => {
+      configListener = fn;
+      return { dispose: sinon.stub() };
+    });
+    const createStub = sinon.stub();
+    const adapter = { create: createStub } as unknown as ILanguageClientAdapter;
+
+    const workspace = {
+      ...stubWorkspaceConfiguration('snyk.loglevel', 'trace'),
+      onDidChangeConfiguration: onDidChangeConfigurationStub,
+    } as IVSCodeWorkspace;
+
+    languageServer = new LanguageServer(
+      user,
+      configurationMock,
+      adapter,
+      workspace,
+      new WindowMock(),
+      authServiceMock,
+      logger,
+      downloadServiceMock,
+      {} as IMcpProvider,
+      {} as IExtensionRetriever,
+      {} as ISummaryProviderService,
+      {} as IUriAdapter,
+      {} as IMarkdownStringAdapter,
+      new CommandsMock(),
+      {} as IDiagnosticsIssueProvider<unknown>,
+      tracker,
+      sinon.stub().resolves(),
+    );
+
+    // No start() — the CLI hasn't downloaded yet, but the listener must already be active.
+    languageServer.registerExplicitKeyMarkingListener();
+    // Idempotent: a second call must not subscribe again.
+    languageServer.registerExplicitKeyMarkingListener();
+
+    configListener({ affectsConfiguration: (s: string) => s === 'snyk' || s.startsWith('snyk.') });
+
+    sinon.assert.calledOnce(onDidChangeConfigurationStub);
+    sinon.assert.called(markStub);
+    sinon.assert.notCalled(createStub);
+  });
+
+  suite('parseProtocolVersionOutput', () => {
+    let parse: (stdout: string) => number | 'development' | undefined;
+
+    setup(() => {
+      const ls = createFakeLanguageServer(
+        { create: sinon.stub() } as unknown as ILanguageClientAdapter,
+        stubWorkspaceConfiguration('snyk.loglevel', 'trace'),
+      );
+      parse = (stdout: string) =>
+        (
+          ls as unknown as {
+            parseProtocolVersionOutput(s: string): number | 'development' | undefined;
+          }
+        ).parseProtocolVersionOutput(stdout);
+    });
+
+    test('parses a plain integer version', () => {
+      strictEqual(parse('25'), 25);
+    });
+
+    test('trims surrounding whitespace and newlines', () => {
+      strictEqual(parse('  25\n'), 25);
+    });
+
+    test('returns the development sentinel for local builds', () => {
+      strictEqual(parse('development'), 'development');
+    });
+
+    test('returns undefined for empty output', () => {
+      strictEqual(parse(''), undefined);
+    });
+
+    test('returns undefined for non-numeric output (e.g. CLI help text)', () => {
+      strictEqual(parse('CLI help\n  snyk auth\n  snyk test'), undefined);
+    });
+
+    test('returns undefined for partially-numeric output', () => {
+      strictEqual(parse('25abc'), undefined);
+      strictEqual(parse('v25'), undefined);
+    });
+  });
+
   suite('LanguageServer is initialized', () => {
     setup(() => {
       const mockLanguageClient = {
@@ -608,6 +702,39 @@ suite('Language Server', () => {
       sinon.assert.notCalled(startStub);
       sinon.assert.calledOnce(window.showErrorMessage);
       assert.match(window.showErrorMessage.firstCall.args[0] as string, /Failed to verify/);
+    });
+
+    test('starts the LanguageClient when the CLI reports the "development" protocol version', async () => {
+      protocolVersionStub.resolves('development');
+      const { adapter, createSpy, startStub } = createTrackingAdapter();
+      const window = new WindowMock();
+
+      languageServer = new LanguageServer(
+        user,
+        configurationMock,
+        adapter,
+        stubWorkspaceConfiguration('snyk.loglevel', 'trace'),
+        window,
+        authServiceMock,
+        new LoggerMock(),
+        downloadServiceMock,
+        {} as IMcpProvider,
+        {} as IExtensionRetriever,
+        {} as ISummaryProviderService,
+        {} as IUriAdapter,
+        {} as IMarkdownStringAdapter,
+        new CommandsMock(),
+        {} as IDiagnosticsIssueProvider<unknown>,
+        explicitLspConfigurationChangeTracker,
+        sinon.stub().resolves(),
+      );
+      downloadServiceMock.downloadReady$.next();
+
+      await languageServer.start();
+
+      sinon.assert.calledOnce(createSpy);
+      sinon.assert.calledOnce(startStub);
+      sinon.assert.notCalled(window.showErrorMessage);
     });
 
     test('opens Snyk HTML settings panel when user clicks Open Settings', async () => {

--- a/src/test/unit/common/views/workspaceConfiguration/services/configurationPersistenceService.test.ts
+++ b/src/test/unit/common/views/workspaceConfiguration/services/configurationPersistenceService.test.ts
@@ -220,6 +220,37 @@ suite('ConfigurationPersistenceService — LS key mapping', () => {
     );
   });
 
+  test('does not throw when saving while the Language Server is not running', async () => {
+    // getLanguageClient() returns undefined until the LS has started (e.g. fallback settings
+    // page while the CLI is still downloading). The save must still persist settings.
+    const noClientAdapter = {
+      getLanguageClient: sinon.stub().returns(undefined),
+    } as unknown as ILanguageClientAdapter;
+
+    const service = new ConfigurationPersistenceService(
+      workspace,
+      configuration,
+      scopeDetectionService,
+      noClientAdapter,
+      logger,
+    );
+
+    const configJson = JSON.stringify({
+      isFallbackForm: true,
+      cli_path: '/usr/local/bin/snyk',
+    });
+
+    await service.handleSaveConfig(configJson);
+
+    sinon.assert.calledWith(
+      updateConfigurationStub,
+      CONFIGURATION_IDENTIFIER,
+      'advanced.cliPath',
+      '/usr/local/bin/snyk',
+      true,
+    );
+  });
+
   test('maps cli_release_channel LS key to VS Code setting', async () => {
     const service = new ConfigurationPersistenceService(
       workspace,
@@ -455,56 +486,6 @@ suite('ConfigurationPersistenceService — persistInbound trusts LS', () => {
       CONFIGURATION_IDENTIFIER,
       DELTA_FINDINGS.replace(`${CONFIGURATION_IDENTIFIER}.`, ''),
       NEWISSUES,
-      true,
-    );
-  });
-
-  test('persistInbound skips settings the LS reports with source "default" (no echo revert)', async () => {
-    const service = new ConfigurationPersistenceService(
-      workspace,
-      configuration,
-      scopeDetectionService,
-      clientAdapter,
-      logger,
-    );
-
-    // LS boots from a local binary and pushes a full snapshot. It never received the
-    // user's explicit `automaticDependencyManagement=false`, so it falls back to its
-    // built-in default (true) and reports it as source "default". This must NOT be
-    // persisted back over the user's choice.
-    const param: LspConfigurationParam = {
-      settings: {
-        [LS_KEY.automaticDownload]: { value: true, source: 'default', changed: false },
-      },
-    };
-
-    await service.persistInboundLspConfiguration(param);
-
-    sinon.assert.notCalled(updateConfigurationStub);
-  });
-
-  test('persistInbound persists settings with a non-default source', async () => {
-    const service = new ConfigurationPersistenceService(
-      workspace,
-      configuration,
-      scopeDetectionService,
-      clientAdapter,
-      logger,
-    );
-
-    const param: LspConfigurationParam = {
-      settings: {
-        [LS_KEY.automaticDownload]: { value: false, source: 'user-override' },
-      },
-    };
-
-    await service.persistInboundLspConfiguration(param);
-
-    sinon.assert.calledWith(
-      updateConfigurationStub,
-      CONFIGURATION_IDENTIFIER,
-      'advanced.automaticDependencyManagement',
-      false,
       true,
     );
   });

--- a/src/test/unit/common/views/workspaceConfiguration/services/configurationPersistenceService.test.ts
+++ b/src/test/unit/common/views/workspaceConfiguration/services/configurationPersistenceService.test.ts
@@ -459,6 +459,56 @@ suite('ConfigurationPersistenceService — persistInbound trusts LS', () => {
     );
   });
 
+  test('persistInbound skips settings the LS reports with source "default" (no echo revert)', async () => {
+    const service = new ConfigurationPersistenceService(
+      workspace,
+      configuration,
+      scopeDetectionService,
+      clientAdapter,
+      logger,
+    );
+
+    // LS boots from a local binary and pushes a full snapshot. It never received the
+    // user's explicit `automaticDependencyManagement=false`, so it falls back to its
+    // built-in default (true) and reports it as source "default". This must NOT be
+    // persisted back over the user's choice.
+    const param: LspConfigurationParam = {
+      settings: {
+        [LS_KEY.automaticDownload]: { value: true, source: 'default', changed: false },
+      },
+    };
+
+    await service.persistInboundLspConfiguration(param);
+
+    sinon.assert.notCalled(updateConfigurationStub);
+  });
+
+  test('persistInbound persists settings with a non-default source', async () => {
+    const service = new ConfigurationPersistenceService(
+      workspace,
+      configuration,
+      scopeDetectionService,
+      clientAdapter,
+      logger,
+    );
+
+    const param: LspConfigurationParam = {
+      settings: {
+        [LS_KEY.automaticDownload]: { value: false, source: 'user-override' },
+      },
+    };
+
+    await service.persistInboundLspConfiguration(param);
+
+    sinon.assert.calledWith(
+      updateConfigurationStub,
+      CONFIGURATION_IDENTIFIER,
+      'advanced.automaticDependencyManagement',
+      false,
+      true,
+    );
+  });
+
   test('persistInbound clears folder configs when LS sends empty array', async () => {
     const svc = new ConfigurationPersistenceService(
       workspace,

--- a/src/test/unit/mocks/languageServer.mock.ts
+++ b/src/test/unit/mocks/languageServer.mock.ts
@@ -6,6 +6,7 @@ import { ShowIssueDetailTopicParams, Scan } from '../../../snyk/common/languageS
 export class LanguageServerMock implements ILanguageServer {
   start = sinon.fake();
   stop = sinon.fake();
+  registerExplicitKeyMarkingListener = sinon.fake();
   showOutputChannel = sinon.fake();
   setWorkspaceConfigurationProvider = sinon.fake();
   setInboundConfigurationPersistenceHandler = sinon.fake();


### PR DESCRIPTION
### Description

Several fixes:

Config listener is now tied to the plugin lifecycle, not the LS lifecycle. This means that changes made when LS is not running do not get lost.

Improved version detection for debug CLI binaries, including improved logging (a few times when testing I ended up running a different binary than I was expecting and this made it easier to spot)

Fix crash when attempting to save config when LS was not running.

Manage Binaries Automatically and CLI path changes now trigger seamless LS restarts (no need to restart VSCode).

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/vscode-extension/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/vscode-extension/blob/main/CONTRIBUTING.md).
- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
