### PR TITLE
fix: keep tree view severity filters in sync with settings page

### DIFF
--- a/src/snyk/common/languageServer/languageServer.ts
+++ b/src/snyk/common/languageServer/languageServer.ts
@@ -317,6 +317,11 @@ export class LanguageServer implements ILanguageServer {
   private handleSnykConfigurationNotification(params: LspConfigurationParam): void {
     this.logger.debug('Received $/snyk.configuration notification');
     this.runInboundPersistence(params);
+    // Reflect inbound per-folder filter changes (e.g. from the tree-view toolbar)
+    // in an open settings window. The provider posts a message the webview applies
+    // to its filter controls only — silently, so it doesn't echo a change back
+    // (no loop) and preserves any other in-progress edits.
+    this.workspaceConfigurationProvider?.applyFilterUpdate(params.folderConfigs);
   }
 
   private runInboundPersistence(params: LspConfigurationParam): void {

--- a/src/snyk/common/languageServer/languageServer.ts
+++ b/src/snyk/common/languageServer/languageServer.ts
@@ -317,11 +317,11 @@ export class LanguageServer implements ILanguageServer {
   private handleSnykConfigurationNotification(params: LspConfigurationParam): void {
     this.logger.debug('Received $/snyk.configuration notification');
     this.runInboundPersistence(params);
-    // Reflect inbound per-folder filter changes (e.g. from the tree-view toolbar)
-    // in an open settings window. The provider posts a message the webview applies
-    // to its filter controls only — silently, so it doesn't echo a change back
-    // (no loop) and preserves any other in-progress edits.
-    this.workspaceConfigurationProvider?.applyFilterUpdate(params.folderConfigs);
+    // Reflect inbound per-folder config changes (e.g. filter/delta toggles from the tree-view
+    // toolbar) in an open settings window. The provider forwards the whole folderConfigs payload;
+    // the webview applies the relevant controls silently, so it doesn't echo a change back (no loop)
+    // and preserves any other in-progress edits.
+    this.workspaceConfigurationProvider?.applyInboundFolderConfig(params.folderConfigs);
   }
 
   private runInboundPersistence(params: LspConfigurationParam): void {

--- a/src/snyk/common/views/workspaceConfiguration/services/htmlInjectionService.ts
+++ b/src/snyk/common/views/workspaceConfiguration/services/htmlInjectionService.ts
@@ -52,10 +52,11 @@ export class HtmlInjectionService implements IHtmlInjectionService {
               if (typeof window.setAuthToken === 'function') {
                 window.setAuthToken(message.token, message.apiUrl);
               }
-            } else if (message.type === 'applyFilterSettings' && message.folderConfigs) {
-              // Filter values changed elsewhere (e.g. the tree-view toolbar). Apply
-              // them to the open form's per-folder controls without firing change
-              // events (no autosave, no feedback loop). See snyk-ls filter-sync.js.
+            } else if (message.type === 'applyInboundFolderConfig' && message.folderConfigs) {
+              // Per-folder config changed elsewhere (e.g. tree-view toolbar filter/delta toggles).
+              // Apply it to the open form's per-folder controls without firing change events (no
+              // autosave, no feedback loop). 'applyFilterSettings' is the LS-served apply function
+              // (snyk-ls template/js/features/filter-sync.js) — its name is owned by snyk-ls.
               if (typeof window.applyFilterSettings === 'function') {
                 window.applyFilterSettings(message.folderConfigs);
               }

--- a/src/snyk/common/views/workspaceConfiguration/services/htmlInjectionService.ts
+++ b/src/snyk/common/views/workspaceConfiguration/services/htmlInjectionService.ts
@@ -52,6 +52,13 @@ export class HtmlInjectionService implements IHtmlInjectionService {
               if (typeof window.setAuthToken === 'function') {
                 window.setAuthToken(message.token, message.apiUrl);
               }
+            } else if (message.type === 'applyFilterSettings' && message.folderConfigs) {
+              // Filter values changed elsewhere (e.g. the tree-view toolbar). Apply
+              // them to the open form's per-folder controls without firing change
+              // events (no autosave, no feedback loop). See snyk-ls filter-sync.js.
+              if (typeof window.applyFilterSettings === 'function') {
+                window.applyFilterSettings(message.folderConfigs);
+              }
             }
           });
         })();

--- a/src/snyk/common/views/workspaceConfiguration/types/workspaceConfiguration.types.ts
+++ b/src/snyk/common/views/workspaceConfiguration/types/workspaceConfiguration.types.ts
@@ -16,6 +16,9 @@ export interface IWorkspaceConfigurationWebviewProvider {
   showPanel(): Promise<void>;
   disposePanel(): void;
   setAuthToken(token: string, apiUrl?: string): void;
+  // Pushes per-folder filter values to an open settings webview so it reflects
+  // changes made elsewhere (e.g. the tree-view toolbar). No-op if not open.
+  applyFilterUpdate(folderConfigs: unknown): void;
 }
 
 export interface SaveConfigMessage {

--- a/src/snyk/common/views/workspaceConfiguration/types/workspaceConfiguration.types.ts
+++ b/src/snyk/common/views/workspaceConfiguration/types/workspaceConfiguration.types.ts
@@ -16,9 +16,10 @@ export interface IWorkspaceConfigurationWebviewProvider {
   showPanel(): Promise<void>;
   disposePanel(): void;
   setAuthToken(token: string, apiUrl?: string): void;
-  // Pushes per-folder filter values to an open settings webview so it reflects
-  // changes made elsewhere (e.g. the tree-view toolbar). No-op if not open.
-  applyFilterUpdate(folderConfigs: unknown): void;
+  // Pushes inbound per-folder config to an open settings webview so it reflects folder-scoped
+  // changes made elsewhere (e.g. tree-view toolbar filter/delta toggles). Field-agnostic: forwards
+  // the whole folderConfigs payload; the LS-served page decides what to apply. No-op if not open.
+  applyInboundFolderConfig(folderConfigs: unknown): void;
 }
 
 export interface SaveConfigMessage {

--- a/src/snyk/common/views/workspaceConfiguration/types/workspaceConfiguration.types.ts
+++ b/src/snyk/common/views/workspaceConfiguration/types/workspaceConfiguration.types.ts
@@ -1,4 +1,5 @@
 // ABOUTME: Type definitions for workspace configuration data structures
+import type { LspFolderConfiguration } from '../../../languageServer/types';
 
 /** Minimal shape for the JSON blob the HTML settings form posts via `saveConfig`. */
 export interface HtmlSettingsData extends Record<string, unknown> {
@@ -19,7 +20,7 @@ export interface IWorkspaceConfigurationWebviewProvider {
   // Pushes inbound per-folder config to an open settings webview so it reflects folder-scoped
   // changes made elsewhere (e.g. tree-view toolbar filter/delta toggles). Field-agnostic: forwards
   // the whole folderConfigs payload; the LS-served page decides what to apply. No-op if not open.
-  applyInboundFolderConfig(folderConfigs: unknown): void;
+  applyInboundFolderConfig(folderConfigs: LspFolderConfiguration[] | undefined): void;
 }
 
 export interface SaveConfigMessage {

--- a/src/snyk/common/views/workspaceConfiguration/workspaceConfigurationWebviewProvider.ts
+++ b/src/snyk/common/views/workspaceConfiguration/workspaceConfigurationWebviewProvider.ts
@@ -174,6 +174,21 @@ export class WorkspaceConfigurationWebviewProvider
     );
   }
 
+  // applyFilterUpdate pushes per-folder filter values (severity / issue view) to an
+  // open settings webview so it reflects changes made elsewhere (e.g. the tree-view
+  // toolbar) without being reopened. The webview applies them to its filter controls
+  // only, silently (no autosave / feedback loop) and preserves other in-progress
+  // edits. No-op when the panel isn't open. (IDE-1866)
+  public applyFilterUpdate(folderConfigs: unknown): void {
+    if (!this.panel) {
+      return;
+    }
+    void this.panel.webview.postMessage({
+      type: 'applyFilterSettings',
+      folderConfigs,
+    });
+  }
+
   public setAuthToken(token: string, apiUrl?: string): void {
     if (!this.panel) {
       this.logger.debug('Cannot set auth token: webview panel not initialized');

--- a/src/snyk/common/views/workspaceConfiguration/workspaceConfigurationWebviewProvider.ts
+++ b/src/snyk/common/views/workspaceConfiguration/workspaceConfigurationWebviewProvider.ts
@@ -174,17 +174,17 @@ export class WorkspaceConfigurationWebviewProvider
     );
   }
 
-  // applyFilterUpdate pushes per-folder filter values (severity / issue view) to an
-  // open settings webview so it reflects changes made elsewhere (e.g. the tree-view
-  // toolbar) without being reopened. The webview applies them to its filter controls
-  // only, silently (no autosave / feedback loop) and preserves other in-progress
-  // edits. No-op when the panel isn't open. (IDE-1866)
-  public applyFilterUpdate(folderConfigs: unknown): void {
+  // applyInboundFolderConfig pushes inbound per-folder config (e.g. severity / issue-view / delta
+  // filters changed via the tree-view toolbar) to an open settings webview so it reflects them
+  // without being reopened. Field-agnostic: it forwards the whole folderConfigs payload and the
+  // LS-served page applies the relevant controls silently (no autosave / feedback loop), preserving
+  // other in-progress edits. No-op when the panel isn't open. (IDE-1866)
+  public applyInboundFolderConfig(folderConfigs: unknown): void {
     if (!this.panel) {
       return;
     }
     void this.panel.webview.postMessage({
-      type: 'applyFilterSettings',
+      type: 'applyInboundFolderConfig',
       folderConfigs,
     });
   }

--- a/src/snyk/common/views/workspaceConfiguration/workspaceConfigurationWebviewProvider.ts
+++ b/src/snyk/common/views/workspaceConfiguration/workspaceConfigurationWebviewProvider.ts
@@ -16,6 +16,7 @@ import { IHtmlInjectionService } from './services/htmlInjectionService';
 import { IScopeDetectionService } from './services/scopeDetectionService';
 import { IMessageHandlerFactory } from './handlers/messageHandlerFactory';
 import { lsKeyToVscodeKey } from '../../languageServer/lsKeyToVscodeKeyMap';
+import type { LspFolderConfiguration } from '../../languageServer/types';
 const SNYK_VIEW_WORKSPACE_CONFIGURATION = 'snyk.views.workspaceConfiguration';
 const WORKSPACE_CONFIGURATION_PANEL_TITLE = 'Snyk Workspace Configuration';
 
@@ -179,7 +180,7 @@ export class WorkspaceConfigurationWebviewProvider
   // without being reopened. Field-agnostic: it forwards the whole folderConfigs payload and the
   // LS-served page applies the relevant controls silently (no autosave / feedback loop), preserving
   // other in-progress edits. No-op when the panel isn't open. (IDE-1866)
-  public applyInboundFolderConfig(folderConfigs: unknown): void {
+  public applyInboundFolderConfig(folderConfigs: LspFolderConfiguration[] | undefined): void {
     if (!this.panel) {
       return;
     }

--- a/src/test/unit/common/views/workspaceConfiguration/services/htmlInjectionService.test.ts
+++ b/src/test/unit/common/views/workspaceConfiguration/services/htmlInjectionService.test.ts
@@ -76,4 +76,17 @@ suite('HtmlInjectionService', () => {
       'Should guard setAuthToken call with typeof check to handle pages that have not yet defined it',
     );
   });
+
+  test('injectIdeScripts routes applyFilterSettings messages to window.applyFilterSettings', () => {
+    const processed = service.injectIdeScripts(sampleHtml);
+
+    ok(
+      processed.includes("message.type === 'applyFilterSettings'"),
+      'Should handle applyFilterSettings messages so tree-view filter changes refresh the open settings form',
+    );
+    ok(
+      processed.includes("typeof window.applyFilterSettings === 'function'"),
+      'Should guard applyFilterSettings call with typeof check',
+    );
+  });
 });

--- a/src/test/unit/common/views/workspaceConfiguration/services/htmlInjectionService.test.ts
+++ b/src/test/unit/common/views/workspaceConfiguration/services/htmlInjectionService.test.ts
@@ -77,16 +77,16 @@ suite('HtmlInjectionService', () => {
     );
   });
 
-  test('injectIdeScripts routes applyFilterSettings messages to window.applyFilterSettings', () => {
+  test('injectIdeScripts routes applyInboundFolderConfig messages to window.applyFilterSettings', () => {
     const processed = service.injectIdeScripts(sampleHtml);
 
     ok(
-      processed.includes("message.type === 'applyFilterSettings'"),
-      'Should handle applyFilterSettings messages so tree-view filter changes refresh the open settings form',
+      processed.includes("message.type === 'applyInboundFolderConfig'"),
+      'Should handle applyInboundFolderConfig messages so inbound per-folder config refreshes the open settings form',
     );
     ok(
       processed.includes("typeof window.applyFilterSettings === 'function'"),
-      'Should guard applyFilterSettings call with typeof check',
+      'Should guard the LS-served window.applyFilterSettings call with a typeof check',
     );
   });
 });


### PR DESCRIPTION
### Description

Plumbing to allow the settings page to reflect changes in the severity filters made in the HTML tree view.

Needs the LS changes from https://github.com/snyk/snyk-ls/pull/1316

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/vscode-extension/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/vscode-extension/blob/main/CONTRIBUTING.md).
- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_
