### PR TITLE
feat: seed explicit LS change tracker from pre-existing global settings [IDE-2067]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,23 @@ snyk.config.local.json
 # Local implementation plans (do not commit)
 *_implementation_plan/
 CLAUDE.md
+.commit-progress
+.verify-range
+.commit-reviewed
+.pr-review-*.md
+.verify-complete
+.verify-precommit-hash
+.verify-agents
+.verify-counts
+.verify-staged-hash
+*_????????_??????_*.log
+.verify-metrics-pending
+.verify-staged-diff
+.snyk-sca-output.json
+.snyk-sca-output.err
+.snyk-code-output.json
+.snyk-code-output.err
+.verification-result.*
+.verify-triage.json
+.verify-source-map.json
+.verify-agent-progress

--- a/src/snyk/common/languageServer/explicitLsKeyTracking.ts
+++ b/src/snyk/common/languageServer/explicitLsKeyTracking.ts
@@ -36,8 +36,10 @@ export function markExplicitLsKeysFromConfigurationChangeEvent(
  * - Skips `alwaysChanged` entries — they are always emitted with `changed: true`.
  * - Skips entries without a `vscodeKey` (LS-only keys such as `token`).
  * - Skips keys already present in the tracker (idempotent across activations).
- * - Skips when `inspectConfiguration` returns `undefined`, `globalValue` is `undefined`,
- *   or `defaultValue` is `undefined` (no baseline to compare against).
+ * - Skips when `inspectConfiguration` returns `undefined` or `globalValue` is `undefined`.
+ * - When `defaultValue` is `undefined` (the setting has no package.json `default:` —
+ *   e.g. organization, customEndpoint, cliPath, additionalParameters), a defined
+ *   `globalValue` is treated as an explicit change and seeded.
  * - Uses lodash `isEqual` for deep equality to compare `globalValue` with `defaultValue`.
  */
 export function seedExplicitChangesFromExistingSettings(
@@ -55,8 +57,8 @@ export function seedExplicitChangesFromExistingSettings(
     const { configurationId, section } = Configuration.getConfigName(entry.vscodeKey);
     const inspect = workspace.inspectConfiguration(configurationId, section);
 
-    // R4: only seed when both globalValue and defaultValue are defined and differ
-    if (inspect === undefined || inspect.globalValue === undefined || inspect.defaultValue === undefined) continue;
+    // R4: only seed when globalValue is defined and differs from the default (which may be undefined)
+    if (inspect === undefined || inspect.globalValue === undefined) continue;
     if (!isEqual(inspect.globalValue, inspect.defaultValue)) {
       tracker.markExplicitlyChanged(lsKey);
     }

--- a/src/snyk/common/languageServer/explicitLsKeyTracking.ts
+++ b/src/snyk/common/languageServer/explicitLsKeyTracking.ts
@@ -1,7 +1,10 @@
 import type { ConfigurationChangeEvent } from '../vscode/types';
-import { VSCODE_KEY_TO_LS_KEYS } from './lsKeyToVscodeKeyMap';
+import { SETTINGS_REGISTRY, VSCODE_KEY_TO_LS_KEYS } from './lsKeyToVscodeKeyMap';
 import type { IExplicitLspConfigurationChangeTracker } from './explicitLspConfigurationChangeTracker';
 import type { LspConfigSetting } from './types';
+import { Configuration } from '../configuration/configuration';
+import type { IVSCodeWorkspace } from '../vscode/workspace';
+import isEqual from 'lodash/isEqual';
 
 /**
  * When native VS Code configuration changes, mark matching LS keys so outbound
@@ -18,6 +21,44 @@ export function markExplicitLsKeysFromConfigurationChangeEvent(
       for (const lsKey of lsKeys) {
         tracker.markExplicitlyChanged(lsKey);
       }
+    }
+  }
+}
+
+/**
+ * Seeds the tracker with LS keys whose VS Code global setting value differs from
+ * the registered default.  Call once immediately after constructing the tracker
+ * so that pre-existing user customisations are honoured on the first
+ * `workspace/didChangeConfiguration` even if the user has never saved the
+ * settings form in the current session.
+ *
+ * Rules:
+ * - Skips `alwaysChanged` entries — they are always emitted with `changed: true`.
+ * - Skips entries without a `vscodeKey` (LS-only keys such as `token`).
+ * - Skips keys already present in the tracker (idempotent across activations).
+ * - Skips when `inspectConfiguration` returns `undefined`, `globalValue` is `undefined`,
+ *   or `defaultValue` is `undefined` (no baseline to compare against).
+ * - Uses lodash `isEqual` for deep equality to compare `globalValue` with `defaultValue`.
+ */
+export function seedExplicitChangesFromExistingSettings(
+  tracker: IExplicitLspConfigurationChangeTracker,
+  workspace: Pick<IVSCodeWorkspace, 'inspectConfiguration'>,
+): void {
+  for (const [lsKey, entry] of Object.entries(SETTINGS_REGISTRY)) {
+    // R3: skip alwaysChanged
+    if (entry.alwaysChanged) continue;
+    // R2: skip entries without a VS Code key
+    if (!entry.vscodeKey) continue;
+    // R5: idempotent — already tracked by this or a previous activation
+    if (tracker.isExplicitlyChanged(lsKey)) continue;
+
+    const { configurationId, section } = Configuration.getConfigName(entry.vscodeKey);
+    const inspect = workspace.inspectConfiguration(configurationId, section);
+
+    // R4: only seed when both globalValue and defaultValue are defined and differ
+    if (inspect === undefined || inspect.globalValue === undefined || inspect.defaultValue === undefined) continue;
+    if (!isEqual(inspect.globalValue, inspect.defaultValue)) {
+      tracker.markExplicitlyChanged(lsKey);
     }
   }
 }

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -47,6 +47,7 @@ import { ErrorHandler } from './common/error/errorHandler';
 import { TransientNetworkError, isNetworkConnectivityError } from './common/constants/errors';
 import { ExperimentService } from './common/experiment/services/experimentService';
 import { ExplicitLspConfigurationChangeTracker } from './common/languageServer/explicitLspConfigurationChangeTracker';
+import { seedExplicitChangesFromExistingSettings } from './common/languageServer/explicitLsKeyTracking';
 import { LanguageServer } from './common/languageServer/languageServer';
 import { StaticCliApi } from './cli/staticCliApi';
 import { Logger } from './common/logger/logger';
@@ -250,6 +251,7 @@ class SnykExtension extends SnykLib implements IExtension {
     }
 
     const explicitLspConfigurationChangeTracker = new ExplicitLspConfigurationChangeTracker(vscodeContext.globalState);
+    seedExplicitChangesFromExistingSettings(explicitLspConfigurationChangeTracker, vsCodeWorkspace);
 
     const scopeDetectionService = new ScopeDetectionService(vsCodeWorkspace);
     const configPersistenceService = new ConfigurationPersistenceService(

--- a/src/test/unit/common/languageServer/explicitLsKeyTracking.test.ts
+++ b/src/test/unit/common/languageServer/explicitLsKeyTracking.test.ts
@@ -238,8 +238,8 @@ suite('seedExplicitChangesFromExistingSettings', () => {
     assert.ok(tracker.isExplicitlyChanged(LS_GLOBAL_KEY.severityFilterLow), 'severityFilterLow seeded');
   });
 
-  // T_F2: defaultValue undefined → NOT seeded (no baseline to compare against)
-  test('T_F2: does not seed when defaultValue is undefined', () => {
+  // T_F2: defaultValue undefined but globalValue defined → IS seeded (defined globalValue is itself a deviation)
+  test('T_F2: seeds when defaultValue is undefined but the user set a global value', () => {
     const tracker = new FakeTracker();
     const ws = fakeWorkspace({
       snyk: {
@@ -250,8 +250,8 @@ suite('seedExplicitChangesFromExistingSettings', () => {
     seedExplicitChangesFromExistingSettings(tracker, ws);
 
     assert.ok(
-      !tracker.isExplicitlyChanged(LS_GLOBAL_KEY.organization),
-      'organization LS key should NOT be seeded when defaultValue is undefined',
+      tracker.isExplicitlyChanged(LS_GLOBAL_KEY.organization),
+      'organization LS key should be seeded when defaultValue is undefined but globalValue is defined',
     );
   });
 
@@ -303,6 +303,36 @@ suite('seedExplicitChangesFromExistingSettings', () => {
         lsParams.settings?.[LS_GLOBAL_KEY.apiEndpoint]?.changed,
         false,
         'apiEndpoint should be changed:false when not seeded',
+      );
+    });
+
+    // T10: no-default setting (defaultValue undefined) with user global value → changed:true via fromConfiguration
+    test('T10: no-default setting with user global value produces changed:true via fromConfiguration', async () => {
+      const tracker = new FakeTracker();
+
+      // organization has no package.json default (defaultValue: undefined); user set a global value.
+      const config: IConfiguration = {
+        ...minimalConfig,
+        organization: 'no-default-org',
+        snykApiEndpoint: 'https://api.snyk.io/api',
+      } as unknown as IConfiguration;
+
+      const ws = fakeWorkspace({
+        snyk: {
+          'advanced.organization': { globalValue: 'no-default-org', defaultValue: undefined },
+        },
+      });
+
+      seedExplicitChangesFromExistingSettings(tracker, ws);
+
+      const lsParams = await LanguageServerSettings.fromConfiguration(config, lsKey =>
+        tracker.isExplicitlyChanged(lsKey),
+      );
+
+      assert.strictEqual(
+        lsParams.settings?.[LS_GLOBAL_KEY.organization]?.changed,
+        true,
+        'organization should be changed:true when defaultValue is undefined but user set a global value',
       );
     });
   });

--- a/src/test/unit/common/languageServer/explicitLsKeyTracking.test.ts
+++ b/src/test/unit/common/languageServer/explicitLsKeyTracking.test.ts
@@ -1,0 +1,309 @@
+import assert from 'assert';
+import {
+  DEFAULT_ISSUE_VIEW_OPTIONS,
+  DEFAULT_RISK_SCORE_THRESHOLD,
+  DEFAULT_SEVERITY_FILTER,
+  FolderConfig,
+  IConfiguration,
+} from '../../../../snyk/common/configuration/configuration';
+import { IExplicitLspConfigurationChangeTracker } from '../../../../snyk/common/languageServer/explicitLspConfigurationChangeTracker';
+import { seedExplicitChangesFromExistingSettings } from '../../../../snyk/common/languageServer/explicitLsKeyTracking';
+import { LanguageServerSettings } from '../../../../snyk/common/languageServer/settings';
+import { LS_GLOBAL_KEY } from '../../../../snyk/common/languageServer/serverSettingsToLspConfigurationParam';
+import { IVSCodeWorkspace } from '../../../../snyk/common/vscode/workspace';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Minimal in-memory tracker that fulfils the interface. */
+class FakeTracker implements IExplicitLspConfigurationChangeTracker {
+  private readonly keys = new Set<string>();
+
+  markExplicitlyChanged(lsKey: string): void {
+    this.keys.add(lsKey);
+  }
+
+  unmarkExplicitlyChanged(lsKey: string): void {
+    this.keys.delete(lsKey);
+  }
+
+  isExplicitlyChanged(lsKey: string): boolean {
+    return this.keys.has(lsKey);
+  }
+
+  allKeys(): Set<string> {
+    return new Set(this.keys);
+  }
+}
+
+type InspectResult = { globalValue?: unknown; defaultValue?: unknown };
+
+/** Builds a fake IVSCodeWorkspace whose inspectConfiguration is driven by a lookup map. */
+function fakeWorkspace(
+  map: Record<string, Record<string, InspectResult | undefined>>,
+): Pick<IVSCodeWorkspace, 'inspectConfiguration'> {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    inspectConfiguration(configId: string, section: string): any {
+      return map[configId]?.[section];
+    },
+  };
+}
+
+/** A minimal IConfiguration stub sufficient for the seeding function (strategy a — resolve is not called). */
+const minimalConfig: IConfiguration = {
+  shouldReportErrors: false,
+  snykApiEndpoint: 'https://api.snyk.io/api',
+  organization: 'test-org',
+  // eslint-disable-next-line @typescript-eslint/require-await
+  getToken: async () => '',
+  getFeaturesConfiguration: () => ({
+    ossEnabled: true,
+    codeSecurityEnabled: true,
+    iacEnabled: true,
+    secretsEnabled: true,
+  }),
+  getCliPath: () => '/path/to/cli',
+  getCliBaseDownloadUrl: () => 'https://downloads.snyk.io',
+  getAdditionalCliParameters: () => '',
+  getTrustedFolders: () => [],
+  getInsecure: () => false,
+  getDeltaFindingsEnabled: () => false,
+  isAutomaticDependencyManagementEnabled: () => true,
+  getFolderConfigs: () => [] as FolderConfig[],
+  getOssQuickFixCodeActionsEnabled: () => true,
+  getAuthenticationMethod: () => 'oauth',
+  severityFilter: DEFAULT_SEVERITY_FILTER,
+  riskScoreThreshold: DEFAULT_RISK_SCORE_THRESHOLD,
+  issueViewOptions: DEFAULT_ISSUE_VIEW_OPTIONS,
+  scanningMode: 'auto',
+  getSecureAtInceptionExecutionFrequency: () => 'Manual',
+  getAutoConfigureMcpServer: () => false,
+} as unknown as IConfiguration;
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+suite('seedExplicitChangesFromExistingSettings', () => {
+  // T1: global value differs from default → LS key seeded
+  test('T1: seeds LS key when global value differs from default', () => {
+    const tracker = new FakeTracker();
+    // organization: ADVANCED_ORGANIZATION = 'snyk.advanced.organization'
+    // → configId: 'snyk', section: 'advanced.organization'
+    const ws = fakeWorkspace({
+      snyk: {
+        'advanced.organization': { globalValue: 'acme-corp', defaultValue: '' },
+      },
+    });
+
+    seedExplicitChangesFromExistingSettings(tracker, ws);
+
+    assert.ok(
+      tracker.isExplicitlyChanged(LS_GLOBAL_KEY.organization),
+      'organization LS key should be seeded when globalValue differs from default',
+    );
+  });
+
+  // T2: global value equals default → NOT seeded
+  test('T2: does not seed when global value equals default', () => {
+    const tracker = new FakeTracker();
+    const ws = fakeWorkspace({
+      snyk: {
+        'advanced.organization': { globalValue: '', defaultValue: '' },
+      },
+    });
+
+    seedExplicitChangesFromExistingSettings(tracker, ws);
+
+    assert.ok(
+      !tracker.isExplicitlyChanged(LS_GLOBAL_KEY.organization),
+      'organization LS key should NOT be seeded when globalValue equals default',
+    );
+  });
+
+  // T3: globalValue undefined → NOT seeded
+  test('T3: does not seed when globalValue is undefined', () => {
+    const tracker = new FakeTracker();
+    const ws = fakeWorkspace({
+      snyk: {
+        'advanced.organization': { globalValue: undefined, defaultValue: '' },
+      },
+    });
+
+    seedExplicitChangesFromExistingSettings(tracker, ws);
+
+    assert.ok(
+      !tracker.isExplicitlyChanged(LS_GLOBAL_KEY.organization),
+      'organization LS key should NOT be seeded when globalValue is undefined',
+    );
+  });
+
+  // T4: alwaysChanged entry → never seeded regardless of inspected value
+  test('T4: never seeds alwaysChanged entries', () => {
+    const tracker = new FakeTracker();
+    // Even if inspect would match, alwaysChanged keys must be skipped.
+    // trustEnabled, automaticAuthentication, hoverVerbosity, trustedFolders are alwaysChanged.
+    const ws = fakeWorkspace({
+      snyk: {
+        // trustedFolders has alwaysChanged AND vscodeKey — provide a differing value to make clear
+        // the alwaysChanged guard fires first.
+        trustedFolders: { globalValue: ['/my/folder'], defaultValue: [] },
+      },
+    });
+
+    seedExplicitChangesFromExistingSettings(tracker, ws);
+
+    assert.ok(
+      !tracker.isExplicitlyChanged(LS_GLOBAL_KEY.trustedFolders),
+      'trustedFolders (alwaysChanged) should never be seeded',
+    );
+    assert.ok(
+      !tracker.isExplicitlyChanged(LS_GLOBAL_KEY.trustEnabled),
+      'trustEnabled (alwaysChanged) should never be seeded',
+    );
+    assert.ok(
+      !tracker.isExplicitlyChanged(LS_GLOBAL_KEY.automaticAuthentication),
+      'automaticAuthentication (alwaysChanged) should never be seeded',
+    );
+    assert.ok(
+      !tracker.isExplicitlyChanged(LS_GLOBAL_KEY.hoverVerbosity),
+      'hoverVerbosity (alwaysChanged) should never be seeded',
+    );
+  });
+
+  // T5: entry without vscodeKey → skipped
+  test('T5: skips entries without vscodeKey (LS-only settings)', () => {
+    const tracker = new FakeTracker();
+    // token, sendErrorReports, enableSnykOssQuickFixActions have no vscodeKey.
+    // Provide an empty workspace — if the seed incorrectly tries to inspect them it may throw or mark.
+    const ws = fakeWorkspace({});
+
+    seedExplicitChangesFromExistingSettings(tracker, ws);
+
+    assert.ok(!tracker.isExplicitlyChanged(LS_GLOBAL_KEY.token), 'token (no vscodeKey) should never be seeded');
+    assert.ok(
+      !tracker.isExplicitlyChanged(LS_GLOBAL_KEY.sendErrorReports),
+      'sendErrorReports (no vscodeKey) should never be seeded',
+    );
+    assert.ok(
+      !tracker.isExplicitlyChanged(LS_GLOBAL_KEY.enableSnykOssQuickFixActions),
+      'enableSnykOssQuickFixActions (no vscodeKey) should never be seeded',
+    );
+  });
+
+  // T6: key already in tracker → idempotent; inspect not re-evaluated
+  test('T6: is idempotent — does not re-evaluate keys already in tracker', () => {
+    const tracker = new FakeTracker();
+    // Pre-seed organization
+    tracker.markExplicitlyChanged(LS_GLOBAL_KEY.organization);
+
+    let inspectCallCount = 0;
+    const ws: Pick<IVSCodeWorkspace, 'inspectConfiguration'> = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      inspectConfiguration(configId: string, section: string): any {
+        if (configId === 'snyk' && section === 'advanced.organization') {
+          inspectCallCount++;
+        }
+        return undefined;
+      },
+    };
+
+    seedExplicitChangesFromExistingSettings(tracker, ws);
+
+    assert.strictEqual(
+      inspectCallCount,
+      0,
+      'inspectConfiguration should not be called for keys already in the tracker',
+    );
+    assert.ok(tracker.isExplicitlyChanged(LS_GLOBAL_KEY.organization), 'organization should still be in tracker');
+  });
+
+  // T7: shared vscodeKey (severity filter object customised) → all 4 severity LS keys seeded
+  test('T7: seeds all severity LS keys when the shared severity vscodeKey object differs from default', () => {
+    const tracker = new FakeTracker();
+    // SEVERITY_FILTER_SETTING = 'snyk.severity' → configId: 'snyk', section: 'severity'
+    // User customised — object differs from default.
+    const ws = fakeWorkspace({
+      snyk: {
+        severity: {
+          globalValue: { critical: true, high: true, medium: false, low: false },
+          defaultValue: { critical: true, high: true, medium: true, low: true },
+        },
+      },
+    });
+
+    seedExplicitChangesFromExistingSettings(tracker, ws);
+
+    assert.ok(tracker.isExplicitlyChanged(LS_GLOBAL_KEY.severityFilterCritical), 'severityFilterCritical seeded');
+    assert.ok(tracker.isExplicitlyChanged(LS_GLOBAL_KEY.severityFilterHigh), 'severityFilterHigh seeded');
+    assert.ok(tracker.isExplicitlyChanged(LS_GLOBAL_KEY.severityFilterMedium), 'severityFilterMedium seeded');
+    assert.ok(tracker.isExplicitlyChanged(LS_GLOBAL_KEY.severityFilterLow), 'severityFilterLow seeded');
+  });
+
+  // T_F2: defaultValue undefined → NOT seeded (no baseline to compare against)
+  test('T_F2: does not seed when defaultValue is undefined', () => {
+    const tracker = new FakeTracker();
+    const ws = fakeWorkspace({
+      snyk: {
+        'advanced.organization': { globalValue: 'custom-value', defaultValue: undefined },
+      },
+    });
+
+    seedExplicitChangesFromExistingSettings(tracker, ws);
+
+    assert.ok(
+      !tracker.isExplicitlyChanged(LS_GLOBAL_KEY.organization),
+      'organization LS key should NOT be seeded when defaultValue is undefined',
+    );
+  });
+
+  // T8: inspectConfiguration returns undefined → skip without throwing
+  test('T8: does not throw when inspectConfiguration returns undefined', () => {
+    const tracker = new FakeTracker();
+    // All inspections return undefined
+    const ws = fakeWorkspace({});
+
+    assert.doesNotThrow(() => {
+      seedExplicitChangesFromExistingSettings(tracker, ws);
+    }, 'seedExplicitChangesFromExistingSettings must not throw when inspect returns undefined');
+  });
+
+  // ── Integration-style suite (CP2) ─────────────────────────────────────────
+
+  suite('integration: seeded org produces changed:true via LanguageServerSettings.fromConfiguration', () => {
+    // T9: seeded org/endpoint → changed:true; untouched setting → changed:false
+    test('T9: seeded org produces changed:true; untouched api endpoint produces changed:false', async () => {
+      const tracker = new FakeTracker();
+
+      // Build a config with a custom org and default-like endpoint.
+      const config: IConfiguration = {
+        ...minimalConfig,
+        organization: 'my-company',
+        snykApiEndpoint: 'https://api.snyk.io/api',
+      } as unknown as IConfiguration;
+
+      // Workspace reports org as customised, endpoint as default (undefined globalValue).
+      const ws = fakeWorkspace({
+        snyk: {
+          'advanced.organization': { globalValue: 'my-company', defaultValue: '' },
+          'advanced.customEndpoint': { globalValue: undefined, defaultValue: '' },
+        },
+      });
+
+      seedExplicitChangesFromExistingSettings(tracker, ws);
+
+      const lsParams = await LanguageServerSettings.fromConfiguration(config, lsKey =>
+        tracker.isExplicitlyChanged(lsKey),
+      );
+
+      assert.strictEqual(
+        lsParams.settings?.[LS_GLOBAL_KEY.organization]?.changed,
+        true,
+        'organization should be changed:true after seeding',
+      );
+      assert.strictEqual(
+        lsParams.settings?.[LS_GLOBAL_KEY.apiEndpoint]?.changed,
+        false,
+        'apiEndpoint should be changed:false when not seeded',
+      );
+    });
+  });
+});


### PR DESCRIPTION
### **User description**
## Summary

- Add `seedExplicitChangesFromExistingSettings()` to `explicitLsKeyTracking.ts` — runs once after tracker construction, inspects each `SETTINGS_REGISTRY` entry, and marks any key whose VS Code global value differs from its registered default as explicitly changed
- Fixes: on fresh install/upgrade `ExplicitLspConfigurationChangeTracker` is empty, so all non-`alwaysChanged` settings go out with `changed:false` on first `workspace/didChangeConfiguration`, causing the LS to silently ignore pre-existing user-customised values
- Uses lodash `isEqual` for deep equality; guards `globalValue === undefined || defaultValue === undefined` to avoid false positives; idempotent across activations
- Mirrors the fix applied to the Eclipse plugin (PR #395)

## Test plan

- [ ] `npm run test:unit` — 273 passing (10 new: T1–T9 + T_F2 covering all guard rules)
- [ ] Manual T10: fresh-install with customised global endpoint → first `didChangeConfiguration` honoured by LS
- [ ] CI green


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Seed tracker with pre-existing user settings.

- Fixes lost customizations on fresh installs.

- Handles various configuration scenarios and edge cases.

- Includes comprehensive unit tests for seeding logic.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Extension Initialization] --> B(Create Tracker);
  B --> C{Seed Tracker with User Settings};
  C --> D[LS Processes Config];
  C -- Handles: alwaysChanged, no default, diffs --> C;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>explicitLsKeyTracking.ts</strong><dd><code>Add function to seed explicit LS change tracker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/snyk/common/languageServer/explicitLsKeyTracking.ts

<ul><li>Introduces <code>seedExplicitChangesFromExistingSettings</code> function.<br> <li> Iterates through <code>SETTINGS_REGISTRY</code> to inspect VS Code global settings.<br> <li> Seeds the <code>ExplicitLspConfigurationChangeTracker</code> if global settings <br>differ from defaults.<br> <li> Handles edge cases like <code>alwaysChanged</code> entries and settings without a <br>default value.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/vscode-extension/pull/763/changes#diff-4cbfc77e3e72d54d8d09f0fbb372b573fc07b00acf1ee2320ea3dcf21ed0b917">+44/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>extension.ts</strong><dd><code>Integrate seeding logic into extension initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/snyk/extension.ts

<ul><li>Imports the new <code>seedExplicitChangesFromExistingSettings</code> function.<br> <li> Calls <code>seedExplicitChangesFromExistingSettings</code> after initializing the <br><code>ExplicitLspConfigurationChangeTracker</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/vscode-extension/pull/763/changes#diff-cd593458f6d172e17fb40ceb7782e58f1ab4c804e40abcd54a2b3f236a020722">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>explicitLsKeyTracking.test.ts</strong><dd><code>Add unit tests for explicit LS change tracker seeding</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/unit/common/languageServer/explicitLsKeyTracking.test.ts

<ul><li>Adds a comprehensive unit test suite for <br><code>seedExplicitChangesFromExistingSettings</code>.<br> <li> Includes tests for various scenarios: differing global values, equal <br>values, undefined values, <code>alwaysChanged</code> entries, and no <code>vscodeKey</code> <br>entries.<br> <li> Tests idempotency and deep equality checks.<br> <li> Includes integration-style tests to verify seeded changes reflect in <br><code>LanguageServerSettings.fromConfiguration</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/vscode-extension/pull/763/changes#diff-ba06d306c9345438406299aad8e7e6feec4eee814b1764fcce4939994c26f669">+339/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

