### PR TITLE
fix: wire Restart button to actually restart the language server

### DIFF
--- a/package.json
+++ b/package.json
@@ -462,7 +462,7 @@
     "viewsWelcome": [
       {
         "view": "snyk.views.welcome",
-        "contents": "Snyk has encountered a problem. Please restart the extension: \n[Restart](command:snyk.start 'Restart Snyk')\nIf the error persists, please check your [settings](command:snyk.settings) and [contact us](https://snyk.io/contact-us/?utm_source=vsc).\n\n You can check the logs to see the exact error in [Snyk Security](command:snyk.showOutputChannel) and [Snyk Language Server](command:snyk.showLsOutputChannel) output channels.\n[Display Error](command:snyk.showErrorFromContext)\n",
+        "contents": "Snyk has encountered a problem. Please restart the extension: \n[Restart](command:snyk.restart 'Restart Snyk')\nIf the error persists, please check your [settings](command:snyk.settings) and [contact us](https://snyk.io/contact-us/?utm_source=vsc).\n\n You can check the logs to see the exact error in [Snyk Security](command:snyk.showOutputChannel) and [Snyk Language Server](command:snyk.showLsOutputChannel) output channels.\n[Display Error](command:snyk.showErrorFromContext)\n",
         "when": "snyk:error"
       },
       {
@@ -529,6 +529,11 @@
         "title": "Rescan",
         "category": "Snyk",
         "icon": "$(run)"
+      },
+      {
+        "command": "snyk.restart",
+        "title": "Restart Snyk Language Server",
+        "category": "Snyk"
       },
       {
         "command": "snyk.settings",

--- a/src/snyk/common/constants/commands.ts
+++ b/src/snyk/common/constants/commands.ts
@@ -5,6 +5,7 @@ export const VSCODE_ADD_COMMENT_COMMAND = 'editor.action.addCommentLine';
 
 // custom Snyk commands
 export const SNYK_START_COMMAND = 'snyk.start';
+export const SNYK_RESTART_COMMAND = 'snyk.restart';
 export const SNYK_INITIATE_LOGIN_COMMAND = 'snyk.initiateLogin';
 export const SNYK_INITIATE_LOGOUT_COMMAND = 'snyk.initiateLogout';
 export const SNYK_SET_TOKEN_COMMAND = 'snyk.setToken';

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -29,6 +29,7 @@ import {
   SNYK_SHOW_LS_OUTPUT_COMMAND,
   SNYK_SHOW_OUTPUT_COMMAND,
   SNYK_START_COMMAND,
+  SNYK_RESTART_COMMAND,
   SNYK_TOGGLE_DELTA,
   SNYK_WORKSPACE_SCAN_COMMAND,
 } from './common/constants/commands';
@@ -727,6 +728,9 @@ class SnykExtension extends SnykLib implements IExtension {
       vscode.commands.registerCommand(SNYK_START_COMMAND, async () => {
         await vscode.commands.executeCommand(SNYK_WORKSPACE_SCAN_COMMAND);
         await vscode.commands.executeCommand('setContext', 'scanSummaryHtml', 'scanSummary');
+      }),
+      vscode.commands.registerCommand(SNYK_RESTART_COMMAND, async () => {
+        await this.restartLanguageServer();
       }),
       vscode.commands.registerCommand(SNYK_SETTINGS_COMMAND, async () => {
         await this.workspaceConfigurationProvider?.showPanel();


### PR DESCRIPTION
## Summary
- Restart button in the error panel was calling `snyk.start` which only triggers a workspace scan
- Added dedicated `snyk.restart` command that stops and restarts the language server
- Updated the error panel `viewsWelcome` entry in `package.json` to use `snyk.restart`

## Test plan
- [ ] Trigger the error state (`snyk:error` context key set) so the Restart button appears
- [ ] Click Restart — verify the language server stops and restarts (check Snyk Language Server output channel)
- [ ] Verify `snyk.start` (Rescan toolbar button) still works as before