### PR TITLE
chore: remove dead CHANGELOG references from PR template and RELEASE

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,6 @@ _Provide description of this PR and changes, if linked Jira ticket doesn't cover
 - [ ] Read and understood the [Code of Conduct](https://github.com/snyk/vscode-extension/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/vscode-extension/blob/main/CONTRIBUTING.md).
 - [ ] Tests added and all succeed
 - [ ] Linted
-- [ ] CHANGELOG.md updated
 - [ ] README.md updated, if user-facing
 
 ### Screenshots / GIFs

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,7 @@
 
 - Trigger or wait for the preview release workflow to build a preview version on the commit that will be used for the release.
   - The preview release workflow runs automatically on pushes to main.
-- Install the preview version from the marketplace and verify that the changes listed in the changelog are present and working correctly.
+- Install the preview version from the marketplace and verify that the changes for this release are present and working correctly.
 
 **Initiate Release**
 


### PR DESCRIPTION
## Description

CHANGELOG.md is no longer hand-maintained: release workflows generate notes via `gh release create --generate-notes`. This removes the dead CHANGELOG references from the PR template and release docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)