### PR TITLE
fix: use the default cli download url if the configured value is null, empty, blank or not a string [IDE-2245]

### DIFF
--- a/src/snyk/common/configuration/configuration.ts
+++ b/src/snyk/common/configuration/configuration.ts
@@ -388,7 +388,10 @@ export class Configuration implements IConfiguration {
 
   getCliBaseDownloadUrl(): string {
     const { configurationId, section } = Configuration.getConfigName(ADVANCED_CLI_BASE_DOWNLOAD_URL);
-    return this.workspace.getConfiguration<string>(configurationId, section) ?? this.defaultCliBaseDownloadUrl;
+    // If the configured CLI Base Download URL is null, empty, or not a string, use the default.
+    const raw = this.workspace.getConfiguration<string>(configurationId, section);
+    const value = typeof raw === 'string' ? raw.trim() : undefined;
+    return value ? value : this.defaultCliBaseDownloadUrl;
   }
 
   getOssQuickFixCodeActionsEnabled(): boolean {

--- a/src/snyk/common/languageServer/lsKeyToVscodeKeyMap.ts
+++ b/src/snyk/common/languageServer/lsKeyToVscodeKeyMap.ts
@@ -315,10 +315,12 @@ export function mapConfigToSettings(config: HtmlSettingsData): Record<string, un
  * Maps inbound LS global settings directly to VS Code settings.
  * Entries without a vscodeKey (token, sendErrorReports, etc.) are skipped.
  *
- * The LS is the source of truth: every reported value is persisted. The IDE keeps the
- * LS's view authoritative by sending user overrides as `changed: true` (tracked from
- * activation onward, even while the LS is down), so the LS resolves and echoes the
- * user's value rather than its own default.
+ * The LS is the source of truth: every reported value is persisted, except null/undefined
+ * (nothing to write) and blank strings for keys marked `skipBlankInbound` (where blank has no
+ * valid meaning). The IDE keeps the LS's view authoritative by sending user overrides as
+ * `changed: true`. Because those overrides are tracked via VS Code configuration events and
+ * persisted in the extension's global state — independently of the LS process — edits made
+ * while the LS is down are still captured and flagged on the next push.
  */
 export function mapLspSettingsToVscodeSettings(
   globalSettings: Record<string, LspConfigSetting>,

--- a/src/snyk/common/languageServer/lsKeyToVscodeKeyMap.ts
+++ b/src/snyk/common/languageServer/lsKeyToVscodeKeyMap.ts
@@ -42,6 +42,8 @@ interface SettingsEntry {
   alwaysChanged?: true;
   /** Included in fallback  */
   useInFallbackForm?: true;
+  /** Skip empty or whitespace-only values for string fields where blank has no valid meaning. */
+  skipBlankInbound?: true;
 }
 
 const AUTH_METHOD_MAP: Record<string, string> = {
@@ -123,6 +125,7 @@ export const SETTINGS_REGISTRY: Record<GlobalLsKeyValue, SettingsEntry> = {
     vscodeKey: ADVANCED_CLI_BASE_DOWNLOAD_URL,
     resolve: c => c.getCliBaseDownloadUrl(),
     useInFallbackForm: true,
+    skipBlankInbound: true,
   },
   [LS_GLOBAL_KEY.cliPath]: {
     vscodeKey: ADVANCED_CLI_PATH,
@@ -327,6 +330,8 @@ export function mapLspSettingsToVscodeSettings(
 
     const value = globalSettings[lsKey]?.value;
     if (value === undefined || value === null) continue;
+    // Skip empty or whitespace-only values for string fields where blank has no valid meaning.
+    if (entry.skipBlankInbound && typeof value === 'string' && value.trim() === '') continue;
 
     setOrMerge(result, entry.vscodeKey, entry.toVscodeValue ? entry.toVscodeValue(value) : value);
   }

--- a/src/test/unit/common/configuration.test.ts
+++ b/src/test/unit/common/configuration.test.ts
@@ -10,6 +10,7 @@ import {
 import { LS_KEY } from '../../../snyk/common/languageServer/serverSettingsToLspConfigurationParam';
 import { IVSCodeWorkspace } from '../../../snyk/common/vscode/workspace';
 import {
+  ADVANCED_CLI_BASE_DOWNLOAD_URL,
   ADVANCED_CLI_PATH,
   ADVANCED_CLI_RELEASE_CHANNEL,
   ADVANCED_CUSTOM_ENDPOINT,
@@ -72,6 +73,51 @@ suite('Configuration', () => {
     const configuration = new Configuration({}, workspace);
 
     strictEqual(configuration.snykApiEndpoint, customEndpoint);
+  });
+
+  test('CLI base download URL: returns default when unset', () => {
+    const workspace = stubWorkspaceConfiguration(ADVANCED_CLI_BASE_DOWNLOAD_URL, undefined);
+
+    const configuration = new Configuration({}, workspace);
+
+    strictEqual(configuration.getCliBaseDownloadUrl(), 'https://downloads.snyk.io');
+  });
+
+  test('CLI base download URL: returns custom URL when set', () => {
+    const customUrl = 'https://custom.downloads.example.com';
+    const workspace = stubWorkspaceConfiguration(ADVANCED_CLI_BASE_DOWNLOAD_URL, customUrl);
+
+    const configuration = new Configuration({}, workspace);
+
+    strictEqual(configuration.getCliBaseDownloadUrl(), customUrl);
+  });
+
+  test('CLI base download URL: falls back to default when persisted blank', () => {
+    // A blank value (e.g. written by an inbound LS config echo) would otherwise produce
+    // hostless URLs like `/cli/stable/...` and break the CLI download. `??` does not rescue it.
+    const workspace = stubWorkspaceConfiguration(ADVANCED_CLI_BASE_DOWNLOAD_URL, '');
+
+    const configuration = new Configuration({}, workspace);
+
+    strictEqual(configuration.getCliBaseDownloadUrl(), 'https://downloads.snyk.io');
+  });
+
+  test('CLI base download URL: falls back to default when persisted whitespace', () => {
+    const workspace = stubWorkspaceConfiguration(ADVANCED_CLI_BASE_DOWNLOAD_URL, '   ');
+
+    const configuration = new Configuration({}, workspace);
+
+    strictEqual(configuration.getCliBaseDownloadUrl(), 'https://downloads.snyk.io');
+  });
+
+  test('CLI base download URL: falls back to default when persisted value is not a string', () => {
+    // Guards a hand-edited/malformed settings.json — trimming a non-string must not throw on the
+    // CLI-download path.
+    const workspace = stubWorkspaceConfiguration<unknown>(ADVANCED_CLI_BASE_DOWNLOAD_URL, 42);
+
+    const configuration = new Configuration({}, workspace);
+
+    strictEqual(configuration.getCliBaseDownloadUrl(), 'https://downloads.snyk.io');
   });
 
   test('Preview features: not enabled', () => {

--- a/src/test/unit/common/languageServer/lsKeyToVscodeKeyMap.test.ts
+++ b/src/test/unit/common/languageServer/lsKeyToVscodeKeyMap.test.ts
@@ -1,6 +1,12 @@
 // ABOUTME: Unit tests for lsKeyToVscodeKeyMap — registry invariants and drift guards
 import assert from 'assert';
-import { GLOBAL_RESET_FIELDS, lsKeyToVscodeKey } from '../../../../snyk/common/languageServer/lsKeyToVscodeKeyMap';
+import {
+  GLOBAL_RESET_FIELDS,
+  lsKeyToVscodeKey,
+  mapLspSettingsToVscodeSettings,
+} from '../../../../snyk/common/languageServer/lsKeyToVscodeKeyMap';
+import { ADVANCED_CLI_BASE_DOWNLOAD_URL, ADVANCED_CLI_PATH } from '../../../../snyk/common/constants/settings';
+import { LS_GLOBAL_KEY } from '../../../../snyk/common/languageServer/serverSettingsToLspConfigurationParam';
 
 // ── Fix 1: GLOBAL_RESET_FIELDS drift guard ──────────────────────────────────
 //
@@ -23,5 +29,45 @@ suite('GLOBAL_RESET_FIELDS — drift guard (lsKeyToVscodeKeyMap)', () => {
           `Either add a vscodeKey entry for '${lsKey}' in SETTINGS_REGISTRY or remove it from GLOBAL_RESET_FIELDS.`,
       );
     }
+  });
+});
+
+// ── Inbound blank-value guard (skipBlankInbound) ────────────────────────────
+//
+// The LS occasionally echoes a blank binary_base_url. Persisting a blank to
+// snyk.advanced.cliBaseDownloadUrl corrupts the setting: downstream URL assembly
+// (staticCliApi) concatenates it into hostless paths like `/cli/stable/...`, the
+// CLI download fails, and the Language Server never starts. mapLspSettingsToVscodeSettings
+// must skip blank values for keys marked skipBlankInbound, mirroring the outbound
+// guard in Configuration.setCliBaseDownloadUrl.
+suite('mapLspSettingsToVscodeSettings — blank binary_base_url guard', () => {
+  test('skips a blank binary_base_url (does not persist it)', () => {
+    const result = mapLspSettingsToVscodeSettings({ [LS_GLOBAL_KEY.binaryBaseUrl]: { value: '' } });
+    assert.ok(
+      !(ADVANCED_CLI_BASE_DOWNLOAD_URL in result),
+      'blank binary_base_url must not be written to VS Code settings',
+    );
+  });
+
+  test('skips a whitespace-only binary_base_url', () => {
+    const result = mapLspSettingsToVscodeSettings({ [LS_GLOBAL_KEY.binaryBaseUrl]: { value: '   ' } });
+    assert.ok(
+      !(ADVANCED_CLI_BASE_DOWNLOAD_URL in result),
+      'whitespace-only binary_base_url must not be written to VS Code settings',
+    );
+  });
+
+  test('writes a non-blank binary_base_url', () => {
+    const url = 'https://downloads.snyk.io';
+    const result = mapLspSettingsToVscodeSettings({ [LS_GLOBAL_KEY.binaryBaseUrl]: { value: url } });
+    assert.strictEqual(result[ADVANCED_CLI_BASE_DOWNLOAD_URL], url);
+  });
+
+  // Scope guard: the blank-skip must apply ONLY to skipBlankInbound-flagged keys. cli_path is not
+  // flagged — a blank cli_path is a meaningful "use the managed binary", so it must still be
+  // written. This locks the deliberate scoping so a future refactor cannot globalize the skip.
+  test('does NOT skip a blank cli_path (only skipBlankInbound keys are guarded)', () => {
+    const result = mapLspSettingsToVscodeSettings({ [LS_GLOBAL_KEY.cliPath]: { value: '' } });
+    assert.strictEqual(result[ADVANCED_CLI_PATH], '');
   });
 });

--- a/src/test/unit/common/languageServer/lsKeyToVscodeKeyMap.test.ts
+++ b/src/test/unit/common/languageServer/lsKeyToVscodeKeyMap.test.ts
@@ -38,8 +38,9 @@ suite('GLOBAL_RESET_FIELDS — drift guard (lsKeyToVscodeKeyMap)', () => {
 // snyk.advanced.cliBaseDownloadUrl corrupts the setting: downstream URL assembly
 // (staticCliApi) concatenates it into hostless paths like `/cli/stable/...`, the
 // CLI download fails, and the Language Server never starts. mapLspSettingsToVscodeSettings
-// must skip blank values for keys marked skipBlankInbound, mirroring the outbound
-// guard in Configuration.setCliBaseDownloadUrl.
+// must skip blank values for keys marked skipBlankInbound. This complements the outbound
+// guard in Configuration.setCliBaseDownloadUrl (which rejects empty strings); the inbound
+// guard is stricter — it also treats whitespace-only as blank.
 suite('mapLspSettingsToVscodeSettings — blank binary_base_url guard', () => {
   test('skips a blank binary_base_url (does not persist it)', () => {
     const result = mapLspSettingsToVscodeSettings({ [LS_GLOBAL_KEY.binaryBaseUrl]: { value: '' } });


### PR DESCRIPTION
### **User description**
### Description

_Provide description of this PR and changes, if linked Jira ticket doesn't cover it in full._

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/vscode-extension/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/vscode-extension/blob/main/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Robustly handle invalid CLI download URL configs.

- Skip blank inbound CLI download URL settings.

- Add comprehensive unit tests for configuration handling.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.ts</strong><dd><code>Improve CLI base download URL configuration handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/snyk/common/configuration/configuration.ts

<ul><li>Modified <code>getCliBaseDownloadUrl</code> to handle null, empty, or non-string <br>values.<br> <li> Trims whitespace from the configuration value.<br> <li> Falls back to the default download URL if the configured value is <br>invalid.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/vscode-extension/pull/779/changes#diff-ea516e6da03ef31b513852a7029ea1873e6672eab75b939bc6465f90dc24c69f">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lsKeyToVscodeKeyMap.ts</strong><dd><code>Add inbound skipping for blank CLI download URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/snyk/common/languageServer/lsKeyToVscodeKeyMap.ts

<ul><li>Introduced <code>skipBlankInbound</code> flag for <code>SettingsEntry</code>.<br> <li> Applied <code>skipBlankInbound</code> to <code>LS_GLOBAL_KEY.binaryBaseUrl</code>.<br> <li> Updated <code>mapLspSettingsToVscodeSettings</code> to skip persisting blank or <br>whitespace-only values for flagged settings.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/vscode-extension/pull/779/changes#diff-5cfcafef88bd04313c7267e85151aabc992950891ab0414a407b5f14f092a9ab">+11/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.test.ts</strong><dd><code>Test CLI base download URL configuration handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/unit/common/configuration.test.ts

<ul><li>Added new tests for <code>getCliBaseDownloadUrl</code>.<br> <li> Covered scenarios with unset, custom, blank, whitespace, and <br>non-string values.<br> <li> Verified fallback to default URL in invalid configuration cases.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/vscode-extension/pull/779/changes#diff-71f325c8fd7cc6dcb92d6e776bb03e4c481f05649bc33a37b063e1829bf2cf88">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lsKeyToVscodeKeyMap.test.ts</strong><dd><code>Test inbound blank CLI download URL skipping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/unit/common/languageServer/lsKeyToVscodeKeyMap.test.ts

<ul><li>Added tests for <code>mapLspSettingsToVscodeSettings</code> with blank <br><code>binary_base_url</code>.<br> <li> Verified skipping of blank and whitespace-only values.<br> <li> Confirmed that <code>cliPath</code> is not affected by the blank-skip logic.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/vscode-extension/pull/779/changes#diff-1a850c0f49d5a784f2f7584817b0eacbaf912e9715507c2c2398831f3198de8a">+48/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

