### PR TITLE
fix: add migration code for code scanner enablement [IDE-2254]

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
             "type": "boolean",
             "title": "Snyk Code security issues",
             "description": "Find and fix security issues in your application code in real time.\n\nFor these scans to run, Snyk Code must be enabled for your organization in Snyk settings.",
-            "default": true,
+            "default": false,
             "markdownDeprecationMessage": "This setting is now managed via the [Snyk Settings page](command:snyk.settings). Use the `Snyk: Settings` command to configure Snyk."
           },
           "snyk.features.infrastructureAsCode": {

--- a/src/snyk/common/constants/globalState.ts
+++ b/src/snyk/common/constants/globalState.ts
@@ -5,3 +5,4 @@ export const MEMENTO_LS_PROTOCOL_VERSION = 'snyk.lsProtocolVersion';
 export const MEMENTO_ANALYTICS_PLUGIN_INSTALLED_SENT = 'snyk.pluginInstalledSent';
 export const MEMENTO_SECURE_AT_INCEPTION_MODAL = 'snyk.secureAtInceptionModal';
 export const MEMENTO_FOLDER_ORG_MIGRATION_V1 = 'snyk.folderOrgMigrationV1';
+export const MEMENTO_CODE_ENABLEMENT_MIGRATED = 'snyk.codeEnablementMigrated';

--- a/src/snyk/common/languageServer/codeEnablementMigration.ts
+++ b/src/snyk/common/languageServer/codeEnablementMigration.ts
@@ -1,0 +1,80 @@
+import { Configuration } from '../configuration/configuration';
+import { CODE_SECURITY_ENABLED_SETTING } from '../constants/settings';
+import {
+  MEMENTO_ANALYTICS_PLUGIN_INSTALLED_SENT,
+  MEMENTO_CLI_VERSION,
+  MEMENTO_CODE_ENABLEMENT_MIGRATED,
+  MEMENTO_LS_PROTOCOL_VERSION,
+} from '../constants/globalState';
+import type { ExtensionContext } from '../vscode/extensionContext';
+import type { IVSCodeWorkspace } from '../vscode/workspace';
+import type { ILog } from '../logger/interfaces';
+
+// Mementos a prior activation persists that evidence a pre-existing install. All are written
+// after this migration runs in a given activation (download at extension.ts and the plugin-
+// installed event both run later), so on a fresh install's first launch they are all undefined.
+// Using several — rather than the download-gated protocol version alone — means a custom-cliPath
+// or air-gapped install (which never triggers a managed download, so never writes the protocol or
+// CLI version) is still recognised via the download-independent plugin-installed memento.
+const EXISTING_INSTALL_MEMENTOS = [
+  MEMENTO_LS_PROTOCOL_VERSION,
+  MEMENTO_CLI_VERSION,
+  MEMENTO_ANALYTICS_PLUGIN_INSTALLED_SENT,
+];
+
+/**
+ * One-shot recovery migration for the Snyk Code enabled state.
+ *
+ * The default value for Cdde enablement changed from True to False (to match the language server)
+ * in extension version 2.32.0.
+ *
+ * On the first run after upgrade, we set `codeSecurity = true` into global settings for users
+ * of pre-2.32.0 extensions who have no explicit global value. Fresh installs are never seeded:
+ * they defer to org governance / the LS default. This does mean that users who relied on Code being
+ * enabled will have a user preference for Code enablement after upgrade, which might override
+ * LDX-Sync values. This is a deliberate trade-off to preserve functionality.
+ *
+ * {@link EXISTING_INSTALL_MEMENTOS} is used to track state over upgrade. Since they arw written
+ * on first launch (after this migration runs), the migration only runs once.
+ *
+ * There is a deliberate asymmetry with OSS/IaC/Secrets: those defaults already match the LS,
+ * wehereas the Code value was the opposite of the LS default.
+ *
+ * Best-effort: never throws. A failure is logged and the migration retries on the next activation
+ * (the guard is recorded only after a successful pass), so it can never abort extension activation.
+ */
+export async function migrateCodeEnablementForExistingInstall(
+  context: Pick<ExtensionContext, 'getGlobalStateValue' | 'updateGlobalStateValue'>,
+  workspace: Pick<IVSCodeWorkspace, 'inspectConfiguration' | 'updateConfiguration'>,
+  logger: ILog,
+): Promise<void> {
+  try {
+    // Idempotent: the migration is evaluated exactly once per install.
+    if (context.getGlobalStateValue<boolean>(MEMENTO_CODE_ENABLEMENT_MIGRATED)) {
+      return;
+    }
+
+    // A prior activation persisted a lifecycle memento → this is an upgrade, not a fresh install.
+    const isExistingInstall = EXISTING_INSTALL_MEMENTOS.some(key => context.getGlobalStateValue(key) !== undefined);
+
+    if (isExistingInstall) {
+      const { configurationId, section } = Configuration.getConfigName(CODE_SECURITY_ENABLED_SETTING);
+      const inspect = workspace.inspectConfiguration<boolean>(configurationId, section);
+
+      // Only materialize when the user relied on the old default: the setting resolves (inspect is
+      // defined for a registered key) but has no explicit global value. An explicitly persisted
+      // true or false is left untouched. Matches the seed's `inspect === undefined` skip.
+      if (inspect !== undefined && inspect.globalValue === undefined) {
+        await workspace.updateConfiguration(configurationId, section, true, true);
+        logger.info('Preserved the existing Snyk Code enabled state as an explicit setting on upgrade.');
+      }
+    }
+
+    // Record evaluation regardless of outcome so a fresh install is never seeded on a later launch.
+    await context.updateGlobalStateValue(MEMENTO_CODE_ENABLEMENT_MIGRATED, true);
+  } catch (e) {
+    // Never let a best-effort recovery migration abort activation. The guard is not recorded on
+    // failure, so the migration retries on the next activation.
+    logger.warn(`Snyk Code enablement recovery migration failed; will retry on next activation: ${e}`);
+  }
+}

--- a/src/snyk/common/languageServer/codeEnablementMigration.ts
+++ b/src/snyk/common/languageServer/codeEnablementMigration.ts
@@ -21,7 +21,7 @@ const EXISTING_INSTALL_MEMENTOS = [
 /**
  * One-shot recovery migration for the Snyk Code enabled state.
  *
- * The default value for Cdde enablement changed from True to False (to match the language server)
+ * The default value for Code enablement changed from True to False (to match the language server)
  * in extension version 2.32.0.
  *
  * On the first run after upgrade, we set `codeSecurity = true` into global settings for users
@@ -30,11 +30,11 @@ const EXISTING_INSTALL_MEMENTOS = [
  * enabled will have a user preference for Code enablement after upgrade, which might override
  * LDX-Sync values. This is a deliberate trade-off to preserve functionality.
  *
- * {@link EXISTING_INSTALL_MEMENTOS} is used to track state over upgrade. Since they arw written
+ * {@link EXISTING_INSTALL_MEMENTOS} is used to track state over upgrade. Since they are written
  * on first launch (after this migration runs), the migration only runs once.
  *
  * There is a deliberate asymmetry with OSS/IaC/Secrets: those defaults already match the LS,
- * wehereas the Code value was the opposite of the LS default.
+ * whereas the Code value was the opposite of the LS default.
  *
  * Best-effort: never throws. A failure is logged and the migration retries on the next activation
  * (the guard is recorded only after a successful pass), so it can never abort extension activation.

--- a/src/snyk/common/languageServer/codeEnablementMigration.ts
+++ b/src/snyk/common/languageServer/codeEnablementMigration.ts
@@ -10,8 +10,9 @@ import type { ExtensionContext } from '../vscode/extensionContext';
 import type { IVSCodeWorkspace } from '../vscode/workspace';
 import type { ILog } from '../logger/interfaces';
 
-// This migration writes these mememtos after it runs. They will be null if the migration has 
-// never run.
+// This migration only reads these mementos; they are written elsewhere, later in activation
+// (see the "do not reorder" notes at downloadService.ts and extension.ts), so they are still
+// undefined on a fresh install's first launch — that is what makes them a reliable upgrade signal.
 const EXISTING_INSTALL_MEMENTOS = [
   MEMENTO_LS_PROTOCOL_VERSION,
   MEMENTO_CLI_VERSION,

--- a/src/snyk/common/languageServer/codeEnablementMigration.ts
+++ b/src/snyk/common/languageServer/codeEnablementMigration.ts
@@ -10,12 +10,8 @@ import type { ExtensionContext } from '../vscode/extensionContext';
 import type { IVSCodeWorkspace } from '../vscode/workspace';
 import type { ILog } from '../logger/interfaces';
 
-// Mementos a prior activation persists that evidence a pre-existing install. All are written
-// after this migration runs in a given activation (download at extension.ts and the plugin-
-// installed event both run later), so on a fresh install's first launch they are all undefined.
-// Using several — rather than the download-gated protocol version alone — means a custom-cliPath
-// or air-gapped install (which never triggers a managed download, so never writes the protocol or
-// CLI version) is still recognised via the download-independent plugin-installed memento.
+// This migration writes these mememtos after it runs. They will be null if the migration has 
+// never run.
 const EXISTING_INSTALL_MEMENTOS = [
   MEMENTO_LS_PROTOCOL_VERSION,
   MEMENTO_CLI_VERSION,

--- a/src/snyk/common/services/downloadService.ts
+++ b/src/snyk/common/services/downloadService.ts
@@ -255,6 +255,9 @@ export class DownloadService {
   }
 
   private async setCurrentLspVersion(): Promise<void> {
+    // Note: codeEnablementMigration treats this memento (among others) as evidence of a prior
+    // install. It is only written on a managed download, so that migration must not rely on it
+    // alone — custom-cliPath / air-gapped installs never reach here.
     await this.extensionContext.updateGlobalStateValue(MEMENTO_LS_PROTOCOL_VERSION, PROTOCOL_VERSION);
   }
 

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -49,6 +49,7 @@ import { LastKnownValueCache } from './common/languageServer/lastKnownValueCache
 import { VSCODE_KEY_TO_LS_KEYS } from './common/languageServer/lsKeyToVscodeKeyMap';
 import { seedExplicitChangesFromExistingSettings } from './common/languageServer/explicitLsKeyTracking';
 import { migrateFolderOrgSettingsIfNeeded } from './common/configuration/folderOrgMigration';
+import { migrateCodeEnablementForExistingInstall } from './common/languageServer/codeEnablementMigration';
 import { LanguageServer } from './common/languageServer/languageServer';
 import { StaticCliApi } from './cli/staticCliApi';
 import { Logger } from './common/logger/logger';
@@ -236,6 +237,9 @@ class SnykExtension extends SnykLib implements IExtension {
     }
 
     const explicitOverridesMap = new ExplicitOverridesMap(vscodeContext.globalState, Logger);
+    // Recover the pre-existing Snyk Code enabled state for upgrading installs before seeding, so a
+    // preference that equalled the old plugin default is carried forward as explicit user intent.
+    await migrateCodeEnablementForExistingInstall(this.context, vsCodeWorkspace, Logger);
     seedExplicitChangesFromExistingSettings(explicitOverridesMap, vsCodeWorkspace);
 
     const lastKnownValueCache = new LastKnownValueCache(vsCodeWorkspace, Object.keys(VSCODE_KEY_TO_LS_KEYS));
@@ -527,6 +531,9 @@ class SnykExtension extends SnykLib implements IExtension {
 
         const category = ['install'];
         const pluginInstalledEvent = new AnalyticsEvent(this.user.anonymousId, 'plugin installed', category);
+        // Note: codeEnablementMigration treats this memento as evidence of a prior install. This
+        // write must stay after that migration runs (initializeExtension, before the LS starts) so
+        // a fresh install's first launch is not misclassified as existing — do not reorder earlier.
         await extensionContext.updateGlobalStateValue(MEMENTO_ANALYTICS_PLUGIN_INSTALLED_SENT, true);
         analyticsSender.logEvent(pluginInstalledEvent, () => {});
 

--- a/src/test/unit/common/languageServer/codeEnablementMigration.test.ts
+++ b/src/test/unit/common/languageServer/codeEnablementMigration.test.ts
@@ -1,0 +1,170 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import { migrateCodeEnablementForExistingInstall } from '../../../../snyk/common/languageServer/codeEnablementMigration';
+import { ExtensionContext } from '../../../../snyk/common/vscode/extensionContext';
+import { IVSCodeWorkspace } from '../../../../snyk/common/vscode/workspace';
+import {
+  MEMENTO_ANALYTICS_PLUGIN_INSTALLED_SENT,
+  MEMENTO_CLI_VERSION,
+  MEMENTO_CODE_ENABLEMENT_MIGRATED,
+  MEMENTO_LS_PROTOCOL_VERSION,
+} from '../../../../snyk/common/constants/globalState';
+import { LoggerMock } from '../../mocks/logger.mock';
+
+// CODE_SECURITY_ENABLED_SETTING = 'snyk.features.codeSecurity' → configId 'snyk', section 'features.codeSecurity'
+const CODE_CONFIG_ID = 'snyk';
+const CODE_SECTION = 'features.codeSecurity';
+
+suite('migrateCodeEnablementForExistingInstall', () => {
+  let getGlobalStateValue: sinon.SinonStub;
+  let updateGlobalStateValue: sinon.SinonStub;
+  let inspectConfiguration: sinon.SinonStub;
+  let updateConfiguration: sinon.SinonStub;
+  let context: Pick<ExtensionContext, 'getGlobalStateValue' | 'updateGlobalStateValue'>;
+  let workspace: Pick<IVSCodeWorkspace, 'inspectConfiguration' | 'updateConfiguration'>;
+  let logger: LoggerMock;
+
+  setup(() => {
+    // Default stub returns undefined for every memento (fresh, un-migrated install).
+    getGlobalStateValue = sinon.stub();
+    updateGlobalStateValue = sinon.stub().resolves();
+    inspectConfiguration = sinon.stub();
+    updateConfiguration = sinon.stub().resolves();
+
+    context = { getGlobalStateValue, updateGlobalStateValue } as unknown as ExtensionContext;
+    workspace = { inspectConfiguration, updateConfiguration } as unknown as IVSCodeWorkspace;
+    logger = new LoggerMock();
+  });
+
+  teardown(() => sinon.restore());
+
+  test('materializes codeSecurity=true for an existing install with no explicit global value', async () => {
+    getGlobalStateValue.withArgs(MEMENTO_LS_PROTOCOL_VERSION).returns(20); // prior install
+    inspectConfiguration
+      .withArgs(CODE_CONFIG_ID, CODE_SECTION)
+      .returns({ globalValue: undefined, defaultValue: false });
+
+    await migrateCodeEnablementForExistingInstall(context, workspace, logger);
+
+    assert.ok(
+      updateConfiguration.calledOnceWithExactly(CODE_CONFIG_ID, CODE_SECTION, true, true),
+      'should write codeSecurity=true to global settings',
+    );
+    assert.ok(
+      updateGlobalStateValue.calledOnceWithExactly(MEMENTO_CODE_ENABLEMENT_MIGRATED, true),
+      'should record that the migration has run',
+    );
+  });
+
+  test('detects a custom-cliPath / air-gapped install via the plugin-installed memento (no download mementos)', async () => {
+    // Neither the protocol version nor CLI version was ever written (no managed download), but a
+    // prior activation sent the plugin-installed event → this is still an existing install.
+    getGlobalStateValue.withArgs(MEMENTO_LS_PROTOCOL_VERSION).returns(undefined);
+    getGlobalStateValue.withArgs(MEMENTO_CLI_VERSION).returns(undefined);
+    getGlobalStateValue.withArgs(MEMENTO_ANALYTICS_PLUGIN_INSTALLED_SENT).returns(true);
+    inspectConfiguration
+      .withArgs(CODE_CONFIG_ID, CODE_SECTION)
+      .returns({ globalValue: undefined, defaultValue: false });
+
+    await migrateCodeEnablementForExistingInstall(context, workspace, logger);
+
+    assert.ok(
+      updateConfiguration.calledOnceWithExactly(CODE_CONFIG_ID, CODE_SECTION, true, true),
+      'must recognise an air-gapped existing install and preserve Code',
+    );
+  });
+
+  test('does NOT seed a fresh install (no lifecycle mementos) but still records evaluation', async () => {
+    // All mementos undefined via the default stub → fresh install.
+    await migrateCodeEnablementForExistingInstall(context, workspace, logger);
+
+    assert.ok(inspectConfiguration.notCalled, 'must not inspect config for a fresh install');
+    assert.ok(updateConfiguration.notCalled, 'must not write codeSecurity for a fresh install');
+    assert.ok(
+      updateGlobalStateValue.calledOnceWithExactly(MEMENTO_CODE_ENABLEMENT_MIGRATED, true),
+      'must record evaluation so a later launch does not seed the fresh install',
+    );
+  });
+
+  test('is a no-op once the migration memento is set (idempotent)', async () => {
+    getGlobalStateValue.withArgs(MEMENTO_CODE_ENABLEMENT_MIGRATED).returns(true);
+
+    await migrateCodeEnablementForExistingInstall(context, workspace, logger);
+
+    assert.ok(inspectConfiguration.notCalled, 'must not inspect config when already migrated');
+    assert.ok(updateConfiguration.notCalled, 'must not write config when already migrated');
+    assert.ok(updateGlobalStateValue.notCalled, 'must not re-write the memento when already migrated');
+  });
+
+  test('leaves an explicit user value untouched (globalValue defined) but records evaluation', async () => {
+    getGlobalStateValue.withArgs(MEMENTO_LS_PROTOCOL_VERSION).returns(20);
+    inspectConfiguration.withArgs(CODE_CONFIG_ID, CODE_SECTION).returns({ globalValue: false, defaultValue: false });
+
+    await migrateCodeEnablementForExistingInstall(context, workspace, logger);
+
+    assert.ok(updateConfiguration.notCalled, 'must not overwrite an explicitly persisted value');
+    assert.ok(
+      updateGlobalStateValue.calledOnceWithExactly(MEMENTO_CODE_ENABLEMENT_MIGRATED, true),
+      'should still record that the migration has run',
+    );
+  });
+
+  test('leaves an explicit true untouched (already survives via seeding)', async () => {
+    getGlobalStateValue.withArgs(MEMENTO_LS_PROTOCOL_VERSION).returns(20);
+    inspectConfiguration.withArgs(CODE_CONFIG_ID, CODE_SECTION).returns({ globalValue: true, defaultValue: false });
+
+    await migrateCodeEnablementForExistingInstall(context, workspace, logger);
+
+    assert.ok(updateConfiguration.notCalled, 'must not rewrite an already-explicit true');
+  });
+
+  test('skips (does not materialize) when inspectConfiguration returns undefined, matching the seed', async () => {
+    getGlobalStateValue.withArgs(MEMENTO_LS_PROTOCOL_VERSION).returns(20);
+    inspectConfiguration.withArgs(CODE_CONFIG_ID, CODE_SECTION).returns(undefined);
+
+    await migrateCodeEnablementForExistingInstall(context, workspace, logger);
+
+    assert.ok(updateConfiguration.notCalled, 'anomalous undefined inspect must not trigger a write');
+    assert.ok(
+      updateGlobalStateValue.calledOnceWithExactly(MEMENTO_CODE_ENABLEMENT_MIGRATED, true),
+      'should still record evaluation',
+    );
+  });
+
+  test('never throws and does NOT record the guard when the config write fails (retries next launch)', async () => {
+    getGlobalStateValue.withArgs(MEMENTO_LS_PROTOCOL_VERSION).returns(20);
+    inspectConfiguration
+      .withArgs(CODE_CONFIG_ID, CODE_SECTION)
+      .returns({ globalValue: undefined, defaultValue: false });
+    updateConfiguration.rejects(new Error('config write failed'));
+
+    await assert.doesNotReject(
+      () => migrateCodeEnablementForExistingInstall(context, workspace, logger),
+      'a failed migration must never propagate and abort activation',
+    );
+
+    assert.ok(
+      updateGlobalStateValue.neverCalledWith(MEMENTO_CODE_ENABLEMENT_MIGRATED, true),
+      'the guard must not be recorded on failure so the migration retries next launch',
+    );
+  });
+
+  // Documents the one conditional edge in the fresh-install protection: if the guard write on the
+  // first launch did NOT persist but the lifecycle mementos did (a store failure isolated to the
+  // guard write — implausible in practice since both use the same global-state store), a later
+  // launch observes the lifecycle mementos and treats the install as existing. See the docstring.
+  test('conditional edge: guard unset + lifecycle mementos present is classified as existing', async () => {
+    getGlobalStateValue.withArgs(MEMENTO_CODE_ENABLEMENT_MIGRATED).returns(undefined); // guard never persisted
+    getGlobalStateValue.withArgs(MEMENTO_ANALYTICS_PLUGIN_INSTALLED_SENT).returns(true); // written on a prior launch
+    inspectConfiguration
+      .withArgs(CODE_CONFIG_ID, CODE_SECTION)
+      .returns({ globalValue: undefined, defaultValue: false });
+
+    await migrateCodeEnablementForExistingInstall(context, workspace, logger);
+
+    assert.ok(
+      updateConfiguration.calledOnceWithExactly(CODE_CONFIG_ID, CODE_SECTION, true, true),
+      'with the guard unset and a lifecycle memento present, the install is treated as existing',
+    );
+  });
+});

--- a/src/test/unit/common/languageServer/explicitOverridesEndToEnd.test.ts
+++ b/src/test/unit/common/languageServer/explicitOverridesEndToEnd.test.ts
@@ -20,6 +20,8 @@ import {
   markExplicitLsKeysFromConfigurationChangeEvent,
   seedExplicitChangesFromExistingSettings,
 } from '../../../../snyk/common/languageServer/explicitLsKeyTracking';
+import { migrateCodeEnablementForExistingInstall } from '../../../../snyk/common/languageServer/codeEnablementMigration';
+import { MEMENTO_LS_PROTOCOL_VERSION } from '../../../../snyk/common/constants/globalState';
 import { ExplicitOverridesMap } from '../../../../snyk/common/languageServer/explicitOverridesMap';
 import { LastKnownValueCache } from '../../../../snyk/common/languageServer/lastKnownValueCache';
 import { VSCODE_KEY_TO_LS_KEYS } from '../../../../snyk/common/languageServer/lsKeyToVscodeKeyMap';
@@ -491,5 +493,63 @@ suite('IDE-2264 ticket 09: explicit-overrides map end-to-end (real objects only)
         `${lsKey}: an inbound migration write of an untouched default must not be marked explicit`,
       );
     }
+  });
+});
+
+suite('IDE-2254: codeEnablementMigration must run before the seed on activation', () => {
+  teardown(() => sinon.restore());
+
+  /** Mirrors ExtensionContext's delegation to vscode.ExtensionContext.globalState — same backing
+   * Memento the ExplicitOverridesMap reads from, matching real activation where both share one store. */
+  function makeSharedContext(memento: import('vscode').Memento) {
+    return {
+      getGlobalStateValue: <T>(key: string) => memento.get<T>(key),
+      updateGlobalStateValue: (key: string, value: unknown) => memento.update(key, value),
+    };
+  }
+
+  // Locks the ordering in src/snyk/extension.ts: the seed only records an override when
+  // inspect.globalValue is already defined (explicitLsKeyTracking.ts R4), so the migration must
+  // materialize codeSecurity=true before the seed runs for the seed to ever see it.
+  test('production order: migrating before seeding marks snykCodeEnabled explicit', async () => {
+    const memento = makeMemento();
+    await memento.update(MEMENTO_LS_PROTOCOL_VERSION, 20); // existing install signal
+    const context = makeSharedContext(memento);
+    const workspace = makeFakeWorkspace(); // codeSecurity unset — relying on the pre-2.32.0 default
+    const explicitOverridesMap = new ExplicitOverridesMap(memento);
+
+    await migrateCodeEnablementForExistingInstall(context, workspace, new LoggerMockFailOnErrors());
+    seedExplicitChangesFromExistingSettings(explicitOverridesMap, workspace);
+
+    assert.strictEqual(
+      workspace.inspectConfiguration('snyk', 'features.codeSecurity')?.globalValue,
+      true,
+      'migration must materialize codeSecurity=true',
+    );
+    assert.deepStrictEqual(
+      explicitOverridesMap.getEntry(LS_GLOBAL_KEY.snykCodeEnabled),
+      { kind: 'value', value: true },
+      'the seed must record the migrated value so the LS receives changed:true',
+    );
+  });
+
+  // The regression this locks: swapping the two calls silently defeats the PR. The seed observes
+  // codeSecurity still unset and skips it; the LS then receives the newly materialized `true` with
+  // changed:false, letting org governance flip Code back off with no explicit override to protect it.
+  test('reverse order regresses: seeding before migrating leaves snykCodeEnabled unmarked', async () => {
+    const memento = makeMemento();
+    await memento.update(MEMENTO_LS_PROTOCOL_VERSION, 20);
+    const context = makeSharedContext(memento);
+    const workspace = makeFakeWorkspace();
+    const explicitOverridesMap = new ExplicitOverridesMap(memento);
+
+    seedExplicitChangesFromExistingSettings(explicitOverridesMap, workspace);
+    await migrateCodeEnablementForExistingInstall(context, workspace, new LoggerMockFailOnErrors());
+
+    assert.strictEqual(
+      explicitOverridesMap.getEntry(LS_GLOBAL_KEY.snykCodeEnabled),
+      undefined,
+      'reordering must never silently pass — this is what fails if extension.ts is reordered',
+    );
   });
 });


### PR DESCRIPTION
### Description

Code Enablement defaults changed to match LS, and existing values migrated so existing users will not get their scanners turned off on upgrade.

### Known limitation

Detection of "existing install" relies on `MEMENTO_LS_PROTOCOL_VERSION` / `MEMENTO_CLI_VERSION` (written by a managed CLI download) and `MEMENTO_ANALYTICS_PLUGIN_INSTALLED_SENT` (written after a successful `languageServer.start()`, since v2.20.0). Users with `snyk.advanced.automaticDependencyManagement = false` (the usual air-gapped / enterprise pairing with a custom `cliPath`) never reach the download writes, so their only signal is the analytics memento. An install matching *all* of: air-gapped + no successful LS start yet + pre-v2.20.0-adjacent upgrade path is misclassified as fresh and loses Code on upgrade — erring toward disabling, the exact harm this PR guards against elsewhere. Narrow, but real.

`MEMENTO_CLI_VERSION` and `MEMENTO_LS_PROTOCOL_VERSION` are deliberate belt-and-braces: both are written in the same two `downloadService` functions, so they're one signal, not two — not meant to imply independent coverage.

Considered and rejected `MEMENTO_ANONYMOUS_ID` as a fourth signal: it's written at `extension.ts:182`, *before* the migration reads at `extension.ts:242`, so including it would classify every fresh install as existing and force-enable Code for new users.

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/vscode-extension/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/vscode-extension/blob/main/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_

