### PR TITLE
docs: add Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+Agent guidance for the Snyk VS Code extension. See `CLAUDE.md` and
+`CONTRIBUTING.md` for general contributor/build docs; this file adds
+Cursor-Cloud-specific environment notes.
+
+## Cursor Cloud specific instructions
+
+Environment notes for Cursor Cloud agents (dependencies are pre-installed by the
+startup update script; the caveats below are the non-obvious bits).
+
+- **Node/npm:** `/exec-daemon/node` is first on `PATH` but ships **no npm**. Use
+  the nvm-managed Node `22.22.3` (nvm default, provides npm `11.12.1`) by
+  prepending `PATH="$HOME/.nvm/versions/node/v22.22.3/bin:$PATH"` before running
+  `npm`. `.nvmrc` names `18.19`, but the project has no Node engine restriction
+  and builds/tests fine on Node 22.
+- **Build:** `npm run build` (`tsc -p ./` + `sass media`) → `out/`.
+- **Lint:** `npm run lint` (`eslint "src/**/*.ts"`) — currently warnings only.
+- **Unit tests:** `npm run test:unit` (mocha over `out/test/unit`, ~446 tests,
+  green).
+- **Integration tests** (`npm run test:integration`) download a full VS Code
+  instance and need a display (xvfb); the download host is blocked in the
+  sandbox, so run these outside Cursor Cloud.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,20 +20,23 @@ gotchas rather than install steps to repeat.
   project builds and tests fine on Node 22.
 - **Standard commands** are in [CLAUDE.md](CLAUDE.md): `npm run build`
   (`tsc -p ./` plus sass, output in `out/`), `npm run lint` (eslint — warnings
-  only, 0 errors), and `npm run test:unit` (mocha over `out/test/unit`, ~446
+  only, 0 errors), and `npm run test:unit` (mocha over `out/test/unit`, ~457
   passing). Run `npm run build` before `npm run test:unit`: the unit tests execute
   compiled output from `out/`, so a stale build produces misleading results.
-- **`npm run test:integration` needs two things — check, don't assume.** It downloads
-  a full VS Code build from `update.code.visualstudio.com` (which 302-redirects to
-  `vscode.download.prss.microsoft.com`) and needs a display. Both have been available
-  in cloud VMs — that download host has been reachable, and the VMs have run XFCE on
-  `DISPLAY=:1` — so verify before writing these tests off; only fall back to running
-  them outside Cursor Cloud if a probe shows the host blocked or there is no display.
+- **`npm run test:integration` should run on a saved GUI environment — do not assume it
+  cannot.** It uses `@vscode/test-electron`, which downloads its **own** VS Code build to
+  `.vscode-test/` from `update.code.visualstudio.com` (302-redirects to
+  `vscode.download.prss.microsoft.com`) — this is separate from the `~/vscode` dev-host
+  install below. It needs a display. On a GUI VM both prerequisites hold (download host
+  reachable, XFCE on `DISPLAY=:1`, and `/dev/shm` remounted to 2G), and the suite passes
+  (confirmed here: 21 passing). Only fall back to running it outside Cursor Cloud if a
+  probe actually shows the host blocked or there is no display.
 - **Driving the extension end-to-end is the strongest proof**, since building and unit
-  tests do not show that the extension works in a running editor. `code` is not
-  installed on the VM: fetch the stable tarball from `update.code.visualstudio.com`,
-  extract it, then launch the extension development host with
-  `DISPLAY=:1 <vscode>/bin/code --extensionDevelopmentPath=<repo> --user-data-dir=/tmp/vscode-userdata --no-sandbox --password-store=basic <project>`.
+  tests do not show that the extension works in a running editor. On a saved GUI
+  environment VS Code is already installed by the update script at **`~/vscode/bin/code`**
+  — use that; do **not** download a fresh tarball unless setup failed and the binary is
+  missing (the update script's log will say why). Launch the extension development host with
+  `DISPLAY=:1 ~/vscode/bin/code --extensionDevelopmentPath=<repo> --user-data-dir=/tmp/vscode-userdata --no-sandbox --password-store=basic <project>`.
   Set `snyk.advanced.cliPath`, uncheck `snyk.advanced.automaticDependencyManagement`
   and set `snyk.authenticationMethod` to the token method, then supply the token via
   the Command Palette (`Snyk: Set Token`). The panel's *Trust folder* button has been

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,41 @@
 # AGENTS.md
 
-Agent guidance for the Snyk VS Code extension. See `CLAUDE.md` and
-`CONTRIBUTING.md` for general contributor/build docs; this file adds
-Cursor-Cloud-specific environment notes.
+The primary agent guidance for this repository lives in [CLAUDE.md](CLAUDE.md)
+(project overview, build/dev/test/lint commands, architecture) and
+[CONTRIBUTING.md](CONTRIBUTING.md) — read those first. This file adds only Cursor
+Cloud environment notes.
 
 ## Cursor Cloud specific instructions
 
-Environment notes for Cursor Cloud agents (dependencies are pre-installed by the
-startup update script; the caveats below are the non-obvious bits).
+Durable, non-obvious notes for agents running in the Cursor Cloud Linux VM. The
+update script already runs `npm ci`, so the items below are setup context and
+gotchas rather than install steps to repeat.
 
-- **Node/npm:** `/exec-daemon/node` is first on `PATH` but ships **no npm**. Use
-  the nvm-managed Node `22.22.3` (nvm default, provides npm `11.12.1`) by
-  prepending `PATH="$HOME/.nvm/versions/node/v22.22.3/bin:$PATH"` before running
-  `npm`. `.nvmrc` names `18.19`, but the project has no Node engine restriction
-  and builds/tests fine on Node 22.
-- **Build:** `npm run build` (`tsc -p ./` + `sass media`) → `out/`.
-- **Lint:** `npm run lint` (`eslint "src/**/*.ts"`) — currently warnings only.
-- **Unit tests:** `npm run test:unit` (mocha over `out/test/unit`, ~446 tests,
-  green).
-- **Integration tests** (`npm run test:integration`) download a full VS Code
-  instance and need a display (xvfb); the download host is blocked in the
-  sandbox, so run these outside Cursor Cloud.
+- **Node comes from nvm, not `/exec-daemon/node`.** `/exec-daemon/node` is first on
+  `PATH` but ships **no npm**. Use the nvm-managed `v22.22.3` (which provides npm
+  `11.12.1`) and **always prepend**
+  `PATH="$HOME/.nvm/versions/node/v22.22.3/bin:$PATH"` before any `npm` command —
+  nvm is not auto-sourced in non-interactive shells. `.nvmrc` pins `18.19`, but
+  `package.json` declares no Node `engines` constraint (only `vscode`), and the
+  project builds and tests fine on Node 22.
+- **Standard commands** are in [CLAUDE.md](CLAUDE.md): `npm run build`
+  (`tsc -p ./` plus sass, output in `out/`), `npm run lint` (eslint — warnings
+  only, 0 errors), and `npm run test:unit` (mocha over `out/test/unit`, ~446
+  passing). Run `npm run build` before `npm run test:unit`: the unit tests execute
+  compiled output from `out/`, so a stale build produces misleading results.
+- **`npm run test:integration` cannot run here.** It downloads a full VS Code build
+  from `update.code.visualstudio.com` (which 302-redirects to
+  `vscode.download.prss.microsoft.com`) and needs a display via xvfb. Unless both
+  hosts are allowlisted and a display is available, run it outside Cursor Cloud.
+- **This extension is a thin UI over the `snyk-ls` language server.** Scan results,
+  configuration merging and product behaviour are implemented there — when
+  something looks wrong in the UI, confirm which side owns it before digging here.
+- **Probe egress instead of trusting a host list.** The allowlist changes between
+  runs, so treat any reachable/blocked list — including in older revisions of this
+  section — as stale. Matching is per hostname, and a bare entry is apex-exact
+  while `*.example.com` covers subdomains only, so an apex host has to be
+  allowlisted in its own right. A block surfaces as a TLS reset mid-handshake
+  rather than a DNS failure, so check a host directly before concluding anything:
+  `timeout 12 openssl s_client -connect update.code.visualstudio.com:443 -servername update.code.visualstudio.com </dev/null`.
+  The hosts worth probing for this repo are `registry.npmjs.org`, `github.com`,
+  and the two VS Code download hosts above if you need integration tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,12 +33,25 @@ gotchas rather than install steps to repeat.
   tests do not show that the extension works in a running editor. `code` is not
   installed on the VM: fetch the stable tarball from `update.code.visualstudio.com`,
   extract it, then launch the extension development host with
-  `DISPLAY=:1 <vscode>/bin/code --extensionDevelopmentPath=<repo> --user-data-dir=/tmp/vscode-userdata --no-sandbox <project>`.
+  `DISPLAY=:1 <vscode>/bin/code --extensionDevelopmentPath=<repo> --user-data-dir=/tmp/vscode-userdata --no-sandbox --password-store=basic <project>`.
   Set `snyk.advanced.cliPath`, uncheck `snyk.advanced.automaticDependencyManagement`
   and set `snyk.authenticationMethod` to the token method, then supply the token via
   the Command Palette (`Snyk: Set Token`). The panel's *Trust folder* button has been
   unreliable — setting `"snyk.trustedFolders": ["<project>"]` in
   `<user-data-dir>/User/settings.json` and reloading is the dependable route.
+- **Three headless-Linux launch failures, none of which names its own cause.** They apply
+  to `npm run test:integration` as well, since that drives a real VS Code:
+  - **`--password-store=basic` is required.** Without it there is no keyring for VS Code's
+    secret storage to talk to, so `Snyk: Set Token` cannot persist a token and
+    authentication silently never completes.
+  - **`renderer process gone (reason: crashed, code: 4)` is a `/dev/shm` problem, not an
+    extension bug.** Chromium needs more than the 64 MB some VMs default to, and the real
+    error underneath is `font_data_service_impl.cc: Check failed: No space left on
+    device`. Fix with `sudo mount -o remount,size=2G /dev/shm`, which lasts for the life
+    of that VM only, so it must be re-applied on each new one.
+  - **A silent exit with no output** means a killed instance left a stale
+    `~/.config/Code/code.lock` or `*.sock` behind; remove them before relaunching. Shut
+    the dev host down cleanly, and after any `kill`, clean those up first.
 - **Authentication does not come from the environment.** The extension passes the
   token it holds in its own settings to the language server, so neither the ambient
   `SNYK_TOKEN` nor the CLI's `~/.config/configstore` authenticates it — running

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,29 @@ gotchas rather than install steps to repeat.
   only, 0 errors), and `npm run test:unit` (mocha over `out/test/unit`, ~446
   passing). Run `npm run build` before `npm run test:unit`: the unit tests execute
   compiled output from `out/`, so a stale build produces misleading results.
-- **`npm run test:integration` cannot run here.** It downloads a full VS Code build
-  from `update.code.visualstudio.com` (which 302-redirects to
-  `vscode.download.prss.microsoft.com`) and needs a display via xvfb. Unless both
-  hosts are allowlisted and a display is available, run it outside Cursor Cloud.
+- **`npm run test:integration` needs two things — check, don't assume.** It downloads
+  a full VS Code build from `update.code.visualstudio.com` (which 302-redirects to
+  `vscode.download.prss.microsoft.com`) and needs a display. Both have been available
+  in cloud VMs — that download host has been reachable, and the VMs have run XFCE on
+  `DISPLAY=:1` — so verify before writing these tests off; only fall back to running
+  them outside Cursor Cloud if a probe shows the host blocked or there is no display.
+- **Driving the extension end-to-end is the strongest proof**, since building and unit
+  tests do not show that the extension works in a running editor. `code` is not
+  installed on the VM: fetch the stable tarball from `update.code.visualstudio.com`,
+  extract it, then launch the extension development host with
+  `DISPLAY=:1 <vscode>/bin/code --extensionDevelopmentPath=<repo> --user-data-dir=/tmp/vscode-userdata --no-sandbox <project>`.
+  Set `snyk.advanced.cliPath`, uncheck `snyk.advanced.automaticDependencyManagement`
+  and set `snyk.authenticationMethod` to the token method, then supply the token via
+  the Command Palette (`Snyk: Set Token`). The panel's *Trust folder* button has been
+  unreliable — setting `"snyk.trustedFolders": ["<project>"]` in
+  `<user-data-dir>/User/settings.json` and reloading is the dependable route.
+- **Authentication does not come from the environment.** The extension passes the
+  token it holds in its own settings to the language server, so neither the ambient
+  `SNYK_TOKEN` nor the CLI's `~/.config/configstore` authenticates it — running
+  `snyk auth` in a terminal has no effect here. Use the API-token method rather than
+  OAuth2, whose browser flow times out in this environment. If `cliPath` is left
+  unset the extension downloads its own CLI/LS from `downloads.snyk.io` /
+  `static.snyk.io`, which also works.
 - **This extension is a thin UI over the `snyk-ls` language server.** Scan results,
   configuration merging and product behaviour are implemented there — when
   something looks wrong in the UI, confirm which side owns it before digging here.


### PR DESCRIPTION
### Description

Adds an `AGENTS.md` whose primary job is to point at the existing guidance
([CLAUDE.md](CLAUDE.md) and [CONTRIBUTING.md](CONTRIBUTING.md)) and then record the
Cursor Cloud environment notes an agent needs when working on this extension in a Linux
VM. Documentation only — no extension code changes.

Two duplicate cloud-setup PRs had been opened against this repo by successive cloud
runs. This one now carries the consolidated content and **#786 has been closed as
superseded**, leaving a single PR per repo.

The notes cover:

- **Node comes from nvm `v22.22.3`, not `/exec-daemon/node`** (which is first on `PATH`
  but ships no npm). `.nvmrc` pins `18.19`, but `package.json` declares no Node `engines`
  constraint — only `vscode` — so Node 22 is safe, and this PR now says why rather than
  just asserting it.
- **Run `npm run build` before `npm run test:unit`**: the unit tests execute compiled
  output from `out/`, so a stale build gives misleading results.
- **`npm run test:integration` cannot run here** — it downloads a full VS Code build and
  needs a display via xvfb.
- **This extension is a thin UI over `snyk-ls`**, so behaviour questions often belong in
  that repo.

### What changed since the first revision

- Took the other branch's framing of CLAUDE.md as the primary guidance, so `AGENTS.md`
  stays a thin pointer plus cloud specifics instead of duplicating the project overview.
- **Named the hosts the integration tests actually download from** —
  `update.code.visualstudio.com`, which 302-redirects to
  `vscode.download.prss.microsoft.com` — instead of referring vaguely to "the download
  host". Confirmed from the installed `@vscode/test-electron`.
- Backed the Node 22 claim with the actual `engines` field rather than asserting there is
  no restriction.
- **Removed the hard-coded reachable/blocked host list.** The egress allowlist changes
  between runs, so a fixed map goes stale and gets trusted anyway; readers are told to
  probe directly instead.

### Second commit: end-to-end verification and auth

- **Documented how to drive the extension end-to-end in a cloud VM with a display**,
  which building and unit tests do not cover: `code` is not installed, so fetch the
  stable tarball and launch the extension development host with
  `--extensionDevelopmentPath`. Notes that the panel's *Trust folder* button proved
  unreliable and that setting `snyk.trustedFolders` in the user-data-dir
  `settings.json` is the dependable route.
- **Recorded the authentication gotchas**, which are easy to lose hours to: the token
  is read from the extension's own settings, so neither `SNYK_TOKEN` nor the CLI's
  `~/.config/configstore` authenticates it — `snyk auth` in a terminal does nothing —
  and the API-token method is required because the OAuth2 browser flow times out.
- **Softened the "`test:integration` cannot run here" claim.** Both prerequisites have
  in fact been available in cloud VMs (the VS Code download host reachable, and a
  display on `DISPLAY=:1`), so the section now says to check rather than assume.

### Third commit: headless launch failure modes

Reported by a later cloud run that lost time to all three. Each one presents as something
other than its actual cause, which is exactly what makes them worth writing down:

- **`--password-store=basic` is required** or headless secret storage has no keyring, so
  `Snyk: Set Token` cannot persist a token and authentication silently never completes.
- **`renderer process gone (reason: crashed, code: 4)` is a `/dev/shm` problem**, not an
  extension bug — Chromium needs more than the 64 MB some VMs default to, reported
  underneath as `font_data_service_impl.cc: Check failed: No space left on device`.
- **A silent exit with no output** is a stale `code.lock` or socket left by a killed
  instance.

All three apply to `npm run test:integration` too, since it drives a real VS Code, so
this is relevant to CI-style runs and not only to manual GUI testing.

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/vscode-extension/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/vscode-extension/blob/main/CONTRIBUTING.md).
- [x] Tests added and all succeed — n/a, no code changes; markdown only
- [x] Linted — n/a, no TypeScript touched
- [x] CHANGELOG.md updated — n/a, no user-facing change (contributor/agent documentation)
- [x] README.md updated, if user-facing — n/a, not user-facing

### Screenshots / GIFs

n/a — documentation only.
