### PR TITLE
docs: add AGENTS.md with Cursor Cloud setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+The primary agent guidance for this repository lives in [CLAUDE.md](CLAUDE.md)
+(project overview, build/dev/test/lint commands, architecture). Read that first.
+This file adds only Cursor Cloud environment notes.
+
+## Cursor Cloud specific instructions
+
+Durable, non-obvious notes for agents running in the Cursor Cloud Linux VM. The
+update script already runs `npm ci`; the items below are setup context and
+gotchas, not install steps to repeat.
+
+- **Node comes from nvm, not `/exec-daemon/node`.** `/exec-daemon/node` is first
+  on `PATH` but ships **no npm**. Use the clean `v22.22.3`. The repo `.nvmrc`
+  pins `18.19`, but Node 22 works and there is no `engine-strict` restriction, so
+  22.22.3 is fine. **Always prepend** `PATH="$HOME/.nvm/versions/node/v22.22.3/bin:$PATH"`
+  before any `npm` command — nvm is not auto-sourced in non-interactive shells.
+- **Standard commands** (see [CLAUDE.md](CLAUDE.md)): `npm run build`
+  (`tsc -p ./` + sass → `out/`); `npm run lint` (eslint — warnings only, 0 errors);
+  `npm run test:unit` (mocha over `out/test/unit` → 446 passing). Run `npm run build`
+  before `npm run test:unit`.
+- **`npm run test:integration` cannot run here.** It downloads a full VS Code
+  build and needs a display (xvfb); the download host is blocked in the VM. Run it
+  outside Cursor Cloud.
+- **Reachable:** `registry.npmjs.org`, `github.com`. This extension is a thin UI
+  over the `snyk-ls` language server (see the `snyk-ls` repo for the backend).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds an `AGENTS.md` (the repo previously had only `CLAUDE.md`) that points to `CLAUDE.md` for the primary guidance and adds a `## Cursor Cloud specific instructions` section for the Cursor Cloud Linux VM.

## Notes captured

- Node must come from the nvm `v22.22.3` install (prepend to `PATH`); `/exec-daemon/node` has no npm. Node 22 works despite `.nvmrc` pinning 18.19 (no engine restriction).
- Standard commands: `npm run build`, `npm run lint` (warnings only), `npm run test:unit` (446 passing). Build before running unit tests.
- `npm run test:integration` can't run here (downloads a full VS Code build + needs a display; download host blocked).

## Verification

`npm ci`, `npm run build`, `npm run lint` (0 errors), `npm run test:unit` (446 passing).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26b90e67-230c-4eb5-8199-42f535d12e57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26b90e67-230c-4eb5-8199-42f535d12e57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

