### PR TITLE
fix: keep settings cog visible on Connect & Trust panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -401,6 +401,7 @@
     "views": {
       "snyk": [
         {
+          "type": "webview",
           "id": "snyk.views.welcome",
           "name": "Snyk",
           "when": "!snyk:loggedIn || snyk:error || !snyk:workspaceFound || snyk:authMethodChanged"
@@ -431,38 +432,8 @@
     },
     "viewsWelcome": [
       {
-        "view": "snyk.views.welcome",
-        "contents": "Snyk has encountered a problem. Please restart the extension: \n[Restart](command:snyk.restart 'Restart Snyk')\nIf the error persists, please check your [settings](command:snyk.settings) and [contact us](https://snyk.io/contact-us/?utm_source=vsc).\n\n You can check the logs to see the exact error in [Snyk Security](command:snyk.showOutputChannel) and [Snyk Language Server](command:snyk.showLsOutputChannel) output channels.\n[Display Error](command:snyk.showErrorFromContext)\n",
-        "when": "snyk:error"
-      },
-      {
-        "view": "snyk.views.welcome",
-        "contents": "👋 Welcome to Snyk for Visual Studio Code.\n⏱️ Please wait, the extension is loading...",
-        "when": "!snyk:error && !snyk:initialized"
-      },
-      {
-        "view": "snyk.views.welcome",
-        "contents": "👋 Let's secure your code! \nTo scan your project for issues, Snyk needs to:\n 1. Connect to your Snyk account: This allows us to securely analyse your code.\n2. Trust this workspace: This lets Snyk safely gather information about your project (like dependencies).\nYou should only scan projects you trust. [More info](https://docs.snyk.io/ide-tools/visual-studio-code-extension/workspace-trust)\nBy connecting your account with Snyk, you agree to the Snyk [Privacy Policy](https://snyk.io/policies/privacy), and the Snyk [Terms of Service](https://snyk.io/policies/terms-of-service).\n\n[Connect & Trust Workspace](command:snyk.initiateLogin 'Connect with Snyk')",
-        "when": "!snyk:error && snyk:initialized && !snyk:loggedIn && !snyk:authMethodChanged"
-      },
-      {
-        "view": "snyk.views.welcome",
-        "contents": "⚠️ Your authentication method has changed.\n\n👉 Please re-authenticate to continue using Snyk\n\nBy connecting your account with Snyk, you agree to the Snyk [Privacy Policy](https://snyk.io/policies/privacy), and the Snyk [Terms of Service](https://snyk.io/policies/terms-of-service).\n\n[Connect & Trust Workspace](command:snyk.initiateLogin 'Re-authenticate')",
-        "when": "!snyk:error && snyk:initialized && !snyk:loggedIn && snyk:authMethodChanged"
-      },
-      {
-        "view": "snyk.views.welcome",
-        "contents": "We are now redirecting you to our auth page, go ahead and log in. If a browser window doesn't open after a few seconds, please copy the url below and manually paste it in a browser.\n[Copy URL to clipboard](command:snyk.copyAuthLink 'Copy URL to clipboard')",
-        "when": "!snyk:error && snyk:initialized && !snyk:loggedIn && snyk:authenticating"
-      },
-      {
         "view": "snyk.views.analysis.code.enablement",
         "contents": "Thanks for connecting with Snyk. ✅\n 👉 You are almost set 🤗.\n[Enable Snyk Code and start analysing](command:snyk.enableCode 'Upload code to Snyk')\nIt looks like your organization's configuration is disabled, that's why you are seeing this message. You can easily enable it by pressing the above button and switching it on.\nWe apologize for the inconvenience and please [contact us](https://snyk.io/contact-us/?utm_source=vsc) if you have any other questions or concerns!"
-      },
-      {
-        "view": "snyk.views.welcome",
-        "contents": "Open a workspace or a folder in Visual Studio Code to start the analysis.",
-        "when": "!snyk:error && snyk:initialized && snyk:loggedIn && !snyk:workspaceFound"
       }
     ],
     "menus": {

--- a/src/snyk/common/services/contextService.ts
+++ b/src/snyk/common/services/contextService.ts
@@ -1,9 +1,11 @@
+import * as vscode from 'vscode';
 import { SNYK_CONTEXT } from '../constants/views';
 import { Logger } from '../logger/logger';
 import { setContext } from '../vscode/vscodeCommandsUtils';
 
 export interface IContextService {
   readonly viewContext: { [key: string]: unknown };
+  readonly onDidChangeContext: vscode.Event<{ key: string; value: unknown }>;
   shouldShowCodeAnalysis: boolean;
   shouldShowOssAnalysis: boolean;
   shouldShowIacAnalysis: boolean;
@@ -13,6 +15,8 @@ export interface IContextService {
 
 export class ContextService implements IContextService {
   readonly viewContext: { [key: string]: unknown };
+  private readonly onDidChangeContextEmitter = new vscode.EventEmitter<{ key: string; value: unknown }>();
+  readonly onDidChangeContext = this.onDidChangeContextEmitter.event;
 
   constructor() {
     this.viewContext = {};
@@ -22,6 +26,7 @@ export class ContextService implements IContextService {
     Logger.debug(`Snyk context ${key}: ${value}`);
     this.viewContext[key] = value;
     await setContext(key, value);
+    this.onDidChangeContextEmitter.fire({ key, value });
   }
 
   get shouldShowCodeAnalysis(): boolean {

--- a/src/snyk/common/views/welcomeContent.ts
+++ b/src/snyk/common/views/welcomeContent.ts
@@ -1,9 +1,5 @@
 import { SNYK_CONTEXT } from '../constants/views';
 
-export type WelcomeViewContext = {
-  [key: string]: unknown;
-};
-
 const WELCOME_CONTENT = {
   error: `Snyk has encountered a problem. Please restart the extension:
 [Restart](command:snyk.restart 'Restart Snyk')
@@ -32,7 +28,7 @@ By connecting your account with Snyk, you agree to the Snyk [Privacy Policy](htt
   noWorkspace: 'Open a workspace or a folder in Visual Studio Code to start the analysis.',
 } as const;
 
-export function getWelcomeMarkdown(viewContext: WelcomeViewContext): string {
+export function getWelcomeMarkdown(viewContext: { [key: string]: unknown }): string {
   if (viewContext[SNYK_CONTEXT.ERROR]) {
     return WELCOME_CONTENT.error;
   }
@@ -42,11 +38,11 @@ export function getWelcomeMarkdown(viewContext: WelcomeViewContext): string {
   }
 
   if (!viewContext[SNYK_CONTEXT.LOGGEDIN]) {
-    if (viewContext[SNYK_CONTEXT.AUTHENTICATION_METHOD_CHANGED]) {
-      return WELCOME_CONTENT.authMethodChanged;
-    }
     if (viewContext[SNYK_CONTEXT.AUTHENTICATING]) {
       return WELCOME_CONTENT.authenticating;
+    }
+    if (viewContext[SNYK_CONTEXT.AUTHENTICATION_METHOD_CHANGED]) {
+      return WELCOME_CONTENT.authMethodChanged;
     }
     return WELCOME_CONTENT.connectAndTrust;
   }

--- a/src/snyk/common/views/welcomeContent.ts
+++ b/src/snyk/common/views/welcomeContent.ts
@@ -1,0 +1,92 @@
+import { SNYK_CONTEXT } from '../constants/views';
+
+export type WelcomeViewContext = {
+  [key: string]: unknown;
+};
+
+const WELCOME_CONTENT = {
+  error: `Snyk has encountered a problem. Please restart the extension:
+[Restart](command:snyk.restart 'Restart Snyk')
+If the error persists, please check your [settings](command:snyk.settings) and [contact us](https://snyk.io/contact-us/?utm_source=vsc).
+
+ You can check the logs to see the exact error in [Snyk Security](command:snyk.showOutputChannel) and [Snyk Language Server](command:snyk.showLsOutputChannel) output channels.
+[Display Error](command:snyk.showErrorFromContext)`,
+  loading: '👋 Welcome to Snyk for Visual Studio Code.\n⏱️ Please wait, the extension is loading...',
+  connectAndTrust: `👋 Let's secure your code!
+To scan your project for issues, Snyk needs to:
+ 1. Connect to your Snyk account: This allows us to securely analyse your code.
+2. Trust this workspace: This lets Snyk safely gather information about your project (like dependencies).
+You should only scan projects you trust. [More info](https://docs.snyk.io/ide-tools/visual-studio-code-extension/workspace-trust)
+By connecting your account with Snyk, you agree to the Snyk [Privacy Policy](https://snyk.io/policies/privacy), and the Snyk [Terms of Service](https://snyk.io/policies/terms-of-service).
+
+[Connect & Trust Workspace](command:snyk.initiateLogin 'Connect with Snyk')`,
+  authMethodChanged: `⚠️ Your authentication method has changed.
+
+👉 Please re-authenticate to continue using Snyk
+
+By connecting your account with Snyk, you agree to the Snyk [Privacy Policy](https://snyk.io/policies/privacy), and the Snyk [Terms of Service](https://snyk.io/policies/terms-of-service).
+
+[Connect & Trust Workspace](command:snyk.initiateLogin 'Re-authenticate')`,
+  authenticating: `We are now redirecting you to our auth page, go ahead and log in. If a browser window doesn't open after a few seconds, please copy the url below and manually paste it in a browser.
+[Copy URL to clipboard](command:snyk.copyAuthLink 'Copy URL to clipboard')`,
+  noWorkspace: 'Open a workspace or a folder in Visual Studio Code to start the analysis.',
+} as const;
+
+export function getWelcomeMarkdown(viewContext: WelcomeViewContext): string {
+  if (viewContext[SNYK_CONTEXT.ERROR]) {
+    return WELCOME_CONTENT.error;
+  }
+
+  if (!viewContext[SNYK_CONTEXT.INITIALIZED]) {
+    return WELCOME_CONTENT.loading;
+  }
+
+  if (!viewContext[SNYK_CONTEXT.LOGGEDIN]) {
+    if (viewContext[SNYK_CONTEXT.AUTHENTICATION_METHOD_CHANGED]) {
+      return WELCOME_CONTENT.authMethodChanged;
+    }
+    if (viewContext[SNYK_CONTEXT.AUTHENTICATING]) {
+      return WELCOME_CONTENT.authenticating;
+    }
+    return WELCOME_CONTENT.connectAndTrust;
+  }
+
+  if (!viewContext[SNYK_CONTEXT.WORKSPACE_FOUND]) {
+    return WELCOME_CONTENT.noWorkspace;
+  }
+
+  return WELCOME_CONTENT.loading;
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function renderInlineMarkdown(text: string): string {
+  return escapeHtml(text)
+    .replace(/\[([^\]]+)\]\((command:[^)\s]+)(?:\s+'[^']*')?\)/g, '<a href="$2">$1</a>')
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, '<a href="$2">$1</a>');
+}
+
+export function renderWelcomeHtml(markdown: string): string {
+  const blocks = markdown.split('\n\n');
+  const htmlBlocks = blocks.map(block => {
+    const lines = block.split('\n');
+    const renderedLines = lines.map(line => {
+      const trimmed = line.trim();
+      if (/^\[[^\]]+\]\(command:[^)]+\)$/.test(trimmed)) {
+        const match = trimmed.match(/^\[([^\]]+)\]\((command:[^)\s]+)(?:\s+'[^']*')?\)$/);
+        if (!match) {
+          return `<p>${renderInlineMarkdown(line)}</p>`;
+        }
+        return `<p class="welcome-button"><a class="welcome-button-link" href="${match[2]}">${escapeHtml(
+          match[1],
+        )}</a></p>`;
+      }
+      return `<p>${renderInlineMarkdown(line)}</p>`;
+    });
+    return renderedLines.join('');
+  });
+
+  return htmlBlocks.join('');
+}

--- a/src/snyk/common/views/welcomeWebviewProvider.ts
+++ b/src/snyk/common/views/welcomeWebviewProvider.ts
@@ -1,0 +1,71 @@
+import * as vscode from 'vscode';
+import { getNonce } from './nonce';
+import { getWelcomeMarkdown, renderWelcomeHtml } from './welcomeContent';
+import { IContextService } from '../services/contextService';
+
+export class WelcomeWebviewViewProvider implements vscode.WebviewViewProvider {
+  private webviewView: vscode.WebviewView | undefined;
+  private lastRenderedMarkdown: string | undefined;
+
+  constructor(private readonly contextService: IContextService) {}
+
+  resolveWebviewView(webviewView: vscode.WebviewView): void {
+    this.webviewView = webviewView;
+    webviewView.webview.options = {
+      enableScripts: false,
+      enableCommandUris: true,
+    };
+    this.refresh();
+  }
+
+  refresh(): void {
+    if (!this.webviewView) {
+      return;
+    }
+
+    const markdown = getWelcomeMarkdown(this.contextService.viewContext);
+    if (markdown === this.lastRenderedMarkdown) {
+      return;
+    }
+    this.lastRenderedMarkdown = markdown;
+
+    const nonce = getNonce();
+    const body = renderWelcomeHtml(markdown);
+    this.webviewView.webview.html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}';">
+  <style nonce="${nonce}">
+    body {
+      box-sizing: border-box;
+      color: var(--vscode-foreground);
+      font-family: var(--vscode-font-family);
+      font-size: var(--vscode-font-size);
+      font-weight: var(--vscode-font-weight);
+      line-height: 1.4;
+      margin: 0;
+      padding: 0 20px 20px;
+    }
+    p { margin: 0 0 0.7em; }
+    a { color: var(--vscode-textLink-foreground); }
+    a:hover { color: var(--vscode-textLink-activeForeground); }
+    .welcome-button { margin-top: 1em; }
+    .welcome-button-link {
+      background: var(--vscode-button-background);
+      border-radius: 2px;
+      color: var(--vscode-button-foreground);
+      display: inline-block;
+      padding: 6px 14px;
+      text-decoration: none;
+    }
+    .welcome-button-link:hover {
+      background: var(--vscode-button-hoverBackground);
+      color: var(--vscode-button-foreground);
+    }
+  </style>
+</head>
+<body>${body}</body>
+</html>`;
+  }
+}

--- a/src/snyk/common/views/welcomeWebviewProvider.ts
+++ b/src/snyk/common/views/welcomeWebviewProvider.ts
@@ -5,7 +5,7 @@ import { IContextService } from '../services/contextService';
 
 export class WelcomeWebviewViewProvider implements vscode.WebviewViewProvider {
   private webviewView: vscode.WebviewView | undefined;
-  private lastRenderedMarkdown: string | undefined;
+  private readonly lastRenderedMarkdownByView = new WeakMap<vscode.WebviewView, string>();
 
   constructor(private readonly contextService: IContextService) {}
 
@@ -24,10 +24,10 @@ export class WelcomeWebviewViewProvider implements vscode.WebviewViewProvider {
     }
 
     const markdown = getWelcomeMarkdown(this.contextService.viewContext);
-    if (markdown === this.lastRenderedMarkdown) {
+    if (this.lastRenderedMarkdownByView.get(this.webviewView) === markdown) {
       return;
     }
-    this.lastRenderedMarkdown = markdown;
+    this.lastRenderedMarkdownByView.set(this.webviewView, markdown);
 
     const nonce = getNonce();
     const body = renderWelcomeHtml(markdown);

--- a/src/snyk/extension.ts
+++ b/src/snyk/extension.ts
@@ -96,6 +96,7 @@ import {
 } from './common/constants/globalState';
 import { AnalyticsEvent } from './common/analytics/AnalyticsEvent';
 import { SummaryWebviewViewProvider } from './common/views/summaryWebviewProvider';
+import { WelcomeWebviewViewProvider } from './common/views/welcomeWebviewProvider';
 import { WorkspaceConfigurationWebviewProvider } from './common/views/workspaceConfiguration/workspaceConfigurationWebviewProvider';
 import { ScopeDetectionService } from './common/views/workspaceConfiguration/services/scopeDetectionService';
 import { HtmlInjectionService } from './common/views/workspaceConfiguration/services/htmlInjectionService';
@@ -193,6 +194,12 @@ class SnykExtension extends SnykLib implements IExtension {
     this.summaryProviderService = new SummaryProviderService(Logger, summaryWebviewViewProvider);
     vscodeContext.subscriptions.push(
       vscode.window.registerWebviewViewProvider(SNYK_VIEW_SUMMARY, summaryWebviewViewProvider),
+    );
+
+    const welcomeWebviewViewProvider = new WelcomeWebviewViewProvider(this.contextService);
+    vscodeContext.subscriptions.push(
+      vscode.window.registerWebviewViewProvider(SNYK_VIEW_WELCOME, welcomeWebviewViewProvider),
+      this.contextService.onDidChangeContext(() => welcomeWebviewViewProvider.refresh()),
     );
 
     const languageClientAdapter = new LanguageClientAdapter();
@@ -432,9 +439,6 @@ class SnykExtension extends SnykLib implements IExtension {
     vscodeContext.subscriptions.push(vscode.window.registerTreeDataProvider(SNYK_VIEW_SUPPORT, new SupportProvider()));
 
     vscodeContext.subscriptions.push(
-      vscode.window.createTreeView(SNYK_VIEW_WELCOME, {
-        treeDataProvider: new EmptyTreeDataProvider(),
-      }),
       vscode.window.createTreeView(SNYK_VIEW_ANALYSIS_CODE_ENABLEMENT, {
         treeDataProvider: new EmptyTreeDataProvider(),
       }),

--- a/src/test/unit/common/views/welcomeContent.test.ts
+++ b/src/test/unit/common/views/welcomeContent.test.ts
@@ -1,0 +1,35 @@
+import { strict as assert } from 'assert';
+import { getWelcomeMarkdown, renderWelcomeHtml } from '../../../../snyk/common/views/welcomeContent';
+import { SNYK_CONTEXT } from '../../../../snyk/common/constants/views';
+
+suite('welcomeContent', () => {
+  test('returns connect and trust content when logged out and initialized', () => {
+    const markdown = getWelcomeMarkdown({
+      [SNYK_CONTEXT.INITIALIZED]: true,
+      [SNYK_CONTEXT.LOGGEDIN]: false,
+      [SNYK_CONTEXT.AUTHENTICATION_METHOD_CHANGED]: false,
+      [SNYK_CONTEXT.AUTHENTICATING]: false,
+    });
+
+    assert.match(markdown, /Let's secure your code!/);
+    assert.match(markdown, /Connect & Trust Workspace/);
+  });
+
+  test('returns loading content before initialization', () => {
+    const markdown = getWelcomeMarkdown({
+      [SNYK_CONTEXT.INITIALIZED]: false,
+    });
+
+    assert.match(markdown, /Please wait, the extension is loading/);
+  });
+
+  test('renders command links and primary action button', () => {
+    const html = renderWelcomeHtml(
+      "Intro text\n\n[Connect & Trust Workspace](command:snyk.initiateLogin 'Connect with Snyk')",
+    );
+
+    assert.match(html, /href="command:snyk.initiateLogin"/);
+    assert.match(html, /welcome-button-link/);
+    assert.match(html, /Connect &amp; Trust Workspace/);
+  });
+});

--- a/src/test/unit/common/views/welcomeContent.test.ts
+++ b/src/test/unit/common/views/welcomeContent.test.ts
@@ -1,6 +1,19 @@
 import { strict as assert } from 'assert';
 import { getWelcomeMarkdown, renderWelcomeHtml } from '../../../../snyk/common/views/welcomeContent';
+import { WelcomeWebviewViewProvider } from '../../../../snyk/common/views/welcomeWebviewProvider';
 import { SNYK_CONTEXT } from '../../../../snyk/common/constants/views';
+import { IContextService } from '../../../../snyk/common/services/contextService';
+
+function makeContextService(viewContext: { [key: string]: unknown }): IContextService {
+  return {
+    viewContext,
+    onDidChangeContext: () => ({ dispose: () => undefined }),
+    shouldShowCodeAnalysis: false,
+    shouldShowOssAnalysis: false,
+    shouldShowIacAnalysis: false,
+    setContext: async () => undefined,
+  };
+}
 
 suite('welcomeContent', () => {
   test('returns connect and trust content when logged out and initialized', () => {
@@ -23,6 +36,48 @@ suite('welcomeContent', () => {
     assert.match(markdown, /Please wait, the extension is loading/);
   });
 
+  test('returns error content when extension is in error state', () => {
+    const markdown = getWelcomeMarkdown({
+      [SNYK_CONTEXT.ERROR]: new Error('boom'),
+      [SNYK_CONTEXT.INITIALIZED]: true,
+    });
+
+    assert.match(markdown, /Snyk has encountered a problem/);
+  });
+
+  test('prefers authenticating content when re-authenticating', () => {
+    const markdown = getWelcomeMarkdown({
+      [SNYK_CONTEXT.INITIALIZED]: true,
+      [SNYK_CONTEXT.LOGGEDIN]: false,
+      [SNYK_CONTEXT.AUTHENTICATION_METHOD_CHANGED]: true,
+      [SNYK_CONTEXT.AUTHENTICATING]: true,
+    });
+
+    assert.match(markdown, /redirecting you to our auth page/);
+    assert.doesNotMatch(markdown, /authentication method has changed/);
+  });
+
+  test('returns auth method changed content when not authenticating', () => {
+    const markdown = getWelcomeMarkdown({
+      [SNYK_CONTEXT.INITIALIZED]: true,
+      [SNYK_CONTEXT.LOGGEDIN]: false,
+      [SNYK_CONTEXT.AUTHENTICATION_METHOD_CHANGED]: true,
+      [SNYK_CONTEXT.AUTHENTICATING]: false,
+    });
+
+    assert.match(markdown, /authentication method has changed/);
+  });
+
+  test('returns no workspace content when logged in without workspace', () => {
+    const markdown = getWelcomeMarkdown({
+      [SNYK_CONTEXT.INITIALIZED]: true,
+      [SNYK_CONTEXT.LOGGEDIN]: true,
+      [SNYK_CONTEXT.WORKSPACE_FOUND]: false,
+    });
+
+    assert.match(markdown, /Open a workspace or a folder/);
+  });
+
   test('renders command links and primary action button', () => {
     const html = renderWelcomeHtml(
       "Intro text\n\n[Connect & Trust Workspace](command:snyk.initiateLogin 'Connect with Snyk')",
@@ -31,5 +86,55 @@ suite('welcomeContent', () => {
     assert.match(html, /href="command:snyk.initiateLogin"/);
     assert.match(html, /welcome-button-link/);
     assert.match(html, /Connect &amp; Trust Workspace/);
+  });
+});
+
+suite('WelcomeWebviewViewProvider', () => {
+  function makeWebviewView() {
+    let html = '';
+    return {
+      webview: {
+        options: {} as Record<string, unknown>,
+        get html() {
+          return html;
+        },
+        set html(value: string) {
+          html = value;
+        },
+      },
+    };
+  }
+
+  test('re-renders content when VS Code resolves a new webview instance', () => {
+    const provider = new WelcomeWebviewViewProvider(
+      makeContextService({
+        [SNYK_CONTEXT.INITIALIZED]: true,
+        [SNYK_CONTEXT.LOGGEDIN]: false,
+      }),
+    );
+
+    const firstView = makeWebviewView();
+    provider.resolveWebviewView(firstView as never);
+    assert.match(firstView.webview.html, /Let's secure your code!/);
+
+    const secondView = makeWebviewView();
+    provider.resolveWebviewView(secondView as never);
+    assert.match(secondView.webview.html, /Let's secure your code!/);
+  });
+
+  test('skips redundant refresh for the same webview instance and content', () => {
+    const provider = new WelcomeWebviewViewProvider(
+      makeContextService({
+        [SNYK_CONTEXT.INITIALIZED]: true,
+        [SNYK_CONTEXT.LOGGEDIN]: false,
+      }),
+    );
+    const webviewView = makeWebviewView();
+
+    provider.resolveWebviewView(webviewView as never);
+    const firstHtml = webviewView.webview.html;
+
+    provider.refresh();
+    assert.strictEqual(webviewView.webview.html, firstHtml);
   });
 });

--- a/src/test/unit/snykCode/codeSettings.test.ts
+++ b/src/test/unit/snykCode/codeSettings.test.ts
@@ -17,6 +17,7 @@ suite('Snyk Code Settings', () => {
 
     contextService = {
       setContext: setContextFake,
+      onDidChangeContext: () => ({ dispose: () => undefined }),
       shouldShowCodeAnalysis: false,
       shouldShowOssAnalysis: false,
       shouldShowIacAnalysis: false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What’s this PR about?

The Settings cog in the Snyk sidebar header was only visible when hovering over the Connect & Trust panel (logged-out welcome state). Tree views in VS Code hide view title actions until hover/focus; webview views use `WhenExpanded` and keep navigation actions visible when the section is expanded.

This change converts `snyk.views.welcome` from a tree view to a webview view (matching the SUMMARY panel behaviour) and renders the same welcome states via `WelcomeWebviewViewProvider`.

### Screenshots / Visual verification

**Before (no hover):** settings cog hidden in SNYK section header  
**After (no hover):** settings cog visible in SNYK section header while mouse is in the editor area

### Checklist

- [x] Unit tests added/updated (`welcomeContent.test.ts`)
- [x] `npm run build` passes
- [x] `npm run test:unit` passes (460 tests)
- [x] `npm run lint:fix` passes (0 errors)
- [x] Visually verified in Extension Development Host on cloud VM

### Notes

- Welcome copy previously contributed via `viewsWelcome` in `package.json` is now owned by `welcomeContent.ts`.
- `ContextService` now emits `onDidChangeContext` so the welcome webview refreshes when auth/loading state changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e27c08b-87da-4925-954a-fc5e554aefc9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e27c08b-87da-4925-954a-fc5e554aefc9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

