### PR TITLE
fix: add Settings link to Connect & Trust welcome panels

### DIFF
--- a/package.json
+++ b/package.json
@@ -442,12 +442,12 @@
       },
       {
         "view": "snyk.views.welcome",
-        "contents": "👋 Let's secure your code! \nTo scan your project for issues, Snyk needs to:\n 1. Connect to your Snyk account: This allows us to securely analyse your code.\n2. Trust this workspace: This lets Snyk safely gather information about your project (like dependencies).\nYou should only scan projects you trust. [More info](https://docs.snyk.io/ide-tools/visual-studio-code-extension/workspace-trust)\nBy connecting your account with Snyk, you agree to the Snyk [Privacy Policy](https://snyk.io/policies/privacy), and the Snyk [Terms of Service](https://snyk.io/policies/terms-of-service).\n\n[Connect & Trust Workspace](command:snyk.initiateLogin 'Connect with Snyk')\nCustom network, authentication or Snyk binary settings? Open [Settings](command:snyk.settings 'Snyk Settings').",
+        "contents": "👋 Let's secure your code! \nTo scan your project for issues, Snyk needs to:\n 1. Connect to your Snyk account: This allows us to securely analyse your code.\n2. Trust this workspace: This lets Snyk safely gather information about your project (like dependencies).\nYou should only scan projects you trust. [More info](https://docs.snyk.io/ide-tools/visual-studio-code-extension/workspace-trust)\nBy connecting your account with Snyk, you agree to the Snyk [Privacy Policy](https://snyk.io/policies/privacy), and the Snyk [Terms of Service](https://snyk.io/policies/terms-of-service).\n\n[Connect & Trust Workspace](command:snyk.initiateLogin 'Connect with Snyk')\nCustom network or Snyk binary configuration? Open [Settings](command:snyk.settings 'Snyk Settings').",
         "when": "!snyk:error && snyk:initialized && !snyk:loggedIn && !snyk:authMethodChanged"
       },
       {
         "view": "snyk.views.welcome",
-        "contents": "⚠️ Your authentication method has changed.\n\n👉 Please re-authenticate to continue using Snyk\n\nBy connecting your account with Snyk, you agree to the Snyk [Privacy Policy](https://snyk.io/policies/privacy), and the Snyk [Terms of Service](https://snyk.io/policies/terms-of-service).\n\n[Connect & Trust Workspace](command:snyk.initiateLogin 'Re-authenticate')\nCustom network, authentication or Snyk binary settings? Open [Settings](command:snyk.settings 'Snyk Settings').",
+        "contents": "⚠️ Your authentication method has changed.\n\n👉 Please re-authenticate to continue using Snyk\n\nBy connecting your account with Snyk, you agree to the Snyk [Privacy Policy](https://snyk.io/policies/privacy), and the Snyk [Terms of Service](https://snyk.io/policies/terms-of-service).\n\n[Connect & Trust Workspace](command:snyk.initiateLogin 'Re-authenticate')\nCustom network or Snyk binary configuration? Open [Settings](command:snyk.settings 'Snyk Settings').",
         "when": "!snyk:error && snyk:initialized && !snyk:loggedIn && snyk:authMethodChanged"
       },
       {

--- a/package.json
+++ b/package.json
@@ -442,12 +442,12 @@
       },
       {
         "view": "snyk.views.welcome",
-        "contents": "👋 Let's secure your code! \nTo scan your project for issues, Snyk needs to:\n 1. Connect to your Snyk account: This allows us to securely analyse your code.\n2. Trust this workspace: This lets Snyk safely gather information about your project (like dependencies).\nYou should only scan projects you trust. [More info](https://docs.snyk.io/ide-tools/visual-studio-code-extension/workspace-trust)\nBy connecting your account with Snyk, you agree to the Snyk [Privacy Policy](https://snyk.io/policies/privacy), and the Snyk [Terms of Service](https://snyk.io/policies/terms-of-service).\n\n[Connect & Trust Workspace](command:snyk.initiateLogin 'Connect with Snyk')\nNeed a custom endpoint or authentication method? Open [Settings](command:snyk.settings 'Snyk Settings').",
+        "contents": "👋 Let's secure your code! \nTo scan your project for issues, Snyk needs to:\n 1. Connect to your Snyk account: This allows us to securely analyse your code.\n2. Trust this workspace: This lets Snyk safely gather information about your project (like dependencies).\nYou should only scan projects you trust. [More info](https://docs.snyk.io/ide-tools/visual-studio-code-extension/workspace-trust)\nBy connecting your account with Snyk, you agree to the Snyk [Privacy Policy](https://snyk.io/policies/privacy), and the Snyk [Terms of Service](https://snyk.io/policies/terms-of-service).\n\n[Connect & Trust Workspace](command:snyk.initiateLogin 'Connect with Snyk')\nCustom network, authentication or Snyk binary settings? Open [Settings](command:snyk.settings 'Snyk Settings').",
         "when": "!snyk:error && snyk:initialized && !snyk:loggedIn && !snyk:authMethodChanged"
       },
       {
         "view": "snyk.views.welcome",
-        "contents": "⚠️ Your authentication method has changed.\n\n👉 Please re-authenticate to continue using Snyk\n\nBy connecting your account with Snyk, you agree to the Snyk [Privacy Policy](https://snyk.io/policies/privacy), and the Snyk [Terms of Service](https://snyk.io/policies/terms-of-service).\n\n[Connect & Trust Workspace](command:snyk.initiateLogin 'Re-authenticate')\nNeed a custom endpoint or authentication method? Open [Settings](command:snyk.settings 'Snyk Settings').",
+        "contents": "⚠️ Your authentication method has changed.\n\n👉 Please re-authenticate to continue using Snyk\n\nBy connecting your account with Snyk, you agree to the Snyk [Privacy Policy](https://snyk.io/policies/privacy), and the Snyk [Terms of Service](https://snyk.io/policies/terms-of-service).\n\n[Connect & Trust Workspace](command:snyk.initiateLogin 'Re-authenticate')\nCustom network, authentication or Snyk binary settings? Open [Settings](command:snyk.settings 'Snyk Settings').",
         "when": "!snyk:error && snyk:initialized && !snyk:loggedIn && snyk:authMethodChanged"
       },
       {

--- a/package.json
+++ b/package.json
@@ -442,12 +442,12 @@
       },
       {
         "view": "snyk.views.welcome",
-        "contents": "👋 Let's secure your code! \nTo scan your project for issues, Snyk needs to:\n 1. Connect to your Snyk account: This allows us to securely analyse your code.\n2. Trust this workspace: This lets Snyk safely gather information about your project (like dependencies).\nYou should only scan projects you trust. [More info](https://docs.snyk.io/ide-tools/visual-studio-code-extension/workspace-trust)\nBy connecting your account with Snyk, you agree to the Snyk [Privacy Policy](https://snyk.io/policies/privacy), and the Snyk [Terms of Service](https://snyk.io/policies/terms-of-service).\n\n[Connect & Trust Workspace](command:snyk.initiateLogin 'Connect with Snyk')",
+        "contents": "👋 Let's secure your code! \nTo scan your project for issues, Snyk needs to:\n 1. Connect to your Snyk account: This allows us to securely analyse your code.\n2. Trust this workspace: This lets Snyk safely gather information about your project (like dependencies).\nYou should only scan projects you trust. [More info](https://docs.snyk.io/ide-tools/visual-studio-code-extension/workspace-trust)\nBy connecting your account with Snyk, you agree to the Snyk [Privacy Policy](https://snyk.io/policies/privacy), and the Snyk [Terms of Service](https://snyk.io/policies/terms-of-service).\n\n[Connect & Trust Workspace](command:snyk.initiateLogin 'Connect with Snyk')\nNeed a custom endpoint or authentication method? Open [Settings](command:snyk.settings 'Snyk Settings').",
         "when": "!snyk:error && snyk:initialized && !snyk:loggedIn && !snyk:authMethodChanged"
       },
       {
         "view": "snyk.views.welcome",
-        "contents": "⚠️ Your authentication method has changed.\n\n👉 Please re-authenticate to continue using Snyk\n\nBy connecting your account with Snyk, you agree to the Snyk [Privacy Policy](https://snyk.io/policies/privacy), and the Snyk [Terms of Service](https://snyk.io/policies/terms-of-service).\n\n[Connect & Trust Workspace](command:snyk.initiateLogin 'Re-authenticate')",
+        "contents": "⚠️ Your authentication method has changed.\n\n👉 Please re-authenticate to continue using Snyk\n\nBy connecting your account with Snyk, you agree to the Snyk [Privacy Policy](https://snyk.io/policies/privacy), and the Snyk [Terms of Service](https://snyk.io/policies/terms-of-service).\n\n[Connect & Trust Workspace](command:snyk.initiateLogin 'Re-authenticate')\nNeed a custom endpoint or authentication method? Open [Settings](command:snyk.settings 'Snyk Settings').",
         "when": "!snyk:error && snyk:initialized && !snyk:loggedIn && snyk:authMethodChanged"
       },
       {

--- a/src/test/unit/base/views/welcomeContent.test.ts
+++ b/src/test/unit/base/views/welcomeContent.test.ts
@@ -34,7 +34,7 @@ suite('Welcome view content', () => {
   test('Connect & Trust panels link to the Snyk settings page', () => {
     for (const contribution of loggedOutContributions) {
       ok(
-        contribution.contents.includes(`[Settings](command:${SNYK_SETTINGS_COMMAND}`),
+        contribution.contents.includes(`](command:${SNYK_SETTINGS_COMMAND}`),
         `expected a settings link in welcome content for "${contribution.when ?? ''}"`,
       );
     }

--- a/src/test/unit/base/views/welcomeContent.test.ts
+++ b/src/test/unit/base/views/welcomeContent.test.ts
@@ -1,0 +1,42 @@
+import { ok, strictEqual } from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import { SNYK_SETTINGS_COMMAND } from '../../../../snyk/common/constants/commands';
+import { SNYK_VIEW_WELCOME } from '../../../../snyk/common/constants/views';
+
+type ViewsWelcomeContribution = {
+  view: string;
+  contents: string;
+  when?: string;
+};
+
+// The settings cog in the view title bar is only rendered while the tree view is hovered or focused,
+// so the logged out panels have to expose the settings page through their own content.
+suite('Welcome view content', () => {
+  let loggedOutContributions: ViewsWelcomeContribution[];
+
+  setup(() => {
+    const packageJsonPath = path.resolve(__dirname, '../../../../..', 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
+      contributes: { viewsWelcome: ViewsWelcomeContribution[] };
+    };
+
+    loggedOutContributions = packageJson.contributes.viewsWelcome.filter(
+      contribution =>
+        contribution.view === SNYK_VIEW_WELCOME && contribution.contents.includes('Connect & Trust Workspace'),
+    );
+  });
+
+  test('finds the Connect & Trust panels', () => {
+    strictEqual(loggedOutContributions.length, 2);
+  });
+
+  test('Connect & Trust panels link to the Snyk settings page', () => {
+    for (const contribution of loggedOutContributions) {
+      ok(
+        contribution.contents.includes(`[Settings](command:${SNYK_SETTINGS_COMMAND}`),
+        `expected a settings link in welcome content for "${contribution.when ?? ''}"`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Follow-up to #793, which was closed as too large a change (it converted `snyk.views.welcome` from a tree view to a webview view). This takes the alternative suggested in [this comment](https://github.com/snyk/vscode-extension/pull/793#issuecomment-5214870072): just add a "Settings" link to the wording.

The settings cog contributed to the SNYK view title bar is only rendered while the tree view is hovered or focused, so on the logged-out **Connect & Trust** panel there is no discoverable way to reach the Snyk settings page — which is exactly where a user has to go to point the extension at a different network or CLI setup *before* connecting.

Both logged-out welcome contributions in `package.json` now end with:

> Custom network or Snyk binary configuration? Open [Settings](command:snyk.settings 'Snyk Settings').

- `!snyk:loggedIn && !snyk:authMethodChanged` — the initial Connect & Trust panel
- `!snyk:loggedIn && snyk:authMethodChanged` — the re-authenticate panel

The change is two string edits in `package.json`; no production TypeScript is touched.

#### Why this wording

Clicking the link before the CLI has been downloaded renders `media/views/common/configuration/settings-fallback.html` rather than the fuller page served by snyk-ls. That fallback deliberately runs in "Limited settings mode" and exposes six controls:

| Fallback control | Covered by |
| --- | --- |
| Insecure (Skip SSL Verification) | network |
| CLI Path | Snyk binary |
| Manage Binaries Automatically | Snyk binary |
| CLI Release (channel / pinned version) | Snyk binary |
| CLI Download Base URL | Snyk binary |
| Clear credentials (`snyk.logout`) | — |

The two buckets cover everything a user would go there for pre-connect. `Clear credentials` is the one control not named, which is deliberate: it is a no-op on a panel that only renders when you are already logged out. The same buckets describe the `Setup` tab of the snyk-ls page (endpoint and insecure, plus the CLI configuration block).

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/vscode-extension/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/vscode-extension/blob/main/CONTRIBUTING.md).
- [x] Tests added and all succeed — new `src/test/unit/base/views/welcomeContent.test.ts` guards that both Connect & Trust contributions keep linking to the `snyk.settings` command. `npm run test:unit` 459 passing, `npm run test:integration` 21 passing.
- [x] Linted — `npm run lint:fix` 0 errors, `npm run knip` clean, `snyk code test` reports no new findings.
- [ ] CHANGELOG.md updated — n/a, the file defers to GitHub releases
- [ ] README.md updated, if user-facing — n/a

### Screenshots / GIFs

<img width="481" height="531" alt="image" src="https://github.com/user-attachments/assets/8bfcdf84-58e3-48fc-8280-320f9e1350e0" />

Verified in an Extension Development Host on a cloud VM against a fresh (logged-out) VS Code profile.

Logged-out Connect & Trust panel with the mouse parked in the editor area. The gear cog in the `SNYK` section header is **not** rendered — this is the original problem — while the new link stays available:

[Connect and Trust panel with the settings hint, gear cog hidden](https://cursor.com/agents/bc-c189594c-7707-4bc8-93b4-3262dbcf66fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwelcome_panel_final_copy_cog_hidden.png)

[Close-up of the new wording under the Connect and Trust Workspace button](https://cursor.com/agents/bc-c189594c-7707-4bc8-93b4-3262dbcf66fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwelcome_panel_final_copy_zoomed.png)

Clicking the link runs `snyk.settings` and opens the `Snyk Workspace Configuration` tab, here rendering the page served by snyk-ls:

[Snyk Workspace Configuration page opened from the welcome panel link](https://cursor.com/agents/bc-c189594c-7707-4bc8-93b4-3262dbcf66fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsnyk_settings_page_from_welcome_link.webp)

The same link with a deliberately broken `snyk.advanced.cliPath` and automatic dependency management off, so the language server cannot start and the fallback page renders instead:

[Fallback settings page in limited settings mode showing all six controls](https://cursor.com/agents/bc-c189594c-7707-4bc8-93b4-3262dbcf66fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffallback_settings_page_all_six_controls.webp)

End-to-end recording (hover shows the `Snyk Settings` tooltip, click opens the settings page):

[settings_link_final_copy.mp4](https://cursor.com/agents/bc-c189594c-7707-4bc8-93b4-3262dbcf66fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_link_final_copy.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c189594c-7707-4bc8-93b4-3262dbcf66fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c189594c-7707-4bc8-93b4-3262dbcf66fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

