### PR TITLE
test(config): cover secure at inception persistence [IDE-2452]

### DIFF
--- a/src/test/unit/common/views/workspaceConfiguration/services/configurationPersistenceService.test.ts
+++ b/src/test/unit/common/views/workspaceConfiguration/services/configurationPersistenceService.test.ts
@@ -14,10 +14,12 @@ import { ILanguageClientAdapter } from '../../../../../../snyk/common/vscode/lan
 import { ILog } from '../../../../../../snyk/common/logger/interfaces';
 import {
   ADVANCED_ORGANIZATION,
+  AUTO_CONFIGURE_MCP_SERVER,
   CODE_SECURITY_ENABLED_SETTING,
   CONFIGURATION_IDENTIFIER,
   DELTA_FINDINGS,
   SCANNING_MODE,
+  SECURITY_AT_INCEPTION_EXECUTION_FREQUENCY,
 } from '../../../../../../snyk/common/constants/settings';
 import {
   ALLISSUES,
@@ -1449,6 +1451,61 @@ suite('ConfigurationPersistenceService — outbound concrete-value save records 
       settings: { [LS_GLOBAL_KEY.organization]: { value: 'new-org', changed: false } },
     });
     sinon.assert.notCalled(updateConfigurationStub);
+  });
+
+  test('outbound Secure At Inception HTML values write mapped VS Code settings and explicit overrides', async () => {
+    const service = newService();
+
+    await service.handleSaveConfig(
+      JSON.stringify({
+        isFallbackForm: false,
+        token: 'tok',
+        [LS_GLOBAL_KEY.autoConfigureMcpServer]: true,
+        [LS_GLOBAL_KEY.secureAtInceptionExecutionFreq]: 'Smart Scan',
+      }),
+    );
+
+    assert.strictEqual(AUTO_CONFIGURE_MCP_SERVER, 'snyk.securityAtInception.autoConfigureSnykMcpServer');
+    assert.strictEqual(SECURITY_AT_INCEPTION_EXECUTION_FREQUENCY, 'snyk.securityAtInception.executionFrequency');
+    sinon.assert.calledWith(
+      updateConfigurationStub,
+      CONFIGURATION_IDENTIFIER,
+      'securityAtInception.autoConfigureSnykMcpServer',
+      true,
+      true,
+    );
+    sinon.assert.calledWith(
+      updateConfigurationStub,
+      CONFIGURATION_IDENTIFIER,
+      'securityAtInception.executionFrequency',
+      'Smart Scan',
+      true,
+    );
+
+    const readConfig = makeReadPathConfiguration({
+      getAutoConfigureMcpServer: () => true,
+      getSecureAtInceptionExecutionFrequency: () => 'Smart Scan',
+    });
+    const autoConfigureSetting = await readPullSetting(
+      readConfig,
+      explicitOverridesMap,
+      LS_GLOBAL_KEY.autoConfigureMcpServer,
+    );
+    assertPullSetting(
+      autoConfigureSetting,
+      { changed: true, value: true },
+      'MCP auto-configuration must surface as an explicit boolean override',
+    );
+    const executionFrequencySetting = await readPullSetting(
+      readConfig,
+      explicitOverridesMap,
+      LS_GLOBAL_KEY.secureAtInceptionExecutionFreq,
+    );
+    assertPullSetting(
+      executionFrequencySetting,
+      { changed: true, value: 'Smart Scan' },
+      'execution frequency must surface as an explicit string override',
+    );
   });
 
   test('a field absent from the payload is never written and never recorded', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Adds a focused regression test for the existing VS Code bridge used by [snyk-ls#1406](https://github.com/snyk/snyk-ls/pull/1406).

The test proves HTML payload values:

- map to the exact native `snyk.securityAtInception.*` settings
- retain boolean/string types and user scope
- are recorded as explicit LS overrides

No VS Code production code changes are needed.

Jira: [IDE-2452](https://snyksec.atlassian.net/browse/IDE-2452)

### Verification

- focused persistence suite: 47/47
- unit suite: 460/460
- integration suite: 21/21
- `npm run lint:fix`, `npm run knip`, `npm run build`
- real Extension Development Host persistence across close/reopen and reload

### Checklist

- [x] Read and understood the [Code of Conduct](https://github.com/snyk/vscode-extension/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/vscode-extension/blob/main/CONTRIBUTING.md).
- [x] Tests added and all succeed
- [x] Linted
- [x] CHANGELOG.md updated (not applicable; test-only change)
- [x] README.md updated, if user-facing (not applicable; test-only change)

### Screenshots / GIFs

[ide_2452_vscode_settings_persistence.mp4](https://cursor.com/agents/bc-a30e72ee-d177-49ed-83e2-d191d25a5ab9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fide_2452_vscode_settings_persistence.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a30e72ee-d177-49ed-83e2-d191d25a5ab9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a30e72ee-d177-49ed-83e2-d191d25a5ab9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[IDE-2452]: https://snyksec.atlassian.net/browse/IDE-2452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ